### PR TITLE
Add dynamic manifest url logic and examples.

### DIFF
--- a/src/components/ImageViewer/ImageViewer.tsx
+++ b/src/components/ImageViewer/ImageViewer.tsx
@@ -35,9 +35,15 @@ const ImageViewer: React.FC<IIIFExternalWebResource> = ({ service }) => {
    */
   useEffect(() => {
     if (imageService) {
-      getInfoResponse(imageService.id).then((tileSource) =>
-        openSeadragonInstance?.open(tileSource),
-      );
+      let id: string | undefined;
+      "@id" in imageService
+        ? (id = imageService["@id"])
+        : (id = imageService.id);
+
+      if (id)
+        getInfoResponse(id).then((tileSource) =>
+          openSeadragonInstance?.open(tileSource),
+        );
     }
   }, [openSeadragonInstance, imageService]);
 

--- a/src/dev.tsx
+++ b/src/dev.tsx
@@ -1,18 +1,19 @@
 import React from "react";
 import ReactDOM from "react-dom";
 import App from "./index";
+import DynamicUrl from "./dev/DynamicUrl";
+import { manifests } from "./dev/manifests";
 
-// NOTE: "env" is available via the DotEnv ES Build Plugin defined in serve.js
-import { NODE_ENV, DEV_URL, STATIC_URL } from "env";
+const Wrapper = () => {
+  const defaultUrl: string = manifests[0].url;
 
-const host = NODE_ENV === "development" ? DEV_URL : STATIC_URL;
-let sampleManifest: string = `${host}/fixtures/iiif/manifests/sample.json`;
-
-const options: any = {
-  ignoreCaptionLabels: ["Chapters"],
+  const [url, setUrl] = React.useState(defaultUrl);
+  return (
+    <>
+      <App manifestId={url} key={url} />
+      <DynamicUrl url={url} setUrl={setUrl} />
+    </>
+  );
 };
 
-ReactDOM.render(
-  <App manifestId={sampleManifest} options={options} />,
-  document.getElementById("root"),
-);
+ReactDOM.render(<Wrapper />, document.getElementById("root"));

--- a/src/dev/DynamicUrl.styled.tsx
+++ b/src/dev/DynamicUrl.styled.tsx
@@ -1,0 +1,92 @@
+import { styled } from "@stitches/react";
+
+const DynamicUrlStyled = styled("section", {
+  display: "flex",
+  flexDirection: "column",
+  alignItems: "center",
+  padding: "2rem",
+});
+
+const ManualForm = styled("form", {
+  display: "flex",
+  justifyContent: "center",
+  flexDirection: "column",
+  alignItems: "center",
+  width: "61.8%",
+
+  label: {
+    display: "block",
+    marginBottom: "1rem",
+    fontSize: "1.25rem",
+    color: "$primary",
+    fontWeight: "400",
+    fontFamily: "$display",
+  },
+
+  "> div": {
+    display: "flex",
+    backgroundColor: "$secondaryMuted",
+    position: "relative",
+    width: "100%",
+    borderRadius: "3px",
+
+    input: {
+      padding: "0.618rem 1rem",
+      background: "transparent",
+      color: "$primary",
+      border: "none",
+      fontFamily: "$sans",
+      width: "100%",
+    },
+
+    button: {
+      padding: "0.382rem 0.618rem",
+      cursor: "pointer",
+      position: "absolute",
+      right: "0.382rem",
+      alignSelf: "center",
+      background: "$secondary",
+      border: "none",
+      fontSize: "0.7222rem",
+      fontFamily: "$sans",
+      fontWeight: "700",
+      borderRadius: "3px",
+      backgroundColor: "$secondary",
+      color: "$primary",
+    },
+  },
+});
+
+const Curated = styled("div", {
+  padding: "2rem",
+  display: "flex",
+  justifyContent: "center",
+  flexWrap: "wrap",
+});
+
+const ButtonForm = styled("form", {
+  button: {
+    backgroundColor: "$transparent",
+    border: "none",
+    outline: "1px solid $secondaryMuted",
+    color: "$primaryMuted",
+    fontFamily: "$sans",
+    fontSize: "0.8333rem",
+    height: "2rem",
+    padding: "0 1rem",
+    borderRadius: "1rem",
+    cursor: "pointer",
+    margin: "0.5rem",
+  },
+
+  "&[data-active='true']": {
+    button: {
+      color: "$white",
+      fontWeight: "700",
+      backgroundColor: "$accent",
+      outline: "1px solid $accent",
+    },
+  },
+});
+
+export { DynamicUrlStyled, Curated, ManualForm, ButtonForm };

--- a/src/dev/DynamicUrl.tsx
+++ b/src/dev/DynamicUrl.tsx
@@ -1,0 +1,69 @@
+import React, {
+  Dispatch,
+  FormEvent,
+  SetStateAction,
+  useEffect,
+  useRef,
+} from "react";
+import {
+  ButtonForm,
+  Curated,
+  DynamicUrlStyled,
+  ManualForm,
+} from "./DynamicUrl.styled";
+import { manifests } from "./manifests";
+
+interface DynamicUrlProps {
+  url: string;
+  setUrl: Dispatch<SetStateAction<string>>;
+}
+
+const DynamicUrl: React.FC<DynamicUrlProps> = ({ url, setUrl }) => {
+  const inputRef = useRef<HTMLInputElement>(null);
+  const handleSubmit = (e: FormEvent) => {
+    e.preventDefault();
+    const target = e.target as typeof e.target & {
+      url: { value: string };
+    };
+    setUrl(target.url?.value);
+  };
+
+  useEffect(() => {
+    if (inputRef.current) inputRef.current.value = url;
+  }, [url]);
+
+  return (
+    <DynamicUrlStyled>
+      <ManualForm onSubmit={handleSubmit}>
+        <label htmlFor="manual-manifest">View a IIIF Manifest</label>
+        <div>
+          <input
+            type="text"
+            name="url"
+            id="manual-manifest"
+            placeholder="IIIF Manifest"
+            ref={inputRef}
+          />
+          <button type="submit">View</button>
+        </div>
+      </ManualForm>
+      {manifests.length > 0 && (
+        <Curated>
+          {manifests.map((obj) => (
+            <ButtonForm
+              key={obj.label}
+              onSubmit={handleSubmit}
+              data-active={url === obj.url ? true : false}
+            >
+              <button name="url" value={obj.url}>
+                {obj.label}
+              </button>
+            </ButtonForm>
+          ))}
+        </Curated>
+      )}
+    </DynamicUrlStyled>
+  );
+};
+
+export default DynamicUrl;

--- a/src/dev/manifests.ts
+++ b/src/dev/manifests.ts
@@ -1,0 +1,58 @@
+export const manifests = [
+  {
+    url: "https://raw.githubusercontent.com/samvera-labs/clover-iiif/main/public/fixtures/iiif/manifests/sample.json",
+    label: "Default",
+  },
+  {
+    url: "https://iiif.stack.rdc.library.northwestern.edu/public/iiif3/72/34/b6/dd/-d/6a/2-/49/54/-8/fc/c-/6c/9f/2d/fb/88/34-manifest.json",
+    label: "The Takeover",
+  },
+  {
+    url: "https://iiif.stack.rdc.library.northwestern.edu/public/iiif3/66/8a/2a/ea/-4/33/3-/4a/5e/-b/52/3-/41/ac/98/bd/15/b7-manifest.json",
+    label: "Highlight Reel, 1935",
+  },
+  {
+    url: "https://iiif.stack.rdc.library.northwestern.edu/public/iiif3/24/68/7f/7d/-1/59/5-/4f/56/-8/3b/2-/5f/93/36/72/86/b3-manifest.json",
+    label: "Syracuse, 1984",
+  },
+  {
+    url: "https://iiif.stack.rdc.library.northwestern.edu/public/iiif3/00/26/de/66/-6/b5/c-/47/da/-8/ee/2-/70/4b/68/0b/2c/81-manifest.json",
+    label: "Piano Trio",
+  },
+  {
+    url: "https://iiif.stack.rdc.library.northwestern.edu/public/ff/51/2f/7c/-b/df/8-/4a/b7/-9/74/f-/f4/36/f0/ed/13/5d-manifest.json",
+    label: "Joan Baez",
+  },
+  {
+    url: "https://iiif.stack.rdc.library.northwestern.edu/public/a3/c6/40/28/-d/1d/c-/4e/97/-8/2b/b-/1e/23/af/95/f5/e3-manifest.json",
+    label: "Bravazzo",
+  },
+  {
+    url: "https://figgy.princeton.edu/concern/scanned_resources/4ff986e6-4f71-4f7c-8ff9-0d0c33d96cf0/manifest",
+    label: "Parrots and Toucans",
+  },
+  {
+    url: "https://manifests.collections.yale.edu/ycba/obj/21168",
+    label: "Greenland Falcon",
+  },
+  {
+    url: "https://api.artic.edu/api/v1/artworks/25865/manifest.json",
+    label: "The Herring Net",
+  },
+  {
+    url: "https://iiif.harvardartmuseums.org/manifests/object/304096",
+    label: "Basin",
+  },
+  {
+    url: "https://curio.lib.utexas.edu/assets/DAMS/utblac/utblac_bd7d20a3-2069-46df-9882-752e17df9f0a/manifests/3/utblac_bd7d20a3-2069-46df-9882-752e17df9f0a.json",
+    label: "Odom Family Oral History",
+  },
+  {
+    url: "https://figgy.princeton.edu/concern/scanned_resources/ace2909a-8966-43f9-b547-084aeaaea13d/manifest",
+    label: "Selma to Montgomery",
+  },
+  {
+    url: "https://view.nls.uk/manifest/7446/74465058/manifest.json",
+    label: "Scotia depicta",
+  },
+];


### PR DESCRIPTION
- Initial for dynamic url setup
- Add styling and organize dev components.
- Fix type issue on input ref.

![image](https://user-images.githubusercontent.com/7376450/161861299-4302b24d-223e-411c-8ac0-b5f99c38271b.png)

### What's this do?
This adds an input form to update manifest IDs in the example Clover app. I also curated a small set of manifests that showcased Clover functionality and organized them as buttons.

### How do I review locally?
1. Pull down the branch
2. run `npm run build:static`
3. run `npx serve static`