### PR TITLE
Add iiif-content param capability to demo page.

### DIFF
--- a/src/dev.tsx
+++ b/src/dev.tsx
@@ -1,4 +1,4 @@
-import React, { StrictMode } from "react";
+import React, { StrictMode, useEffect, useState } from "react";
 import App from "@/index";
 import DynamicUrl from "@/dev/DynamicUrl";
 import { createRoot } from "react-dom/client";
@@ -7,7 +7,14 @@ import { manifests } from "@/dev/manifests";
 const Wrapper = () => {
   const defaultUrl: string = manifests[0].url;
 
-  const [url, setUrl] = React.useState(defaultUrl);
+  const [url, setUrl] = useState(defaultUrl);
+
+  useEffect(() => {
+    const params = new URLSearchParams(window.location.search);
+    const id = params.get("iiif-content");
+    if (id) setUrl(id);
+  }, []);
+
   return (
     <>
       <App
@@ -24,7 +31,8 @@ const Wrapper = () => {
 };
 
 const container = document.getElementById("root");
-const root = createRoot(container!); // createRoot(container!) if you use TypeScript
+const root = createRoot(container!);
+
 root.render(
   <StrictMode>
     <Wrapper />


### PR DESCRIPTION
## What does this do?

This adds functionality to read a `iiif-content` URL parameter and set it as the `manifestId` prop for Clover on the demo/development view. Doing this should bring us a step closer to Clover being included in the **iiif.io**[ viewer matrix](https://iiif.io/api/cookbook/recipe/matrix/).

**Note** -- This does not yet accommodate Clover for [Content State Encoding](https://iiif.io/api/content-state/0.9/#6-content-state-encoding).

![image](https://user-images.githubusercontent.com/7376450/188936361-5dc5a76a-f9b3-42dc-90f1-7fbdce2f05aa.png)
