### PR TITLE
2416 audio placeholder canvas

### DIFF
--- a/public/fixtures/iiif/manifests/audio-accompanying-canvas.json
+++ b/public/fixtures/iiif/manifests/audio-accompanying-canvas.json
@@ -1,0 +1,75 @@
+{
+  "@context": "http://iiif.io/api/presentation/3/context.json",
+  "id": "https://iiif.io/api/cookbook/recipe/0014-accompanyingcanvas/manifest.json",
+  "type": "Manifest",
+  "label": {
+    "en": ["Partial audio recording of Gustav Mahler's _Symphony No. 3_"]
+  },
+  "items": [
+    {
+      "id": "https://iiif.io/api/cookbook/recipe/0014-accompanyingcanvas/canvas/p1",
+      "type": "Canvas",
+      "label": {
+        "en": ["Gustav Mahler, Symphony No. 3, CD 1"]
+      },
+      "duration": 1985.024,
+      "accompanyingCanvas": {
+        "id": "https://iiif.io/api/cookbook/recipe/0014-accompanyingcanvas/canvas/accompanying",
+        "type": "Canvas",
+        "label": {
+          "en": ["First page of score for Gustav Mahler, Symphony No. 3"]
+        },
+        "height": 998,
+        "width": 772,
+        "items": [
+          {
+            "id": "https://iiif.io/api/cookbook/recipe/0014-accompanyingcanvas/canvas/accompanying/annotation/page",
+            "type": "AnnotationPage",
+            "items": [
+              {
+                "id": "https://iiif.io/api/cookbook/recipe/0014-accompanyingcanvas/canvas/accompanying/annotation/image",
+                "type": "Annotation",
+                "motivation": "painting",
+                "body": {
+                  "id": "https://iiif.io/api/image/3.0/example/reference/4b45bba3ea612ee46f5371ce84dbcd89-mahler-0/full/,998/0/default.jpg",
+                  "type": "Image",
+                  "format": "image/jpeg",
+                  "height": 998,
+                  "width": 772,
+                  "service": [
+                    {
+                      "id": "https://iiif.io/api/image/3.0/example/reference/4b45bba3ea612ee46f5371ce84dbcd89-mahler-0",
+                      "type": "ImageService3",
+                      "profile": "level1"
+                    }
+                  ]
+                },
+                "target": "https://iiif.io/api/cookbook/recipe/0014-accompanyingcanvas/canvas/accompanying"
+              }
+            ]
+          }
+        ]
+      },
+      "items": [
+        {
+          "id": "https://iiif.io/api/cookbook/recipe/0014-accompanyingcanvas/canvas/page/p1",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://iiif.io/api/cookbook/recipe/0014-accompanyingcanvas/canvas/page/annotation/segment1-audio",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": {
+                "id": "https://fixtures.iiif.io/audio/indiana/mahler-symphony-3/CD1/medium/128Kbps.mp4",
+                "type": "Sound",
+                "duration": 1985.024,
+                "format": "video/mp4"
+              },
+              "target": "https://iiif.io/api/cookbook/recipe/0014-accompanyingcanvas/canvas/page/p1"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/src/components/Player/Player.tsx
+++ b/src/components/Player/Player.tsx
@@ -7,6 +7,10 @@ import AudioVisualizer from "./AudioVisualizer";
 import { CurrentTimeContext } from "context/current-time-context";
 import { useViewerState } from "context/viewer-context";
 import Track from "./Track";
+import {
+  getAccompanyingCanvasImage,
+  getCanvasByCriteria,
+} from "hooks/use-hyperion-framework";
 
 // Set referrer header as a NU domain: ie. meadow.rdc-staging.library.northwestern.edu
 
@@ -16,13 +20,27 @@ interface PlayerProps {
 }
 
 const Player: React.FC<PlayerProps> = ({ painting, resources }) => {
-  const viewerState: any = useViewerState();
-  const { configOptions } = viewerState;
-
   const playerRef = React.useRef(null);
   const isAudio = painting?.format?.includes("audio/");
 
   const { startTime, updateCurrentTime } = React.useContext(CurrentTimeContext);
+
+  const viewerState: any = useViewerState();
+  const { activeCanvas, configOptions, vault } = viewerState;
+
+  /**
+   * Get active canvas full object
+   */
+  const activeCanvasObject = getCanvasByCriteria(
+    vault,
+    { id: activeCanvas, type: "Canvas" },
+    "painting",
+    ["Image"],
+  );
+
+  const accompanyingItems: Array<any> =
+    activeCanvasObject.accompanyingCanvas?.items || [];
+  const posterImage = getAccompanyingCanvasImage(accompanyingItems);
 
   /**
    * HLS.js binding for .m3u8 files
@@ -109,6 +127,7 @@ const Player: React.FC<PlayerProps> = ({ painting, resources }) => {
         width={painting.width}
         onPlay={handlePlay}
         crossOrigin="anonymous"
+        poster={posterImage}
       >
         <source src={painting.id} type={painting.format} />
         {resources.length > 0 &&

--- a/src/components/Player/Player.tsx
+++ b/src/components/Player/Player.tsx
@@ -38,9 +38,9 @@ const Player: React.FC<PlayerProps> = ({ painting, resources }) => {
     ["Image"],
   );
 
-  const accompanyingItems: Array<any> =
-    activeCanvasObject.accompanyingCanvas?.items || [];
-  const posterImage = getAccompanyingCanvasImage(accompanyingItems);
+  const posterImage = getAccompanyingCanvasImage(
+    activeCanvasObject.accompanyingCanvas,
+  );
 
   /**
    * HLS.js binding for .m3u8 files

--- a/src/dev.tsx
+++ b/src/dev.tsx
@@ -3,7 +3,7 @@ import ReactDOM from "react-dom";
 import App from "./index";
 
 let sampleManifest: string =
-  "http://127.0.0.1:8080/fixtures/iiif/manifests/captions.json";
+  "http://127.0.0.1:8080/fixtures/iiif/manifests/audio-accompanying-canvas.json";
 
 const options: any = {
   ignoreCaptionLabels: ["Chapters"],

--- a/src/hooks/use-hyperion-framework/getAccompanyingCanvasImage.test.ts
+++ b/src/hooks/use-hyperion-framework/getAccompanyingCanvasImage.test.ts
@@ -1,0 +1,19 @@
+import { getAccompanyingCanvasImage } from "./getAccompanyingCanvasImage";
+import manifest from "../../../public/fixtures/iiif/manifests/audio-accompanying-canvas.json";
+
+describe("getAccompanyingCanvasImage hook", () => {
+  it("returns a url string if passed valid items", () => {
+    const items = manifest.items[0].accompanyingCanvas.items;
+    const expectedResult = items[0].items[0].body.id;
+    const result = getAccompanyingCanvasImage(items);
+    expect(result).toEqual(expectedResult);
+  });
+
+  it("returns undefined if there are any errors", () => {
+    const result = getAccompanyingCanvasImage();
+    expect(result).toBeUndefined();
+
+    const result2 = getAccompanyingCanvasImage([{ foo: "bar" }]);
+    expect(result2).toBeUndefined();
+  });
+});

--- a/src/hooks/use-hyperion-framework/getAccompanyingCanvasImage.test.ts
+++ b/src/hooks/use-hyperion-framework/getAccompanyingCanvasImage.test.ts
@@ -3,17 +3,14 @@ import manifest from "../../../public/fixtures/iiif/manifests/audio-accompanying
 
 describe("getAccompanyingCanvasImage hook", () => {
   it("returns a url string if passed valid items", () => {
-    const items = manifest.items[0].accompanyingCanvas.items;
-    const expectedResult = items[0].items[0].body.id;
-    const result = getAccompanyingCanvasImage(items);
+    const canvas = manifest.items[0].accompanyingCanvas;
+    const expectedResult = canvas.items[0].items[0].body.id;
+    const result = getAccompanyingCanvasImage(canvas);
     expect(result).toEqual(expectedResult);
   });
 
   it("returns undefined if there are any errors", () => {
-    const result = getAccompanyingCanvasImage();
+    const result = getAccompanyingCanvasImage({ foo: "bar" });
     expect(result).toBeUndefined();
-
-    const result2 = getAccompanyingCanvasImage([{ foo: "bar" }]);
-    expect(result2).toBeUndefined();
   });
 });

--- a/src/hooks/use-hyperion-framework/getAccompanyingCanvasImage.ts
+++ b/src/hooks/use-hyperion-framework/getAccompanyingCanvasImage.ts
@@ -1,0 +1,13 @@
+export const getAccompanyingCanvasImage = (
+  items: Array<any> = [],
+): string | undefined => {
+  if (items.length === 0) return;
+  try {
+    // I know there is a better way to do this, and want
+    // to chat about it Mat.
+    return items[0].items[0].body?.id;
+  } catch (e) {
+    console.error("Error retrieving accompanying canvas image", e);
+    return;
+  }
+};

--- a/src/hooks/use-hyperion-framework/getAccompanyingCanvasImage.ts
+++ b/src/hooks/use-hyperion-framework/getAccompanyingCanvasImage.ts
@@ -1,11 +1,34 @@
+import { IIIFExternalWebResource } from "@hyperion-framework/types";
+
+// TODO: Fix this type when fixing tests
+function getUrl(obj: any) {
+  // No IIIF image service, just return vague id value
+  if (!obj.service) {
+    return obj.id;
+  }
+  // Construct a IIIF Image service url path with params
+  return `${obj.service[0].id}/full/,${obj.height || 500}/0/default.jpg`;
+}
+
+// TODO: Fix this type when fixing all tests
 export const getAccompanyingCanvasImage = (
-  items: Array<any> = [],
+  accompanyingCanvas: any | undefined,
 ): string | undefined => {
-  if (items.length === 0) return;
+  if (!accompanyingCanvas) return;
   try {
-    // I know there is a better way to do this, and want
-    // to chat about it Mat.
-    return items[0].items[0].body?.id;
+    /**
+     * Step 1: does a thumbnail item exist on canvas root?
+     */
+    const thumbnail: Array<IIIFExternalWebResource> | undefined =
+      accompanyingCanvas.thumbnail;
+    if (thumbnail && thumbnail.length > 0) {
+      return getUrl(thumbnail[0]);
+    }
+
+    /**
+     * Step 2: Dig into the Annotation Page > Body
+     */
+    return getUrl(accompanyingCanvas.items[0].items[0].body);
   } catch (e) {
     console.error("Error retrieving accompanying canvas image", e);
     return;

--- a/src/hooks/use-hyperion-framework/getCanvasByCriteria.ts
+++ b/src/hooks/use-hyperion-framework/getCanvasByCriteria.ts
@@ -9,6 +9,7 @@ import {
 
 export interface CanvasEntity {
   canvas: CanvasNormalized | undefined;
+  accompanyingCanvas: Canvas | undefined;
   annotationPage: AnnotationPageNormalized | undefined;
   annotations: Array<Annotation | undefined>;
 }
@@ -21,6 +22,7 @@ export const getCanvasByCriteria = (
 ): CanvasEntity => {
   const entity: CanvasEntity = {
     canvas: undefined,
+    accompanyingCanvas: undefined,
     annotationPage: undefined,
     annotations: [],
   };
@@ -61,8 +63,12 @@ export const getCanvasByCriteria = (
 
   entity.canvas = vault.fromRef(item);
 
-  if (entity.canvas)
+  if (entity.canvas) {
     entity.annotationPage = vault.fromRef(entity.canvas.items[0]);
+    entity.accompanyingCanvas = entity.canvas?.accompanyingCanvas
+      ? vault.fromRef(entity.canvas?.accompanyingCanvas)
+      : undefined;
+  }
 
   if (entity.annotationPage)
     entity.annotations = vault

--- a/src/hooks/use-hyperion-framework/index.ts
+++ b/src/hooks/use-hyperion-framework/index.ts
@@ -1,3 +1,4 @@
+import { getAccompanyingCanvasImage } from "./getAccompanyingCanvasImage";
 import { getCanvasByCriteria } from "./getCanvasByCriteria";
 import { getPaintingResource } from "./getPaintingResource";
 import { getSupplementingResources } from "./getSupplementingResources";
@@ -5,6 +6,7 @@ import { getLabel } from "./getLabel";
 import { getThumbnail } from "./getThumbnail";
 
 export {
+  getAccompanyingCanvasImage,
   getCanvasByCriteria,
   getPaintingResource,
   getSupplementingResources,

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -51,7 +51,7 @@ const RenderViewer: React.FC<Props> = ({
   const [manifest, setManifest] = useState<ManifestNormalized>();
 
   /**
-   * Overrides the baseline stiches theme when set.
+   * Overrides the baseline stitches theme when set.
    */
   let theme = {};
   if (customTheme) theme = createTheme("custom", customTheme);


### PR DESCRIPTION
@mathewjordan Would like to chat on this...about 1.) Hyperion shortcut parsing and 2.) Setting up hooks and leaf level components to be tested easier (ie. maybe not passing in `vault`, which is hard if not impossible to mock in tests).

This PR supports Audio placeholder images when pulled in via `accompanyingCanvas` in a IIIF Manifest