### PR TITLE
Add config options for active canvas and styling flexibility.

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,17 +184,19 @@ return <CloverIIIF manifestId={manifestId} customTheme={customTheme} />;
 
 <h2 id="reference">Reference</h2>
 
-| Prop                          | Type       | Required | Default |
-| ----------------------------- | ---------- | -------- | ------- |
-| `manifestId`                  | `string`   | Yes      |         |
-| `canvasIdCallback`            | `function` | No       |         |
-| `customTheme`                 | `object`   | No       |         |
-| `options`                     | `object`   | No       |         |
-| `options.showTitle`           | `boolean`  | No       | true    |
-| `options.showIIIFBadge`       | `boolean`  | No       | true    |
-| `options.ignoreCaptionLabels` | `string[]` | No       | []      |
+| Prop                            | Type       | Required | Default   |
+| ------------------------------- | ---------- | -------- | --------- |
+| `manifestId`                    | `string`   | Yes      |           |
+| `canvasIdCallback`              | `function` | No       |           |
+| `customTheme`                   | `object`   | No       |           |
+| `options`                       | `object`   | No       |           |
+| `options.showTitle`             | `boolean`  | No       | true      |
+| `options.showIIIFBadge`         | `boolean`  | No       | true      |
+| `options.ignoreCaptionLabels`   | `string[]` | No       | []        |
+| `options.canvasBackgroundColor` | `string`   | No       | `#1a1d1e` |
+| `options.canvasHeight`          | `string`   | No       | `500px`   |
 
-Clover IIIF version 1.4.0, introduces an `options` prop, which will serve as a configuration object for common configuration options.
+Clover IIIF version 1.4.0, introduces an `options` prop, which will serve as a configuration object for common configuration options. Options `canvasBackgroundColor` and `canvasHeight` will apply to both `<video>` elements and the OpenseaDragon canvas.
 
 ```jsx
 import CloverIIIF from "@samvera/clover-iiif";

--- a/public/styles.css
+++ b/public/styles.css
@@ -11,10 +11,11 @@ body {
 }
 
 #root {
-  padding: 0 1rem;
+  padding: 0;
 }
 
 #root header > span {
+  font-family: "Calistoga", "Inter", Arial, sans-serif;
   font-weight: 400;
 }
 

--- a/src/components/ImageViewer/ImageViewer.styled.tsx
+++ b/src/components/ImageViewer/ImageViewer.styled.tsx
@@ -31,7 +31,8 @@ const Viewport = styled("div", {
 
 const Wrapper = styled("div", {
   width: "100%",
-  height: "450px",
+  height: "61.8vh",
+  maxHeight: "100vh",
   background: "black",
   backgroundSize: "contain",
   color: "white",

--- a/src/components/ImageViewer/OSD.tsx
+++ b/src/components/ImageViewer/OSD.tsx
@@ -4,6 +4,7 @@ import { Navigator, Viewport, Wrapper } from "./ImageViewer.styled";
 import Controls from "./Controls";
 import { getInfoResponse } from "services/iiif";
 import { v4 as uuidv4 } from "uuid";
+import { useViewerState } from "context/viewer-context";
 
 export type osdImageTypes = "tiledImage" | "simpleImage" | undefined;
 
@@ -14,6 +15,9 @@ interface OSDProps {
 
 const OSD: React.FC<OSDProps> = ({ uri, imageType }) => {
   const [osdUri, setOsdUri] = useState<string>();
+  const viewerState: any = useViewerState();
+  const { configOptions } = viewerState;
+
   const instance = uuidv4();
 
   const config = {
@@ -57,7 +61,12 @@ const OSD: React.FC<OSDProps> = ({ uri, imageType }) => {
   }, [osdUri]);
 
   return (
-    <Wrapper>
+    <Wrapper
+      css={{
+        backgroundColor: configOptions.canvasBackgroundColor,
+        height: configOptions.canvasHeight,
+      }}
+    >
       <Controls />
       <Navigator id={`openseadragon-navigator-${instance}`} />
       <Viewport id={`openseadragon-viewport-${instance}`} />

--- a/src/components/Media/Controls.styled.tsx
+++ b/src/components/Media/Controls.styled.tsx
@@ -77,10 +77,6 @@ const Direction = styled("div", {
     margin: "0 0.5rem",
     fontSize: "0.7222rem",
   },
-
-  [`& ${Button}`]: {
-    // boxShadow: "none",
-  },
 });
 
 const Wrapper = styled("div", {

--- a/src/components/Media/Media.styled.tsx
+++ b/src/components/Media/Media.styled.tsx
@@ -5,14 +5,10 @@ const Group = styled(RadioGroup.Root, {
   display: "flex",
   flexDirection: "row",
   flexGrow: "1",
-  padding: "1.618rem 0.618rem 1.618rem 0 ",
+  padding: "1.618rem",
   overflowX: "scroll",
   position: "relative",
   zIndex: "0",
-
-  "@sm": {
-    padding: "1rem",
-  },
 });
 
 export { Group };

--- a/src/components/Media/Thumbnail.styled.tsx
+++ b/src/components/Media/Thumbnail.styled.tsx
@@ -35,21 +35,9 @@ const Item = styled(RadioGroup.Item, {
     marginRight: "1rem",
   },
 
-  "@sm": {
-    margin: "0 1rem 0 0",
-
-    "&:last-child": {
-      marginRight: "0",
-    },
-  },
-
   figure: {
     margin: "0",
     width: "161.8px",
-
-    "@sm": {
-      width: "123px",
-    },
 
     "> div": {
       position: "relative",
@@ -60,10 +48,6 @@ const Item = styled(RadioGroup.Item, {
       overflow: "hidden",
       borderRadius: "3px",
       transition: "$all",
-
-      "@sm": {
-        height: "76px",
-      },
 
       img: {
         width: "100%",
@@ -77,13 +61,8 @@ const Item = styled(RadioGroup.Item, {
 
       [`& ${Type}`]: {
         position: "absolute",
-        right: "0.5rem",
-        bottom: "0.5rem",
-
-        "@sm": {
-          right: "0",
-          bottom: "0",
-        },
+        right: "0",
+        bottom: "0",
 
         [`& ${Tag}`]: {
           margin: "0",
@@ -92,11 +71,8 @@ const Item = styled(RadioGroup.Item, {
           backgroundColor: "#000d",
           color: "$secondary",
           fill: "$secondary",
-
-          "@sm": {
-            borderBottomLeftRadius: "0",
-            borderTopRightRadius: "0",
-          },
+          borderBottomLeftRadius: "0",
+          borderTopRightRadius: "0",
         },
       },
     },

--- a/src/components/Player/Player.styled.tsx
+++ b/src/components/Player/Player.styled.tsx
@@ -6,7 +6,7 @@ export const PlayerWrapper = styled("div", {
   display: "flex",
   flexGrow: "0",
   flexShrink: "1",
-  maxHeight: "450px",
+  maxHeight: "500px",
   zIndex: "1",
 
   video: {

--- a/src/components/Player/Player.tsx
+++ b/src/components/Player/Player.tsx
@@ -117,7 +117,12 @@ const Player: React.FC<PlayerProps> = ({ painting, resources }) => {
   };
 
   return (
-    <PlayerWrapper>
+    <PlayerWrapper
+      css={{
+        backgroundColor: configOptions.canvasBackgroundColor,
+        maxHeight: configOptions.canvasHeight,
+      }}
+    >
       <video
         id="clover-iiif-video"
         key={painting.id}

--- a/src/components/Viewer/Content.tsx
+++ b/src/components/Viewer/Content.tsx
@@ -36,7 +36,7 @@ const ViewerContent: React.FC<Props> = ({
   isNavigatorOpen,
 }) => {
   return (
-    <Content>
+    <Content className="clover-content">
       <CurrentTimeProvider>
         <Main>
           {isMedia ? (
@@ -53,7 +53,7 @@ const ViewerContent: React.FC<Props> = ({
             </Button>
           </CollapsibleTrigger>
           {items.length > 1 && (
-            <MediaWrapper>
+            <MediaWrapper className="clover-canvases">
               <Media items={items} activeItem={0} />
             </MediaWrapper>
           )}

--- a/src/components/Viewer/Header.styled.tsx
+++ b/src/components/Viewer/Header.styled.tsx
@@ -4,12 +4,15 @@ import { Popover } from "@nulib/design-system";
 const IIIFBadgeButton = styled(Popover.Trigger, {
   width: "30px",
   padding: "5px",
+  margin: "0 0 0 2rem",
 });
 
 const IIIFBadgeContent = styled(Popover.Content, {
   display: "flex",
   flexDirection: "column",
   fontSize: "0.8333rem",
+  border: "none",
+  boxShadow: "2px 2px 5px #0003",
 
   button: {
     display: "flex",
@@ -31,7 +34,7 @@ const Header = styled("header", {
   display: "flex",
   backgroundColor: "transparent !important",
   justifyContent: "space-between",
-  padding: "0 0 0.5rem",
+  padding: "1rem",
 
   span: {
     fontSize: "1.25rem",
@@ -39,7 +42,6 @@ const Header = styled("header", {
     fontFamily: "$display",
 
     "@sm": {
-      padding: "1rem",
       fontSize: "1rem",
     },
   },

--- a/src/components/Viewer/Header.tsx
+++ b/src/components/Viewer/Header.tsx
@@ -16,12 +16,16 @@ const ViewerHeader: React.FC<Props> = ({ manifestId, manifestLabel }) => {
   const viewerState: any = useViewerState();
   const { configOptions } = viewerState;
 
+  const { showTitle, showIIIFBadge } = configOptions;
+
+  if (!showTitle && !showIIIFBadge) return <></>;
+
   return (
-    <Header>
-      {configOptions.showTitle && (
+    <Header className="clover-header">
+      {showTitle && (
         <span>{getLabel(manifestLabel as InternationalString, "en")}</span>
       )}
-      {configOptions.showIIIFBadge && (
+      {showIIIFBadge && (
         <Popover>
           <IIIFBadgeButton>
             <IIIFBadge />

--- a/src/components/Viewer/Viewer.styled.tsx
+++ b/src/components/Viewer/Viewer.styled.tsx
@@ -70,10 +70,9 @@ const Aside = styled("aside", {
   },
 });
 
-const Wrapper = styled("section", {
+const Wrapper = styled("div", {
   display: "flex",
   flexDirection: "column",
-  padding: "1.618rem",
   fontFamily: "$sans",
   backgroundColor: "$secondary",
   fontSmooth: "auto",

--- a/src/components/Viewer/Viewer.tsx
+++ b/src/components/Viewer/Viewer.tsx
@@ -85,7 +85,7 @@ const Viewer: React.FC<ViewerProps> = ({ manifest, theme }) => {
   return (
     <ErrorBoundary FallbackComponent={ErrorFallback}>
       <Wrapper
-        className={theme}
+        className={`${theme} clover-iiif`}
         data-body-locked={isBodyLocked}
         data-navigator={isNavigator}
         data-navigator-open={isNavigatorOpen}

--- a/src/context/viewer-context.tsx
+++ b/src/context/viewer-context.tsx
@@ -5,12 +5,16 @@ export type ConfigOptions = {
   showTitle: boolean;
   showIIIFBadge: boolean;
   ignoreCaptionLabels: string[];
+  canvasBackgroundColor: string;
+  canvasHeight: string;
 };
 
 const defaultConfigOptions = {
   showTitle: true,
   showIIIFBadge: true,
   ignoreCaptionLabels: [],
+  canvasBackgroundColor: "#e6e8eb",
+  canvasHeight: "61.8vh",
 };
 
 interface ViewerContextStore {

--- a/src/dev.tsx
+++ b/src/dev.tsx
@@ -10,7 +10,14 @@ const Wrapper = () => {
   const [url, setUrl] = React.useState(defaultUrl);
   return (
     <>
-      <App manifestId={url} key={url} />
+      <App
+        manifestId={url}
+        key={url}
+        options={{
+          canvasBackgroundColor: "#e6e8eb",
+          canvasHeight: "61.8vh",
+        }}
+      />
       <DynamicUrl url={url} setUrl={setUrl} />
     </>
   );


### PR DESCRIPTION
- Add basic classes for selector styling.
- More flexible styling for consuming app containers.

This adds two new config options for managing height and background color of the active canvas. These values are fed into the viewer context and distilled down to the video player and OpenSeadragon for respective content resources types. 

![image](https://user-images.githubusercontent.com/7376450/165657306-c3d8dffe-aa7b-4571-9b2b-4e009c0028eb.png)

I also refreshed some styling choices that made to make Clover much more flexible in consuming applications.
- Added basic `clover-*` class names to some high level layout elements
- Removed padding wrapping entire app so that Clover reaches the edges of the container in the consuming application
- Replaced `<section>` wrapping element with a generic `<div>`
- **and** Cleaned up some responsive behavior on the media thumbnails 