### PR TITLE
Use Nectar Label component where possible.

### DIFF
--- a/src/components/Media/Thumbnail.tsx
+++ b/src/components/Media/Thumbnail.tsx
@@ -1,10 +1,8 @@
 import React from "react";
-import { getLabel } from "@/hooks/use-iiif";
 import { convertTime } from "@/services/utils";
 import {
   CanvasNormalized,
   IIIFExternalWebResource,
-  InternationalString,
 } from "@iiif/presentation-3";
 import { Icon, Tag } from "@nulib/design-system";
 import {
@@ -13,6 +11,8 @@ import {
   Spacer,
   Type,
 } from "@/components/Media/Thumbnail.styled";
+import { Label } from "@samvera/nectar-iiif";
+import { getLabel } from "@/hooks/use-iiif";
 
 /**
  * Determine appropriate icon by resource type
@@ -54,8 +54,6 @@ const Thumbnail: React.FC<ThumbnailProps> = ({
   type,
   handleChange,
 }) => {
-  const label = getLabel(canvas.label as InternationalString, "en") as string;
-
   return (
     <Item
       aria-checked={isActive}
@@ -66,7 +64,12 @@ const Thumbnail: React.FC<ThumbnailProps> = ({
     >
       <figure>
         <div>
-          {thumbnail?.id && <img src={thumbnail.id} alt={label} />}
+          {thumbnail?.id && (
+            <img
+              src={thumbnail.id}
+              alt={canvas?.label ? (getLabel(canvas.label) as string) : ""}
+            />
+          )}
 
           <Type>
             <Tag isIcon data-testid="thumbnail-tag">
@@ -80,7 +83,11 @@ const Thumbnail: React.FC<ThumbnailProps> = ({
             </Tag>
           </Type>
         </div>
-        <figcaption data-testid="fig-caption">{label}</figcaption>
+        {canvas?.label && (
+          <figcaption data-testid="fig-caption">
+            <Label label={canvas.label} />
+          </figcaption>
+        )}
       </figure>
     </Item>
   );

--- a/src/components/Navigator/Navigator.tsx
+++ b/src/components/Navigator/Navigator.tsx
@@ -8,8 +8,8 @@ import {
   Wrapper,
 } from "@/components/Navigator/Navigator.styled";
 import { LabeledResource } from "@/hooks/use-iiif/getSupplementingResources";
-import { getLabel } from "@/hooks/use-iiif";
 import Resource from "@/components/Navigator/Resource";
+import { Label } from "@samvera/nectar-iiif";
 
 interface NavigatorProps {
   activeCanvas: string;
@@ -45,7 +45,7 @@ export const Navigator: React.FC<NavigatorProps> = ({
       <List aria-label="select chapter" data-testid="navigator-list">
         {resources.map(({ id, label }) => (
           <Trigger key={id} value={id as string}>
-            {getLabel(label as InternationalString, "en")}
+            <Label label={label} />
           </Trigger>
         ))}
       </List>

--- a/src/components/Viewer/Header.tsx
+++ b/src/components/Viewer/Header.tsx
@@ -6,12 +6,12 @@ import {
   ManifestLabel,
 } from "./Header.styled";
 import { InternationalString } from "@iiif/presentation-3";
-import { getLabel } from "hooks/use-iiif";
 import { Popover } from "@nulib/design-system";
 import IIIFBadge from "@/components/Viewer/IIIFBadge";
 import CopyText from "@/components/CopyText";
 import { useViewerState } from "@/context/viewer-context";
 import Collection from "@/components/Collection/Collection";
+import { Label } from "@samvera/nectar-iiif";
 
 interface Props {
   manifestId: string;
@@ -32,7 +32,7 @@ const ViewerHeader: React.FC<Props> = ({ manifestId, manifestLabel }) => {
         <Collection />
       ) : (
         <ManifestLabel>
-          {getLabel(manifestLabel as InternationalString, "en")}
+          <Label label={manifestLabel} />
         </ManifestLabel>
       )}
       {showIIIFBadge && (


### PR DESCRIPTION
This is just a quick PR to make a minor update to Clover, using Nectar `<Label>` wherever a IIIF [label](https://iiif.io/api/presentation/3.0/#label) is rendered.

- Update manifest label.
- Replace rendered labels with Nectar component.
- Use getLabel on alt.
