### PR TITLE
Cleanup paths on imports.

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -4,6 +4,9 @@ import type { Config } from "@jest/types";
 // Sync object
 const config: Config.InitialOptions = {
   moduleDirectories: ["node_modules", "src"],
+  moduleNameMapper: {
+    "@/(.*)": "<rootDir>/src/$1",
+  },
   roots: ["<rootDir>/src"],
   setupFilesAfterEnv: ["./jest-setup.ts"],
   testEnvironment: "jsdom",

--- a/src/components/CopyText.tsx
+++ b/src/components/CopyText.tsx
@@ -1,6 +1,6 @@
 import React from "react";
-import { styled } from "stitches";
-import { useCopyToClipboard, CopyStatus } from "hooks/useCopyToClipboard";
+import { styled } from "@/stitches";
+import { useCopyToClipboard, CopyStatus } from "@/hooks/useCopyToClipboard";
 
 const Status = styled("span", {
   display: "flex",

--- a/src/components/ImageViewer/Button.styled.tsx
+++ b/src/components/ImageViewer/Button.styled.tsx
@@ -1,4 +1,4 @@
-import { styled } from "@stitches/react";
+import { styled } from "@/stitches";
 
 const Item = styled("button", {
   display: "flex",

--- a/src/components/ImageViewer/Button.test.tsx
+++ b/src/components/ImageViewer/Button.test.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { render, screen } from "@testing-library/react";
-import Button from "./Button";
+import Button from "@/components/ImageViewer/Button";
 
 describe("Button component", () => {
   it("renders", () => {

--- a/src/components/ImageViewer/Button.tsx
+++ b/src/components/ImageViewer/Button.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Item } from "./Button.styled";
+import { Item } from "@/components/ImageViewer/Button.styled";
 
 interface ButtonProps {
   id: string;

--- a/src/components/ImageViewer/Controls.styled.tsx
+++ b/src/components/ImageViewer/Controls.styled.tsx
@@ -1,4 +1,4 @@
-import { styled } from "@stitches/react";
+import { styled } from "@/stitches";
 
 const Wrapper = styled("div", {
   position: "absolute",

--- a/src/components/ImageViewer/Controls.test.tsx
+++ b/src/components/ImageViewer/Controls.test.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { render, screen } from "@testing-library/react";
-import Controls from "./Controls";
+import Controls from "@/components/ImageViewer/Controls";
 
 describe("Controls component", () => {
   it("renders", () => {

--- a/src/components/ImageViewer/Controls.tsx
+++ b/src/components/ImageViewer/Controls.tsx
@@ -1,6 +1,6 @@
 import React from "react";
-import Button from "./Button";
-import { Wrapper } from "./Controls.styled";
+import Button from "@/components/ImageViewer/Button";
+import { Wrapper } from "@/components/ImageViewer/Controls.styled";
 
 const Controls: React.FC = () => {
   const ZoomIn = () => {

--- a/src/components/ImageViewer/ImageViewer.styled.tsx
+++ b/src/components/ImageViewer/ImageViewer.styled.tsx
@@ -1,4 +1,4 @@
-import { styled } from "stitches";
+import { styled } from "@/stitches";
 
 const Navigator = styled("div", {
   position: "absolute !important",

--- a/src/components/ImageViewer/ImageViewer.test.tsx
+++ b/src/components/ImageViewer/ImageViewer.test.tsx
@@ -1,8 +1,8 @@
 import { enableFetchMocks } from "jest-fetch-mock";
 import React from "react";
 import { render } from "@testing-library/react";
-import ImageViewer from "./ImageViewer";
-import { tileSourceResponse } from "../../services/iiif-test-fixtures";
+import ImageViewer from "@/components/ImageViewer/ImageViewer";
+import { tileSourceResponse } from "@/services/iiif-test-fixtures";
 
 enableFetchMocks();
 

--- a/src/components/ImageViewer/ImageViewer.tsx
+++ b/src/components/ImageViewer/ImageViewer.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from "react";
 import { IIIFExternalWebResource } from "@iiif/presentation-3";
-import OSD, { osdImageTypes } from "./OSD";
-import { getImageServiceURI } from "services/iiif";
+import OSD, { osdImageTypes } from "@/components/ImageViewer/OSD";
+import { getImageServiceURI } from "@/services/iiif";
 
 interface ImageViewerProps {
   body: IIIFExternalWebResource;

--- a/src/components/ImageViewer/OSD.tsx
+++ b/src/components/ImageViewer/OSD.tsx
@@ -1,10 +1,14 @@
 import React, { useEffect, useState } from "react";
 import OpenSeadragon from "openseadragon";
-import { Navigator, Viewport, Wrapper } from "./ImageViewer.styled";
-import Controls from "./Controls";
-import { getInfoResponse } from "services/iiif";
+import {
+  Navigator,
+  Viewport,
+  Wrapper,
+} from "@/components/ImageViewer/ImageViewer.styled";
+import Controls from "@/components/ImageViewer/Controls";
+import { getInfoResponse } from "@/services/iiif";
 import { v4 as uuidv4 } from "uuid";
-import { useViewerState } from "context/viewer-context";
+import { useViewerState } from "@/context/viewer-context";
 
 export type osdImageTypes = "tiledImage" | "simpleImage" | undefined;
 

--- a/src/components/Media/Controls.styled.tsx
+++ b/src/components/Media/Controls.styled.tsx
@@ -1,4 +1,4 @@
-import { styled } from "stitches";
+import { styled } from "@/stitches";
 
 const Form = styled("div", {
   position: "absolute",

--- a/src/components/Media/Controls.tsx
+++ b/src/components/Media/Controls.tsx
@@ -1,6 +1,12 @@
 import React, { useEffect, useState } from "react";
-import { Button, Direction, Form, Input, Wrapper } from "./Controls.styled";
-import useKeyPress from "hooks/useKeyPress";
+import {
+  Button,
+  Direction,
+  Form,
+  Input,
+  Wrapper,
+} from "@/components/Media/Controls.styled";
+import useKeyPress from "@/hooks/useKeyPress";
 
 interface Props {
   handleCanvasToggle: (arg0: -1 | 1) => void;

--- a/src/components/Media/Media.styled.tsx
+++ b/src/components/Media/Media.styled.tsx
@@ -1,5 +1,5 @@
 import * as RadioGroup from "@radix-ui/react-radio-group";
-import { styled } from "stitches";
+import { styled } from "@/stitches";
 
 const Group = styled(RadioGroup.Root, {
   display: "flex",

--- a/src/components/Media/Media.test.tsx
+++ b/src/components/Media/Media.test.tsx
@@ -1,4 +1,4 @@
-import Media from "./Media";
+import Media from "@/components/Media/Media";
 import React from "react";
 import { render, screen } from "@testing-library/react";
 

--- a/src/components/Media/Media.tsx
+++ b/src/components/Media/Media.tsx
@@ -1,16 +1,16 @@
 import React, { useEffect, useState } from "react";
-import { Group } from "./Media.styled";
-import { CanvasEntity } from "hooks/use-iiif/getCanvasByCriteria";
-import { getCanvasByCriteria, getLabel, getThumbnail } from "hooks/use-iiif";
+import { Group } from "@/components/Media/Media.styled";
+import { CanvasEntity } from "@/hooks/use-iiif/getCanvasByCriteria";
+import { getCanvasByCriteria, getLabel, getThumbnail } from "@/hooks/use-iiif";
 import {
   Canvas,
   CanvasNormalized,
   ExternalResourceTypes,
 } from "@iiif/presentation-3";
-import { useViewerState, useViewerDispatch } from "context/viewer-context";
-import Thumbnail from "./Thumbnail";
-import { getResourceType } from "hooks/use-iiif/getResourceType";
-import Controls from "./Controls";
+import { useViewerState, useViewerDispatch } from "@/context/viewer-context";
+import Thumbnail from "@/components/Media/Thumbnail";
+import { getResourceType } from "@/hooks/use-iiif/getResourceType";
+import Controls from "@/components/Media/Controls";
 
 interface MediaProps {
   items: Canvas[];

--- a/src/components/Media/Thumbnail.styled.tsx
+++ b/src/components/Media/Thumbnail.styled.tsx
@@ -1,5 +1,5 @@
 import * as RadioGroup from "@radix-ui/react-radio-group";
-import { styled } from "stitches";
+import { styled } from "@/stitches";
 import { Tag } from "@nulib/design-system";
 
 const Type = styled("span", {

--- a/src/components/Media/Thumbnail.test.tsx
+++ b/src/components/Media/Thumbnail.test.tsx
@@ -1,8 +1,8 @@
 import React from "react";
-import Thumbnail from "./Thumbnail";
+import Thumbnail from "@/components/Media/Thumbnail";
 import { screen, render, within } from "@testing-library/react";
-import { ThumbnailProps } from "./Thumbnail";
-import { Group } from "./Media.styled";
+import { ThumbnailProps } from "@/components/Media/Thumbnail";
+import { Group } from "@/components/Media/Media.styled";
 
 const props: ThumbnailProps = {
   canvas: {
@@ -36,7 +36,7 @@ const props: ThumbnailProps = {
     ],
     annotations: [],
     seeAlso: [],
-    homepage: null,
+    homepage: [],
     logo: [],
     partOf: [],
     rendering: [],

--- a/src/components/Media/Thumbnail.tsx
+++ b/src/components/Media/Thumbnail.tsx
@@ -1,13 +1,18 @@
 import React from "react";
-import { getLabel } from "hooks/use-iiif";
-import { convertTime } from "services/utils";
+import { getLabel } from "@/hooks/use-iiif";
+import { convertTime } from "@/services/utils";
 import {
   CanvasNormalized,
   IIIFExternalWebResource,
   InternationalString,
 } from "@iiif/presentation-3";
 import { Icon, Tag } from "@nulib/design-system";
-import { Duration, Item, Spacer, Type } from "./Thumbnail.styled";
+import {
+  Duration,
+  Item,
+  Spacer,
+  Type,
+} from "@/components/Media/Thumbnail.styled";
 
 /**
  * Determine appropriate icon by resource type

--- a/src/components/Navigator/Cue.styled.tsx
+++ b/src/components/Navigator/Cue.styled.tsx
@@ -1,5 +1,5 @@
 import * as RadioGroup from "@radix-ui/react-radio-group";
-import { styled, keyframes } from "stitches";
+import { styled, keyframes } from "@/stitches";
 
 const spin = keyframes({
   from: { transform: "rotate(360deg)" },

--- a/src/components/Navigator/Cue.test.tsx
+++ b/src/components/Navigator/Cue.test.tsx
@@ -1,5 +1,5 @@
-import Cue from "./Cue";
-import { Group } from "./Cue.styled";
+import Cue from "@/components/Navigator/Cue";
+import { Group } from "@/components/Navigator/Cue.styled";
 import React from "react";
 import { render, screen } from "@testing-library/react";
 

--- a/src/components/Navigator/Cue.tsx
+++ b/src/components/Navigator/Cue.tsx
@@ -1,7 +1,7 @@
 import React from "react";
-import { Item } from "./Cue.styled";
-import { convertTime } from "services/utils";
-import { CurrentTimeContext } from "context/current-time-context";
+import { Item } from "@/components/Navigator/Cue.styled";
+import { convertTime } from "@/services/utils";
+import { CurrentTimeContext } from "@/context/current-time-context";
 
 interface Props {
   label: string;

--- a/src/components/Navigator/Menu.styled.tsx
+++ b/src/components/Navigator/Menu.styled.tsx
@@ -1,5 +1,5 @@
 import { styled } from "stitches";
-import { Item } from "components/Navigator/Cue.styled";
+import { Item } from "@/components/Navigator/Cue.styled";
 
 export const MenuStyled = styled("ul", {
   listStyle: "none",

--- a/src/components/Navigator/Menu.tsx
+++ b/src/components/Navigator/Menu.tsx
@@ -1,7 +1,7 @@
 import React from "react";
-import { NodeWebVttCueNested } from "hooks/use-webvtt";
-import Cue from "components/Navigator/Cue";
-import { MenuStyled } from "components/Navigator/Menu.styled";
+import { NodeWebVttCueNested } from "@/hooks/use-webvtt";
+import Cue from "@/components/Navigator/Cue";
+import { MenuStyled } from "@/components/Navigator/Menu.styled";
 
 interface MenuProps {
   items: Array<NodeWebVttCueNested>;

--- a/src/components/Navigator/Navigator.styled.tsx
+++ b/src/components/Navigator/Navigator.styled.tsx
@@ -1,5 +1,5 @@
 import * as Tabs from "@radix-ui/react-tabs";
-import { styled } from "stitches";
+import { styled } from "@/stitches";
 
 const Wrapper = styled(Tabs.Root, {
   display: "flex",

--- a/src/components/Navigator/Navigator.test.tsx
+++ b/src/components/Navigator/Navigator.test.tsx
@@ -1,4 +1,4 @@
-import Navigator from "./Navigator";
+import Navigator from "@/components/Navigator/Navigator";
 import React from "react";
 import { render, screen } from "@testing-library/react";
 

--- a/src/components/Navigator/Navigator.tsx
+++ b/src/components/Navigator/Navigator.tsx
@@ -1,9 +1,15 @@
 import React, { useEffect, useState } from "react";
 import { InternationalString } from "@iiif/presentation-3";
-import { Content, List, Scroll, Trigger, Wrapper } from "./Navigator.styled";
-import { LabeledResource } from "hooks/use-iiif/getSupplementingResources";
-import { getLabel } from "hooks/use-iiif";
-import Resource from "./Resource";
+import {
+  Content,
+  List,
+  Scroll,
+  Trigger,
+  Wrapper,
+} from "@/components/Navigator/Navigator.styled";
+import { LabeledResource } from "@/hooks/use-iiif/getSupplementingResources";
+import { getLabel } from "@/hooks/use-iiif";
+import Resource from "@/components/Navigator/Resource";
 
 interface NavigatorProps {
   activeCanvas: string;

--- a/src/components/Navigator/Resource.tsx
+++ b/src/components/Navigator/Resource.tsx
@@ -1,12 +1,12 @@
 import React, { useEffect } from "react";
-import { getLabel } from "hooks/use-iiif";
+import { getLabel } from "@/hooks/use-iiif";
 import { InternationalString } from "@iiif/presentation-3";
-import { Group } from "./Cue.styled";
+import { Group } from "@/components/Navigator/Cue.styled";
 import useWebVtt, {
   NodeWebVttCue,
   NodeWebVttCueNested,
-} from "hooks/use-webvtt";
-import Menu from "components/Navigator/Menu";
+} from "@/hooks/use-webvtt";
+import Menu from "@/components/Navigator/Menu";
 
 // @ts-ignore
 import { parse } from "node-webvtt";

--- a/src/components/Player/AudioVisualizer.styled.tsx
+++ b/src/components/Player/AudioVisualizer.styled.tsx
@@ -1,4 +1,4 @@
-import { styled } from "stitches";
+import { styled } from "@/stitches";
 
 export const AudioVisualizerWrapper = styled("canvas", {
   position: "absolute",

--- a/src/components/Player/AudioVisualizer.tsx
+++ b/src/components/Player/AudioVisualizer.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { AudioVisualizerWrapper } from "./AudioVisualizer.styled";
+import { AudioVisualizerWrapper } from "@/components/Player/AudioVisualizer.styled";
 
 const AudioVisualizer = React.forwardRef((_props, ref: any) => {
   const canvasRef = React.useRef<HTMLCanvasElement>(null);

--- a/src/components/Player/Player.styled.tsx
+++ b/src/components/Player/Player.styled.tsx
@@ -1,4 +1,4 @@
-import { styled } from "stitches";
+import { styled } from "@/stitches";
 
 export const PlayerWrapper = styled("div", {
   position: "relative",

--- a/src/components/Player/Player.test.tsx
+++ b/src/components/Player/Player.test.tsx
@@ -1,8 +1,8 @@
 import React from "react";
 import { render } from "@testing-library/react";
-import Player from "./Player";
+import Player from "@/components/Player/Player";
 import { IIIFExternalWebResource } from "@iiif/presentation-3";
-import { LabeledResource } from "../../hooks/use-iiif/getSupplementingResources";
+import { LabeledResource } from "@/hooks/use-iiif/getSupplementingResources";
 
 const mockPainting: IIIFExternalWebResource = {
   id: "https://bitdash-a.akamaihd.net/content/MI201109210084_1/m3u8s/f08e80da-bf1d-4e3d-8899-f0f6155f6efa.m3u8",

--- a/src/components/Player/Player.tsx
+++ b/src/components/Player/Player.tsx
@@ -1,16 +1,16 @@
 import React from "react";
 import Hls from "hls.js";
-import { PlayerWrapper } from "./Player.styled";
+import { PlayerWrapper } from "@/components/Player/Player.styled";
 import { IIIFExternalWebResource } from "@iiif/presentation-3";
-import { LabeledResource } from "hooks/use-iiif/getSupplementingResources";
-import AudioVisualizer from "./AudioVisualizer";
-import { CurrentTimeContext } from "context/current-time-context";
-import { useViewerState } from "context/viewer-context";
-import Track from "./Track";
+import { LabeledResource } from "@/hooks/use-iiif/getSupplementingResources";
+import AudioVisualizer from "@/components/Player/AudioVisualizer";
+import { CurrentTimeContext } from "@/context/current-time-context";
+import { useViewerState } from "@/context/viewer-context";
+import Track from "@/components/Player/Track";
 import {
   getAccompanyingCanvasImage,
   getCanvasByCriteria,
-} from "hooks/use-iiif";
+} from "@/hooks/use-iiif";
 
 // Set referrer header as a NU domain: ie. meadow.rdc-staging.library.northwestern.edu
 

--- a/src/components/Player/Track.test.tsx
+++ b/src/components/Player/Track.test.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { render, screen } from "@testing-library/react";
-import { LabeledResource } from "../../hooks/use-iiif/getSupplementingResources";
-import Track from "./Track";
+import { LabeledResource } from "@/hooks/use-iiif/getSupplementingResources";
+import Track from "@/components/Player/Track";
 
 const mockResourceCaptions: LabeledResource = {
   id: "https://raw.githubusercontent.com/mathewjordan/mirador-playground/main/assets/iiif/supplementing/new_airliner_en.vtt",

--- a/src/components/Player/Track.tsx
+++ b/src/components/Player/Track.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { InternationalString } from "@iiif/presentation-3";
-import { LabeledResource } from "hooks/use-iiif/getSupplementingResources";
-import { getLabel } from "hooks/use-iiif";
+import { LabeledResource } from "@/hooks/use-iiif/getSupplementingResources";
+import { getLabel } from "@/hooks/use-iiif";
 
 export interface TrackProps {
   resource: LabeledResource;

--- a/src/components/Viewer/Content.tsx
+++ b/src/components/Viewer/Content.tsx
@@ -1,10 +1,10 @@
 import React from "react";
-import Media from "components/Media/Media";
-import Navigator from "components/Navigator/Navigator";
-import Player from "components/Player/Player";
-import ImageViewer from "components/ImageViewer/ImageViewer";
+import Media from "@/components/Media/Media";
+import Navigator from "@/components/Navigator/Navigator";
+import Player from "@/components/Player/Player";
+import ImageViewer from "@/components/ImageViewer/ImageViewer";
 import { Button } from "@nulib/design-system";
-import { Canvas, IIIFExternalWebResource, Service } from "@iiif/presentation-3";
+import { Canvas, IIIFExternalWebResource } from "@iiif/presentation-3";
 import {
   Content,
   Main,
@@ -12,9 +12,9 @@ import {
   CollapsibleContent,
   MediaWrapper,
   Aside,
-} from "./Viewer.styled";
-import { LabeledResource } from "hooks/use-iiif/getSupplementingResources";
-import { CurrentTimeProvider } from "context/current-time-context";
+} from "@/components/Viewer/Viewer.styled";
+import { LabeledResource } from "@/hooks/use-iiif/getSupplementingResources";
+import { CurrentTimeProvider } from "@/context/current-time-context";
 
 interface Props {
   activeCanvas: string;

--- a/src/components/Viewer/ErrorFallback.styled.tsx
+++ b/src/components/Viewer/ErrorFallback.styled.tsx
@@ -1,4 +1,4 @@
-import { styled } from "stitches";
+import { styled } from "@/stitches";
 
 const ErrorFallbackStyled = styled("div", {
   display: "flex",

--- a/src/components/Viewer/ErrorFallback.test.tsx
+++ b/src/components/Viewer/ErrorFallback.test.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import ErrorFallback from "./ErrorFallback";
+import ErrorFallback from "@/components/Viewer/ErrorFallback";
 import { render, screen } from "@testing-library/react";
 
 describe("ErrorFallback component", () => {

--- a/src/components/Viewer/ErrorFallback.tsx
+++ b/src/components/Viewer/ErrorFallback.tsx
@@ -3,7 +3,7 @@ import {
   ErrorFallbackStyled,
   ErrorBody,
   Headline,
-} from "components/Viewer/ErrorFallback.styled";
+} from "@/components/Viewer/ErrorFallback.styled";
 
 interface ErrorFallbackProps {
   error: Error;

--- a/src/components/Viewer/Header.styled.tsx
+++ b/src/components/Viewer/Header.styled.tsx
@@ -1,4 +1,4 @@
-import { styled } from "stitches";
+import { styled } from "@/stitches";
 import { Popover } from "@nulib/design-system";
 
 const IIIFBadgeButton = styled(Popover.Trigger, {

--- a/src/components/Viewer/Header.tsx
+++ b/src/components/Viewer/Header.tsx
@@ -3,9 +3,9 @@ import { Header, IIIFBadgeButton, IIIFBadgeContent } from "./Header.styled";
 import { InternationalString } from "@iiif/presentation-3";
 import { getLabel } from "hooks/use-iiif";
 import { Popover } from "@nulib/design-system";
-import IIIFBadge from "./IIIFBadge";
-import CopyText from "components/CopyText";
-import { useViewerState } from "context/viewer-context";
+import IIIFBadge from "@/components/Viewer/IIIFBadge";
+import CopyText from "@/components/CopyText";
+import { useViewerState } from "@/context/viewer-context";
 
 interface Props {
   manifestId: string;

--- a/src/components/Viewer/Viewer.styled.tsx
+++ b/src/components/Viewer/Viewer.styled.tsx
@@ -1,4 +1,4 @@
-import { styled } from "stitches";
+import { styled } from "@/stitches";
 import * as Collapsible from "@radix-ui/react-collapsible";
 
 const MediaWrapper = styled("div", {

--- a/src/components/Viewer/Viewer.tsx
+++ b/src/components/Viewer/Viewer.tsx
@@ -4,18 +4,21 @@ import {
   InternationalString,
   ManifestNormalized,
 } from "@iiif/presentation-3";
-import { getPaintingResource, getSupplementingResources } from "hooks/use-iiif";
-import { useViewerState } from "context/viewer-context";
-import { Wrapper } from "./Viewer.styled";
-import { useMediaQuery } from "hooks/useMediaQuery";
-import { useBodyLocked } from "hooks/useBodyLocked";
-import { media } from "stitches";
+import {
+  getPaintingResource,
+  getSupplementingResources,
+} from "@/hooks/use-iiif";
+import { useViewerState } from "@/context/viewer-context";
+import { Wrapper } from "@/components/Viewer/Viewer.styled";
+import { useMediaQuery } from "@/hooks/useMediaQuery";
+import { useBodyLocked } from "@/hooks/useBodyLocked";
+import { media } from "@/stitches";
 import * as Collapsible from "@radix-ui/react-collapsible";
-import ViewerHeader from "./Header";
-import ViewerContent from "./Content";
-import { LabeledResource } from "hooks/use-iiif/getSupplementingResources";
+import ViewerHeader from "@/components/Viewer/Header";
+import ViewerContent from "@/components/Viewer/Content";
+import { LabeledResource } from "@/hooks/use-iiif/getSupplementingResources";
 import { IIIFExternalWebResource } from "@iiif/presentation-3";
-import ErrorFallback from "components/Viewer/ErrorFallback";
+import ErrorFallback from "@/components/Viewer/ErrorFallback";
 import { ErrorBoundary } from "react-error-boundary";
 
 interface ViewerProps {

--- a/src/context/viewer-context.tsx
+++ b/src/context/viewer-context.tsx
@@ -2,11 +2,11 @@ import React from "react";
 import { Vault } from "@iiif/vault";
 
 export type ConfigOptions = {
-  showTitle: boolean;
-  showIIIFBadge: boolean;
-  ignoreCaptionLabels: string[];
-  canvasBackgroundColor: string;
-  canvasHeight: string;
+  showTitle?: boolean;
+  showIIIFBadge?: boolean;
+  ignoreCaptionLabels?: string[];
+  canvasBackgroundColor?: string;
+  canvasHeight?: string;
 };
 
 const defaultConfigOptions = {

--- a/src/dev.tsx
+++ b/src/dev.tsx
@@ -1,8 +1,8 @@
 import React, { StrictMode } from "react";
-import App from "./index";
-import DynamicUrl from "./dev/DynamicUrl";
+import App from "@/index";
+import DynamicUrl from "@/dev/DynamicUrl";
 import { createRoot } from "react-dom/client";
-import { manifests } from "./dev/manifests";
+import { manifests } from "@/dev/manifests";
 
 const Wrapper = () => {
   const defaultUrl: string = manifests[0].url;

--- a/src/dev/DynamicUrl.styled.tsx
+++ b/src/dev/DynamicUrl.styled.tsx
@@ -1,4 +1,4 @@
-import { styled } from "@stitches/react";
+import { styled } from "@/stitches";
 
 const DynamicUrlStyled = styled("section", {
   display: "flex",

--- a/src/dev/DynamicUrl.tsx
+++ b/src/dev/DynamicUrl.tsx
@@ -10,8 +10,8 @@ import {
   Curated,
   DynamicUrlStyled,
   ManualForm,
-} from "./DynamicUrl.styled";
-import { manifests } from "./manifests";
+} from "@/dev/DynamicUrl.styled";
+import { manifests } from "@/dev/manifests";
 
 interface DynamicUrlProps {
   url: string;

--- a/src/hooks/use-iiif/getAccompanyingCanvasImage.test.ts
+++ b/src/hooks/use-iiif/getAccompanyingCanvasImage.test.ts
@@ -1,5 +1,5 @@
-import { getAccompanyingCanvasImage } from "./getAccompanyingCanvasImage";
-import manifest from "../../../public/fixtures/iiif/manifests/audio-accompanying-canvas.json";
+import { getAccompanyingCanvasImage } from "@/hooks/use-iiif";
+import { manifest } from "@/mocks/iiif/audio-accompanying-canvas";
 
 describe("getAccompanyingCanvasImage hook", () => {
   it("returns a url string if passed valid items", () => {
@@ -10,7 +10,9 @@ describe("getAccompanyingCanvasImage hook", () => {
   });
 
   it("returns undefined if there are any errors", () => {
+    console.error = jest.fn();
     const result = getAccompanyingCanvasImage({ foo: "bar" });
+    expect(console.error).toHaveBeenCalled();
     expect(result).toBeUndefined();
   });
 });

--- a/src/hooks/use-iiif/getAccompanyingCanvasImage.ts
+++ b/src/hooks/use-iiif/getAccompanyingCanvasImage.ts
@@ -28,6 +28,7 @@ export const getAccompanyingCanvasImage = (
     /**
      * Step 2: Dig into the Annotation Page > Body
      */
+
     return getUrl(accompanyingCanvas.items[0].items[0].body);
   } catch (e) {
     console.error("Error retrieving accompanying canvas image", e);

--- a/src/hooks/use-iiif/getCanvasByCriteria.ts
+++ b/src/hooks/use-iiif/getCanvasByCriteria.ts
@@ -1,6 +1,5 @@
 import {
   Annotation,
-  AnnotationBody,
   AnnotationPageNormalized,
   Canvas,
   CanvasNormalized,

--- a/src/hooks/use-iiif/getLabel.test.ts
+++ b/src/hooks/use-iiif/getLabel.test.ts
@@ -1,4 +1,4 @@
-import { getLabel } from "./getLabel";
+import { getLabel } from "@/hooks/use-iiif";
 
 test("Test output of IIIF presentation label by internationalized language code.", () => {
   const englishLabel = getLabel({ en: ["Sample label"] }, "en");

--- a/src/hooks/use-iiif/getPaintingResource.ts
+++ b/src/hooks/use-iiif/getPaintingResource.ts
@@ -1,5 +1,5 @@
 import { IIIFExternalWebResource } from "@iiif/presentation-3";
-import { getCanvasByCriteria } from "./index";
+import { getCanvasByCriteria } from "@/hooks/use-iiif";
 
 export const getPaintingResource = (
   vault: any,

--- a/src/hooks/use-iiif/getThumbnail.test.ts
+++ b/src/hooks/use-iiif/getThumbnail.test.ts
@@ -1,5 +1,4 @@
-import { getThumbnail } from "./getThumbnail";
-import { CanvasEntity } from "./getCanvasByCriteria";
+import { CanvasEntity } from "@/hooks/use-iiif/getCanvasByCriteria";
 
 //TODO: Figure out how to mock Vault()
 // const vault = new Vault();
@@ -37,7 +36,7 @@ const sampleCanvasEntity: CanvasEntity = {
     ],
     annotations: [],
     seeAlso: [],
-    homepage: null,
+    homepage: [],
     logo: [],
     partOf: [],
     rendering: [],
@@ -65,7 +64,7 @@ const sampleCanvasEntity: CanvasEntity = {
       },
     ],
     seeAlso: [],
-    homepage: null,
+    homepage: [],
     logo: [],
     rendering: [],
     service: [],

--- a/src/hooks/use-iiif/getThumbnail.ts
+++ b/src/hooks/use-iiif/getThumbnail.ts
@@ -1,9 +1,5 @@
-import {
-  AnnotationBody,
-  ContentResource,
-  IIIFExternalWebResource,
-} from "@iiif/presentation-3";
-import { CanvasEntity } from "./getCanvasByCriteria";
+import { IIIFExternalWebResource } from "@iiif/presentation-3";
+import { CanvasEntity } from "@/hooks/use-iiif/getCanvasByCriteria";
 
 export const getThumbnail = (
   vault: any,

--- a/src/hooks/use-iiif/index.ts
+++ b/src/hooks/use-iiif/index.ts
@@ -1,15 +1,15 @@
-import { getAccompanyingCanvasImage } from "./getAccompanyingCanvasImage";
-import { getCanvasByCriteria } from "./getCanvasByCriteria";
-import { getPaintingResource } from "./getPaintingResource";
-import { getSupplementingResources } from "./getSupplementingResources";
-import { getLabel } from "./getLabel";
-import { getThumbnail } from "./getThumbnail";
+import { getAccompanyingCanvasImage } from "@/hooks/use-iiif/getAccompanyingCanvasImage";
+import { getCanvasByCriteria } from "@/hooks/use-iiif/getCanvasByCriteria";
+import { getLabel } from "@/hooks/use-iiif/getLabel";
+import { getPaintingResource } from "@/hooks/use-iiif/getPaintingResource";
+import { getSupplementingResources } from "@/hooks/use-iiif/getSupplementingResources";
+import { getThumbnail } from "@/hooks/use-iiif/getThumbnail";
 
 export {
   getAccompanyingCanvasImage,
   getCanvasByCriteria,
+  getLabel,
   getPaintingResource,
   getSupplementingResources,
-  getLabel,
   getThumbnail,
 };

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -5,8 +5,8 @@ import {
   ViewerProvider,
   useViewerState,
   useViewerDispatch,
-} from "context/viewer-context";
-import Viewer from "components/Viewer/Viewer";
+} from "@/context/viewer-context";
+import Viewer from "@/components/Viewer/Viewer";
 import { createTheme } from "@stitches/react";
 
 interface Props {

--- a/src/mocks/iiif/audio-accompanying-canvas.ts
+++ b/src/mocks/iiif/audio-accompanying-canvas.ts
@@ -1,0 +1,77 @@
+export const manifest = {
+  "@context": "http://iiif.io/api/presentation/3/context.json",
+  id: "https://iiif.io/api/cookbook/recipe/0014-accompanyingcanvas/manifest.json",
+  type: "Manifest",
+  label: {
+    en: ["Partial audio recording of Gustav Mahler's _Symphony No. 3_"],
+  },
+  items: [
+    {
+      id: "https://iiif.io/api/cookbook/recipe/0014-accompanyingcanvas/canvas/p1",
+      type: "Canvas",
+      label: {
+        en: ["Gustav Mahler, Symphony No. 3, CD 1"],
+      },
+      duration: 1985.024,
+      accompanyingCanvas: {
+        id: "https://iiif.io/api/cookbook/recipe/0014-accompanyingcanvas/canvas/accompanying",
+        type: "Canvas",
+        label: {
+          en: ["First page of score for Gustav Mahler, Symphony No. 3"],
+        },
+        height: 998,
+        width: 772,
+        items: [
+          {
+            id: "https://iiif.io/api/cookbook/recipe/0014-accompanyingcanvas/canvas/accompanying/annotation/page",
+            type: "AnnotationPage",
+            items: [
+              {
+                id: "https://iiif.io/api/cookbook/recipe/0014-accompanyingcanvas/canvas/accompanying/annotation/image",
+                type: "Annotation",
+                motivation: "painting",
+                body: {
+                  id: "https://iiif.io/api/image/3.0/example/reference/4b45bba3ea612ee46f5371ce84dbcd89-mahler-0/full/,998/0/default.jpg",
+                  type: "Image",
+                  format: "image/jpeg",
+                  height: 998,
+                  width: 772,
+                  service: [
+                    {
+                      id: "https://iiif.io/api/image/3.0/example/reference/4b45bba3ea612ee46f5371ce84dbcd89-mahler-0",
+                      type: "ImageService3",
+                      profile: "level1",
+                    },
+                  ],
+                },
+                target:
+                  "https://iiif.io/api/cookbook/recipe/0014-accompanyingcanvas/canvas/accompanying",
+              },
+            ],
+          },
+        ],
+      },
+      items: [
+        {
+          id: "https://iiif.io/api/cookbook/recipe/0014-accompanyingcanvas/canvas/page/p1",
+          type: "AnnotationPage",
+          items: [
+            {
+              id: "https://iiif.io/api/cookbook/recipe/0014-accompanyingcanvas/canvas/page/annotation/segment1-audio",
+              type: "Annotation",
+              motivation: "painting",
+              body: {
+                id: "https://fixtures.iiif.io/audio/indiana/mahler-symphony-3/CD1/medium/128Kbps.mp4",
+                type: "Sound",
+                duration: 1985.024,
+                format: "video/mp4",
+              },
+              target:
+                "https://iiif.io/api/cookbook/recipe/0014-accompanyingcanvas/canvas/page/p1",
+            },
+          ],
+        },
+      ],
+    },
+  ],
+};

--- a/src/services/utils.test.ts
+++ b/src/services/utils.test.ts
@@ -1,4 +1,4 @@
-import { cleanTime, convertTime } from "./utils";
+import { cleanTime, convertTime } from "@/services/utils";
 
 test("Test output a 'cleaned time' when given international standard time notation.", () => {
   const hours1 = cleanTime("11:15:55.784");

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,12 +17,21 @@
     "noUnusedLocals": false, // Report errors on unused locals
     "noUnusedParameters": true, // Report errors on unused parameters
     "resolveJsonModule": true, // Include modules imported with .json extension
+    "paths": {
+      "@/*": ["*"],
+      "@/components/*": ["components/*"],
+      "@/context/*": ["context/*"],
+      "@/dev/*": ["dev/*"],
+      "@/hooks/*": ["hooks/*"],
+      "@/mocks/*": ["mocks/*"],
+      "@/services/*": ["services/*"]
+    },
     "outDir": "./dist",
     "skipLibCheck": true, // Skip type checking of all declaration files
     "sourceMap": true, // Generate corrresponding .map file
     "strict": true, // Enable all strict type checking options
     "target": "es6" // Specify ECMAScript target version
   },
-  "include": ["src/**/*.ts", "src/**/*.tsx"],
-  "exclude": ["node_modules", "**/*.test.ts", "**/*.test.tsx", "src/dev.tsx"]
+  "include": ["**/*.ts", "**/*.tsx", "types.d.ts"],
+  "exclude": ["node_modules"]
 }


### PR DESCRIPTION
## What does this do?

This cleans up all of our pathing on imports across the codebase. Low hanging fruit but I was looking to do a little cleanup on Clover and this had been bothering me a bit. This doesn't add any linting and sorting of imports, but maybe that's the next step?