### PR TITLE
Documentation style refinements and syntax highlighter swap.

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,7 +245,7 @@ Clover IIIF is built with:
 
 This will open up a local dev server with live reloading.
 
-```
+```shell
 npm install
 npm run dev
 ```
@@ -254,13 +254,13 @@ npm run dev
 
 This will build and package the component
 
-```
+```shell
 npm run build
 ```
 
 This will create a static version of the site to the `/static` directory
 
-```
+```shell
 npm run build:static
 ```
 
@@ -268,7 +268,7 @@ npm run build:static
 
 - ESBuild compiles TypeScript to JavaScript, but does not do type checking. To view type checking errors (in addtion to what your IDE will be complaining about), run:
 
-```
+```shell
 tsc
 ```
 

--- a/build-static.js
+++ b/build-static.js
@@ -28,13 +28,6 @@ async function emptyDir() {
 async function copyFiles() {
   try {
     await fs.copy("public", OUT_DIR, { filter: filterFunc });
-
-    // Copy highlight.js package styles for markdown code highlighting
-    await fs.copy(
-      "./node_modules/highlight.js/styles/default.css",
-      `./${OUT_DIR}/default.css`,
-      { overwrite: true },
-    );
     console.log("\nSuccess copying files");
   } catch (err) {
     console.error("\nError copying files: ", err);

--- a/package-lock.json
+++ b/package-lock.json
@@ -47,12 +47,12 @@
         "eslint-plugin-prettier": "^4.0.0",
         "eslint-plugin-react": "^7.26.0",
         "fs-extra": "^10.0.1",
-        "highlight.js": "^11.5.0",
         "jest": "^27.2.1",
         "live-server": "^1.2.1",
         "markdown-it": "^12.3.2",
         "prettier": "^2.4.1",
         "rimraf": "^3.0.2",
+        "shiki": "^0.10.1",
         "ts-jest": "^27.0.5",
         "ts-node": "^10.2.1",
         "typescript": "^4.4.3"
@@ -4929,15 +4929,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/highlight.js": {
-      "version": "11.5.0",
-      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.5.0.tgz",
-      "integrity": "sha512-SM6WDj5/C+VfIY8pZ6yW6Xa0Fm1tniYVYWYW1Q/DcMnISZFrC3aQAZZZFAAZtybKNrGId3p/DNbFTtcTXXgYBw==",
-      "dev": true,
-      "engines": {
-        "node": ">=12.0.0"
-      }
-    },
     "node_modules/hls.js": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/hls.js/-/hls.js-1.1.4.tgz",
@@ -6635,6 +6626,12 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/jsonc-parser": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.0.0.tgz",
+      "integrity": "sha512-fQzRfAbIBnR0IQvftw9FJveWiHp72Fg20giDrHz6TdfB12UH/uue0D3hm57UB5KgAVuniLMCaS8P1IMj9NR7cA==",
+      "dev": true
     },
     "node_modules/jsonfile": {
       "version": "6.1.0",
@@ -8938,6 +8935,17 @@
         "node": ">=8"
       }
     },
+    "node_modules/shiki": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/shiki/-/shiki-0.10.1.tgz",
+      "integrity": "sha512-VsY7QJVzU51j5o1+DguUd+6vmCmZ5v/6gYu4vyYAhzjuNQU6P/vmSy4uQaOhvje031qQMiW0d2BwgMH52vqMng==",
+      "dev": true,
+      "dependencies": {
+        "jsonc-parser": "^3.0.0",
+        "vscode-oniguruma": "^1.6.1",
+        "vscode-textmate": "5.2.0"
+      }
+    },
     "node_modules/side-channel": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
@@ -10204,6 +10212,18 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/vscode-oniguruma": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/vscode-oniguruma/-/vscode-oniguruma-1.6.2.tgz",
+      "integrity": "sha512-KH8+KKov5eS/9WhofZR8M8dMHWN2gTxjMsG4jd04YhpbPR91fUj7rYQ2/XjeHCJWbg7X++ApRIU9NUwM2vTvLA==",
+      "dev": true
+    },
+    "node_modules/vscode-textmate": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/vscode-textmate/-/vscode-textmate-5.2.0.tgz",
+      "integrity": "sha512-Uw5ooOQxRASHgu6C7GVvUxisKXfSgW4oFlO+aa+PAkgmH89O3CXxEEzNRNtHSqtXFTl0nAC1uYj0GMSH27uwtQ==",
+      "dev": true
     },
     "node_modules/w3c-hr-time": {
       "version": "1.0.2",
@@ -14183,12 +14203,6 @@
         }
       }
     },
-    "highlight.js": {
-      "version": "11.5.0",
-      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.5.0.tgz",
-      "integrity": "sha512-SM6WDj5/C+VfIY8pZ6yW6Xa0Fm1tniYVYWYW1Q/DcMnISZFrC3aQAZZZFAAZtybKNrGId3p/DNbFTtcTXXgYBw==",
-      "dev": true
-    },
     "hls.js": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/hls.js/-/hls.js-1.1.4.tgz",
@@ -15471,6 +15485,12 @@
       "requires": {
         "minimist": "^1.2.5"
       }
+    },
+    "jsonc-parser": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.0.0.tgz",
+      "integrity": "sha512-fQzRfAbIBnR0IQvftw9FJveWiHp72Fg20giDrHz6TdfB12UH/uue0D3hm57UB5KgAVuniLMCaS8P1IMj9NR7cA==",
+      "dev": true
     },
     "jsonfile": {
       "version": "6.1.0",
@@ -17229,6 +17249,17 @@
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
       "dev": true
     },
+    "shiki": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/shiki/-/shiki-0.10.1.tgz",
+      "integrity": "sha512-VsY7QJVzU51j5o1+DguUd+6vmCmZ5v/6gYu4vyYAhzjuNQU6P/vmSy4uQaOhvje031qQMiW0d2BwgMH52vqMng==",
+      "dev": true,
+      "requires": {
+        "jsonc-parser": "^3.0.0",
+        "vscode-oniguruma": "^1.6.1",
+        "vscode-textmate": "5.2.0"
+      }
+    },
     "side-channel": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
@@ -18183,6 +18214,18 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
       "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw=",
+      "dev": true
+    },
+    "vscode-oniguruma": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/vscode-oniguruma/-/vscode-oniguruma-1.6.2.tgz",
+      "integrity": "sha512-KH8+KKov5eS/9WhofZR8M8dMHWN2gTxjMsG4jd04YhpbPR91fUj7rYQ2/XjeHCJWbg7X++ApRIU9NUwM2vTvLA==",
+      "dev": true
+    },
+    "vscode-textmate": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/vscode-textmate/-/vscode-textmate-5.2.0.tgz",
+      "integrity": "sha512-Uw5ooOQxRASHgu6C7GVvUxisKXfSgW4oFlO+aa+PAkgmH89O3CXxEEzNRNtHSqtXFTl0nAC1uYj0GMSH27uwtQ==",
       "dev": true
     },
     "w3c-hr-time": {

--- a/package.json
+++ b/package.json
@@ -42,12 +42,12 @@
     "eslint-plugin-prettier": "^4.0.0",
     "eslint-plugin-react": "^7.26.0",
     "fs-extra": "^10.0.1",
-    "highlight.js": "^11.5.0",
     "jest": "^27.2.1",
     "live-server": "^1.2.1",
     "markdown-it": "^12.3.2",
     "prettier": "^2.4.1",
     "rimraf": "^3.0.2",
+    "shiki": "^0.10.1",
     "ts-jest": "^27.0.5",
     "ts-node": "^10.2.1",
     "typescript": "^4.4.3"

--- a/public/styles.css
+++ b/public/styles.css
@@ -1,84 +1,103 @@
+@import url("https://fonts.googleapis.com/css2?family=Calistoga&family=IBM+Plex+Mono&family=Inter:wght@100;200;300;400;500;600;700;800;900&display=swap");
 html {
   font-size: 62.5%/1.7em;
 }
 
 body {
   margin: 0;
-  font: 1rem "Akkurat Pro Regular", Arial, sans-serif;
-  color: #342f2e;
+  font: 1rem "Inter", Arial, sans-serif;
+  color: #1a1d1e;
   background: #fff;
+}
+
+#root {
+  padding: 0 1rem;
+}
+
+#root header > span {
+  font-weight: 400;
 }
 
 button * {
   box-sizing: border-box;
 }
 
-header {
-  background-color: #4e2a84;
+h1 {
+  font-weight: 400;
+  font-family: "Calistoga", "Inter", Arial, sans-serif;
 }
 
-p {
+h2 {
+  margin: 2.618rem 0 1rem;
+  font-weight: 400;
+  font-family: "Calistoga", "Inter", Arial, sans-serif;
+}
+
+code {
+  background-color: #151718 !important;
+  padding: 0.25rem 0.618rem;
+  font-family: "IBM Plex Mono", monospace;
+  border-radius: 3px;
+}
+
+pre {
   padding: 1rem;
+  background-color: #151718 !important;
+  border-radius: 3px;
+  overflow-x: scroll;
+  font-family: "IBM Plex Mono", monospace;
+}
+
+pre > code {
+  padding: 0;
+}
+
+hr {
+  margin: 2.618rem 0 1rem;
+  color: #26292b;
+}
+
+p,
+li {
   font-size: 1rem;
   line-height: 1.55em;
+  font-weight: 300;
+}
+
+table {
+  background-color: transparent;
+  padding: 1rem 0;
 }
 
 td,
 th {
-  padding: 0.25rem 1.25rem;
+  padding: 0.618rem;
   text-align: left;
 }
 
+th {
+  font-weight: 300;
+  color: #c1c8cd;
+}
+
+td {
+  border-top: 1px solid #26292b;
+}
+
+td:first-child,
+th:first-child {
+  padding-left: 0;
+}
+
 .documentation-wrapper {
-  margin-top: 5rem;
-  padding: 1.618rem;
-  background: #342f2e;
-  color: white;
+  padding: 2.618rem;
+  background: #1a1d1e;
+  color: #fff;
 }
 .documentation-wrapper a,
 .documentation-wrapper a:visited {
-  color: #d8d6d6;
+  color: #c3e88d;
 }
 .documentation-wrapper .clover-screenshot {
   display: none;
-}
-
-@font-face {
-  font-family: "Akkurat Pro Regular";
-  src: url("https://common.northwestern.edu/v8/css/fonts/AkkuratProRegular.woff")
-    format("woff");
-  font-weight: normal;
-  font-style: normal;
-}
-
-@font-face {
-  font-family: "Akkurat Pro Italic";
-  src: url("https://common.northwestern.edu/v8/css/fonts/AkkuratProItalic.woff")
-    format("woff");
-  font-weight: normal;
-  font-style: normal;
-}
-
-@font-face {
-  font-family: "Akkurat Pro Bold";
-  src: url("https://common.northwestern.edu/v8/css/fonts/AkkuratProBold.woff")
-    format("woff");
-  font-weight: normal;
-  font-style: normal;
-}
-
-@font-face {
-  font-family: "Akkurat Pro Bold Italic";
-  src: url("https://common.northwestern.edu/v8/css/fonts/AkkuratProBoldItalic.woff")
-    format("woff");
-  font-weight: normal;
-  font-style: normal;
-}
-
-@font-face {
-  font-family: "Campton Bold";
-  src: url("https://common.northwestern.edu/v8/css/fonts/CamptonBold.woff")
-    format("woff");
-  font-weight: normal;
-  font-style: normal;
 }

--- a/src/stitches.tsx
+++ b/src/stitches.tsx
@@ -6,30 +6,29 @@ export const theme = {
      * Black and dark grays in a light theme.
      * Must contrast to 4.5 or greater with `secondary`.
      */
-    primary: "#342F2E",
-    primaryMuted: "#716C6B",
-    primaryAlt: "#000000",
+    primary: "#1a1d1e",
+    primaryMuted: "#26292b",
+    primaryAlt: "#151718",
 
     /*
      * Key brand color(s).
      * Must contrast to 4.5 or greater with `secondary`.
      */
-    accent: "#4E2A84",
-    accentMuted: "#B6ACD1",
-    accentAlt: "#401F68",
+    accent: "#006adc",
+    accentMuted: "#5eb0ef",
+    accentAlt: "#00254d",
 
     /*
      * White and light grays in a light theme.
      * Must contrast to 4.5 or greater with `primary` and  `accent`.
      */
     secondary: "#FFFFFF",
-    secondaryMuted: "#F0F0F0",
-    secondaryAlt: "#CCCCCC",
+    secondaryMuted: "#e6e8eb",
+    secondaryAlt: "#c1c8cd",
   },
   fonts: {
-    sans: "'Akkurat Pro Regular', Arial, sans-serif",
-    sansBold: "Akkurat Pro Bold, Arial, sans-serif",
-    display: "Campton, 'Akkurat Pro Regular', Arial, sans-serif",
+    sans: "'Inter', Arial, sans-serif",
+    display: "'Calistoga', 'Inter', Arial, sans-serif",
   },
   transitions: {
     all: "all 500ms cubic-bezier(0.16, 1, 0.3, 1)",

--- a/utils/html.js
+++ b/utils/html.js
@@ -1,11 +1,4 @@
-const fs = require("fs-extra");
-const { markdown } = require("./markdown");
-
-async function buildMarkdown() {
-  const content = await fs.readFile("./README.md", "utf8");
-  const markdownHTML = await markdown.render(content);
-  return `<div class="documentation-wrapper">${markdownHTML}</div>`;
-}
+const { buildMarkdown } = require("./markdown");
 
 async function buildHTML(isStatic) {
   const htmlFile = `<!DOCTYPE html>
@@ -13,7 +6,7 @@ async function buildHTML(isStatic) {
     <head>
       <meta charset="UTF-8" />
       <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-      <title>Demo</title>
+      <title>Clover IIIF</title>
       ${isStatic ? ` <link rel="stylesheet" href="./default.css" />` : ``}
       <link rel="stylesheet" href="./styles.css" />
     </head>

--- a/utils/markdown.js
+++ b/utils/markdown.js
@@ -1,24 +1,24 @@
-const hljs = require("highlight.js");
-const MarkdownIt = require("markdown-it");
+const fs = require("fs");
+const markdown = require("markdown-it");
+const shiki = require("shiki");
 
-const markdown = new MarkdownIt({
-  html: true,
-  highlight: function (str, lang) {
-    if (lang && hljs.getLanguage(lang)) {
-      try {
-        return (
-          '<pre><code class="hljs">' +
-          hljs.highlight(str, { language: lang, ignoreIllegals: true }).value +
-          "</code></pre>"
-        );
-      } catch (__) {}
-    }
-    return (
-      '<pre><code class="hljs">' +
-      markdown.utils.escapeHtml(str) +
-      "</code></pre>"
-    );
-  },
-});
+async function buildMarkdown() {
+  const markdownHTML = await shiki
+    .getHighlighter({
+      theme: "material-darker",
+    })
+    .then((highlighter) => {
+      const md = markdown({
+        html: true,
+        highlight: (code, lang) => {
+          return highlighter.codeToHtml(code, { lang });
+        },
+      });
 
-exports.markdown = markdown;
+      return md.render(fs.readFileSync("./README.md", "utf-8"));
+    });
+
+  return `<div class="documentation-wrapper">${markdownHTML}</div>`;
+}
+
+exports.buildMarkdown = buildMarkdown;


### PR DESCRIPTION
- Adjust styling.
- Add shiki highlighter, remove highlight.js, refine styling.
- Prop table styling.
- Adjust docs `<a>` color.
- Tidy up docs markdown and html writing.

### What's this do?
This makes font and color choices generic, swaps out Highlight.js for [shiki](https://github.com/shikijs/shiki/), and cleans up documentation look and feel overall.


### How do I review locally?
1. Pull down the branch
2. run `npm run build:static`
3. run `npx serve static`