### PR TITLE
Spread out openSeadragon options on OpenSeadragon instances (allows for ajaxWithCredentials)

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,20 +200,21 @@ return <CloverIIIF id={id} customTheme={customTheme} />;
 
 <h2 id="reference">Reference</h2>
 
-| Prop                            | Type       | Required | Default   |
-| ------------------------------- | ---------- | -------- | --------- |
-| `id`                            | `string`   | Yes      |           |
-| `manifestId` _(deprecated)_     | `string`   | No       |           |
-| `canvasIdCallback`              | `function` | No       |           |
-| `customTheme`                   | `object`   | No       |           |
-| `options`                       | `object`   | No       |           |
-| `options.canvasBackgroundColor` | `string`   | No       | `#1a1d1e` |
-| `options.canvasHeight`          | `string`   | No       | `500px`   |
-| `options.ignoreCaptionLabels`   | `string[]` | No       | []        |
-| `options.renderAbout`           | `boolean`  | No       | true      |
-| `options.showIIIFBadge`         | `boolean`  | No       | true      |
-| `options.showInformationToggle` | `boolean`  | No       | true      |
-| `options.showTitle`             | `boolean`  | No       | true      |
+| Prop                            | Type                    | Required | Default   |
+| ------------------------------- | ----------------------- | -------- | --------- |
+| `id`                            | `string`                | Yes      |           |
+| `manifestId` _(deprecated)_     | `string`                | No       |           |
+| `canvasIdCallback`              | `function`              | No       |           |
+| `customTheme`                   | `object`                | No       |           |
+| `options`                       | `object`                | No       |           |
+| `options.canvasBackgroundColor` | `string`                | No       | `#1a1d1e` |
+| `options.canvasHeight`          | `string`                | No       | `500px`   |
+| `options.ignoreCaptionLabels`   | `string[]`              | No       | []        |
+| `options.openSeadragon`         | `OpenSeadragon.Options` | No       |           |
+| `options.renderAbout`           | `boolean`               | No       | true      |
+| `options.showIIIFBadge`         | `boolean`               | No       | true      |
+| `options.showInformationToggle` | `boolean`               | No       | true      |
+| `options.showTitle`             | `boolean`               | No       | true      |
 
 Clover can configured through an `options` prop, which will serve as a object for common options.
 

--- a/src/components/ImageViewer/OSD.tsx
+++ b/src/components/ImageViewer/OSD.tsx
@@ -40,6 +40,7 @@ const OSD: React.FC<OSDProps> = ({ uri, imageType }) => {
       pinchToZoom: true,
       scrollToZoom: false,
     },
+    ...configOptions.openSeadragon,
   };
 
   useEffect(() => {

--- a/src/context/viewer-context.tsx
+++ b/src/context/viewer-context.tsx
@@ -18,6 +18,7 @@ const defaultConfigOptions = {
   canvasBackgroundColor: "#e6e8eb",
   canvasHeight: "61.8vh",
   ignoreCaptionLabels: [],
+  openSeadragon: {},
   renderAbout: true,
   showIIIFBadge: true,
   showInformationToggle: true,


### PR DESCRIPTION
Spreads the already existing and seemingly unused `openSeadragon` property out after defaults. This will allow a user to customize their OpenSeadragon instance more fully using https://openseadragon.github.io/docs/OpenSeadragon.html#.Options.

`options.openSeadragon` now has a default of `{}` and is better documented.

Example usage:
```jsx
      <CloverIIIF
        id={url}
        options={{
          openSeadragon: {
            ajaxWithCredentials: true,
          },
        }}
      />
```

