### PR TITLE
Address seeAlso label rendering issue.

### DIFF
--- a/src/components/Navigator/About.tsx
+++ b/src/components/Navigator/About.tsx
@@ -28,12 +28,16 @@ const About: React.FC<Props> = () => {
   const [thumbnail, setThumbnail] = useState<IIIFExternalWebResource[] | []>(
     [],
   );
+  const [seeAlso, setSeeAlso] = useState<IIIFExternalWebResource[] | []>(
+    [],
+  );
 
   useEffect(() => {
     const data = vault.get(activeManifest);
     setManifest(data);
 
     if (data.thumbnail?.length > 0) setThumbnail(vault.get(data.thumbnail));
+    if (data.seeAlso?.length > 0) setSeeAlso(vault.get(data.seeAlso));
   }, [activeManifest, vault]);
 
   if (!manifest) return <></>;
@@ -95,7 +99,7 @@ const About: React.FC<Props> = () => {
           </>
         )}
 
-        {manifest.seeAlso?.length > 0 && (
+        {seeAlso?.length > 0 && (
           <>
             <label
               className="manifest-property-title"
@@ -105,7 +109,7 @@ const About: React.FC<Props> = () => {
             </label>
             <SeeAlso
               seeAlso={
-                manifest.seeAlso as unknown as NectarExternalWebResource[]
+                seeAlso as unknown as NectarExternalWebResource[]
               }
               id="iiif-manifest-see-also"
               as="ul"

--- a/src/components/Navigator/About.tsx
+++ b/src/components/Navigator/About.tsx
@@ -25,10 +25,9 @@ const About: React.FC<Props> = () => {
 
   const [manifest, setManifest] = useState<ManifestNormalized>();
 
+  const [homepage, setHomepage] = useState<IIIFExternalWebResource[] | []>([]);
+  const [seeAlso, setSeeAlso] = useState<IIIFExternalWebResource[] | []>([]);
   const [thumbnail, setThumbnail] = useState<IIIFExternalWebResource[] | []>(
-    [],
-  );
-  const [seeAlso, setSeeAlso] = useState<IIIFExternalWebResource[] | []>(
     [],
   );
 
@@ -36,8 +35,9 @@ const About: React.FC<Props> = () => {
     const data = vault.get(activeManifest);
     setManifest(data);
 
-    if (data.thumbnail?.length > 0) setThumbnail(vault.get(data.thumbnail));
+    if (data.homepage?.length > 0) setHomepage(vault.get(data.homepage));
     if (data.seeAlso?.length > 0) setSeeAlso(vault.get(data.seeAlso));
+    if (data.thumbnail?.length > 0) setThumbnail(vault.get(data.thumbnail));
   }, [activeManifest, vault]);
 
   if (!manifest) return <></>;
@@ -80,7 +80,7 @@ const About: React.FC<Props> = () => {
           </>
         )}
 
-        {manifest.homepage?.length > 0 && (
+        {homepage?.length > 0 && (
           <>
             <label
               className="manifest-property-title"
@@ -89,13 +89,9 @@ const About: React.FC<Props> = () => {
               Homepage
             </label>
             <Homepage
-              homepage={
-                manifest.homepage as unknown as NectarExternalWebResource[]
-              }
+              homepage={homepage as unknown as NectarExternalWebResource[]}
               id="iiif-manifest-homepage"
-            >
-              View <Label label={manifest.label as InternationalString} />
-            </Homepage>
+            />
           </>
         )}
 
@@ -108,16 +104,13 @@ const About: React.FC<Props> = () => {
               See Also
             </label>
             <SeeAlso
-              seeAlso={
-                seeAlso as unknown as NectarExternalWebResource[]
-              }
+              seeAlso={seeAlso as unknown as NectarExternalWebResource[]}
               id="iiif-manifest-see-also"
-              as="ul"
             />
           </>
         )}
 
-        {manifest.seeAlso?.length > 0 && (
+        {manifest.id && (
           <>
             <label
               className="manifest-property-title"


### PR DESCRIPTION
## What does this do?

This resolve an issue where the `id` as the innerHTML within the `<a>...</a>` for each `seeAlso` entry. The issue related to how `vault` stores resources locally by **id**, I am no making `vault.get()` request to the Redux store and grabbing the additional data for entries.

Clover uses Nectar for rendering a seeAlso, thus it will still fallback to rendering an `id` if the `label` does not exist.

I also made `homepage` render in similar way, and fixed a small typo related issue with `manifest.id` not rendering.