### PR TITLE
Allow setting of OpenSeadragon Options, default scrollToZoom as false.

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 **A minimal IIIF viewer for Image, Audio, and Video canvases built with React.js**
 
-[**Demo**](https://samvera-labs.github.io/clover-iiif/)  |  [**Code**](https://github.com/samvera-labs/clover-iiif)
+[**Demo**](https://samvera-labs.github.io/clover-iiif/) | [**Code**](https://github.com/samvera-labs/clover-iiif)
 
 Clover IIIF is a UI component that renders a multicanvas IIIF item viewer for `Video` and `Sound` content resources with pan-zoom support for `Image` via OpenSeadragon. Provide a [IIIF Presentation](https://iiif.io/api/presentation/3.0/) manifest and the component:
 
@@ -195,8 +195,11 @@ return <CloverIIIF manifestId={manifestId} customTheme={customTheme} />;
 | `options.ignoreCaptionLabels`   | `string[]` | No       | []        |
 | `options.canvasBackgroundColor` | `string`   | No       | `#1a1d1e` |
 | `options.canvasHeight`          | `string`   | No       | `500px`   |
+| `options.openSeadragon`         | `Options`  | No       |           |
 
 Clover IIIF version 1.4.0, introduces an `options` prop, which will serve as a configuration object for common configuration options. Options `canvasBackgroundColor` and `canvasHeight` will apply to both `<video>` elements and the OpenseaDragon canvas.
+
+You can override the [OpenSeadragon default options](https://openseadragon.github.io/docs/OpenSeadragon.html#.Options) set within Clover to adjust touch and mouse gesture settings and various other configurations.
 
 ```jsx
 import CloverIIIF from "@samvera/clover-iiif";
@@ -212,7 +215,17 @@ const options = {
   showIIIFBadge: false,
 
   // Ignore supplementing canvases by label value that are not for captioning
-  ignoreCaptionLabels: ['Chapters']
+  ignoreCaptionLabels: ['Chapters'],
+
+  // Override canvas background color, defaults to #1a1d1e
+  canvasBackgroundColor: "#000",
+
+  // Set canvas zooming onScoll (this defaults to false)
+  openSeadragon: {
+    gestureSettingsMouse: {
+      scrollToZoom: true;
+    }
+  }
 }
 ...
 

--- a/src/components/ImageViewer/OSD.tsx
+++ b/src/components/ImageViewer/OSD.tsx
@@ -34,6 +34,12 @@ const OSD: React.FC<OSDProps> = ({ uri, imageType }) => {
     showNavigator: true,
     navigatorBorderColor: "transparent",
     navigatorId: `openseadragon-navigator-${instance}`,
+    gestureSettingsMouse: {
+      clickToZoom: true,
+      dblClickToZoom: true,
+      pinchToZoom: true,
+      scrollToZoom: false,
+    },
   };
 
   useEffect(() => {

--- a/src/context/viewer-context.tsx
+++ b/src/context/viewer-context.tsx
@@ -1,3 +1,4 @@
+import { Options } from "openseadragon";
 import React from "react";
 import { Vault } from "@iiif/vault";
 
@@ -7,6 +8,7 @@ export type ConfigOptions = {
   ignoreCaptionLabels?: string[];
   canvasBackgroundColor?: string;
   canvasHeight?: string;
+  openSeadragon?: Options;
 };
 
 const defaultConfigOptions = {

--- a/src/dev.tsx
+++ b/src/dev.tsx
@@ -16,11 +16,6 @@ const Wrapper = () => {
         options={{
           canvasBackgroundColor: "#e6e8eb",
           canvasHeight: "61.8vh",
-          openSeadragon: {
-            gestureSettingsMouse: {
-              scrollToZoom: true,
-            },
-          },
         }}
       />
       <DynamicUrl url={url} setUrl={setUrl} />

--- a/src/dev.tsx
+++ b/src/dev.tsx
@@ -16,6 +16,11 @@ const Wrapper = () => {
         options={{
           canvasBackgroundColor: "#e6e8eb",
           canvasHeight: "61.8vh",
+          openSeadragon: {
+            gestureSettingsMouse: {
+              scrollToZoom: true,
+            },
+          },
         }}
       />
       <DynamicUrl url={url} setUrl={setUrl} />


### PR DESCRIPTION
## What does this do?

This sets the default **scrollToZoom** functionality as `false` for the OpenSeadragon options. Along with this, I have included the ability for a Clover implementer to modify (with some possibility for danger) the OpenSeadragon options through the **configOptions.openSeadragon** prop.

**What doesn't this do?**
Well, the cursor can still be _captured_ currently by OpenSeadragon canvas. I believe we might need to dig into that in a separate issue as it is somewhat annoying if you're trying to scroll past the canvas and are not aware that your cursor should be outside of the bound of it to affect the body scroll.