### PR TITLE
Remove duplicate getLabel call on track return.

### DIFF
--- a/src/components/Player/Track.tsx
+++ b/src/components/Player/Track.tsx
@@ -21,9 +21,7 @@ const Track: React.FC<TrackProps> = ({ resource, ignoreCaptionLabels }) => {
     <track
       key={resource.id}
       src={resource.id as string}
-      label={
-        getLabel(resource.label as InternationalString, "en") as any as string
-      }
+      label={label}
       srcLang="en"
       data-testid="player-track"
     />


### PR DESCRIPTION
## Summary

This just tightens up some code and removes a duplicate `getLabel()` call on the returned `<track>`.