### PR TITLE
Add custom fetcher and withCredentials.

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,11 +215,13 @@ return <CloverIIIF id={id} customTheme={customTheme} />;
 | `options.showIIIFBadge`         | `boolean`               | No       | true      |
 | `options.showInformationToggle` | `boolean`               | No       | true      |
 | `options.showTitle`             | `boolean`               | No       | true      |
+| `options.withCredentials`       | `boolean`               | No       | false     |
 
 Clover can configured through an `options` prop, which will serve as a object for common options.
 
 - Options `canvasBackgroundColor` and `canvasHeight` will apply to both `<video>` elements and the OpenseaDragon canvas.
 - Options `renderAbout` and `showInformationToggle` relate to rendering Manifest content in an `<aside>` and providing user ability to close that panel.
+- The Option `withCredentials` being set as `true` will inform IIIF resource requests to be made [using credentials](https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest/withCredentials) such as cookies, authorization headers or TLS client certificates.
 
 You can override the [OpenSeadragon default options](https://openseadragon.github.io/docs/OpenSeadragon.html#.Options) set within Clover to adjust touch and mouse gesture settings and various other configurations.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@samvera/clover-iiif",
-  "version": "1.12.5",
+  "version": "1.12.6-rc.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@samvera/clover-iiif",
-      "version": "1.12.5",
+      "version": "1.12.6-rc.0",
       "license": "MIT",
       "dependencies": {
         "@iiif/vault": "^0.9.19",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@samvera/clover-iiif",
-  "version": "1.12.5",
+  "version": "1.12.6-rc.0",
   "description": "Viewer for audio, video and image file types driven by a IIIF manifest",
   "main": "dist/index.cjs.js",
   "module": "dist/index.esm.js",

--- a/src/components/ImageViewer/OSD.tsx
+++ b/src/components/ImageViewer/OSD.tsx
@@ -41,6 +41,7 @@ const OSD: React.FC<OSDProps> = ({ uri, imageType }) => {
       scrollToZoom: false,
     },
     ...configOptions.openSeadragon,
+    ajaxWithCredentials: configOptions.withCredentials,
   };
 
   useEffect(() => {

--- a/src/context/viewer-context.tsx
+++ b/src/context/viewer-context.tsx
@@ -1,7 +1,7 @@
 import { Options } from "openseadragon";
 import React, { useReducer } from "react";
-import { Vault } from "@iiif/vault";
 import { CollectionNormalized } from "@iiif/presentation-3";
+import { Vault } from "@iiif/vault";
 
 export type ConfigOptions = {
   canvasBackgroundColor?: string;
@@ -12,6 +12,7 @@ export type ConfigOptions = {
   showIIIFBadge?: boolean;
   showInformationToggle?: boolean;
   showTitle?: boolean;
+  withCredentials?: boolean;
 };
 
 const defaultConfigOptions = {
@@ -23,6 +24,7 @@ const defaultConfigOptions = {
   showIIIFBadge: true,
   showInformationToggle: true,
   showTitle: true,
+  withCredentials: false,
 };
 
 interface ViewerContextStore {
@@ -43,9 +45,10 @@ interface ViewerAction {
   informationExpanded: boolean;
   isLoaded: boolean;
   manifestId: string;
+  vault: Vault;
 }
 
-const defaultState: ViewerContextStore = {
+export const defaultState: ViewerContextStore = {
   activeCanvas: "",
   activeManifest: "",
   collection: {},

--- a/src/dev.tsx
+++ b/src/dev.tsx
@@ -33,6 +33,7 @@ const Wrapper = () => {
           canvasHeight: "600px",
           renderAbout: true,
           showInformationToggle: true,
+          withCredentials: false,
         }}
       />
       <DynamicUrl url={url} setUrl={setUrl} />

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -5,9 +5,12 @@ import {
   ViewerProvider,
   useViewerState,
   useViewerDispatch,
+  defaultState,
 } from "@/context/viewer-context";
+import { Vault } from "@iiif/vault";
 import Viewer from "@/components/Viewer/Viewer";
 import { createTheme } from "@stitches/react";
+import { getRequest } from "@/services/xhr";
 
 interface Props {
   canvasIdCallback?: (arg0: string) => void;
@@ -25,7 +28,17 @@ const App: React.FC<Props> = ({
   options,
 }) => {
   return (
-    <ViewerProvider>
+    <ViewerProvider
+      initialState={{
+        ...defaultState,
+        vault: new Vault({
+          customFetcher: (url: string) =>
+            getRequest(url, {
+              withCredentials: options?.withCredentials as boolean,
+            }).then((response) => JSON.parse(response.data)),
+        }),
+      }}
+    >
       <RenderViewer
         id={id}
         manifestId={manifestId}

--- a/src/services/xhr.ts
+++ b/src/services/xhr.ts
@@ -1,0 +1,82 @@
+export interface RequestOptions {
+  ignoreCache?: boolean;
+  headers?: { [key: string]: string };
+  timeout?: number;
+  withCredentials: boolean;
+}
+
+export const DEFAULT_REQUEST_OPTIONS = {
+  ignoreCache: false,
+  headers: {
+    Accept: "application/json, text/javascript, text/plain",
+  },
+  timeout: 5000,
+  withCredentials: false,
+};
+
+export interface RequestResult {
+  ok: boolean;
+  status: number;
+  statusText: string;
+  data: string;
+  json: <T>() => T;
+  headers: string;
+}
+
+function parseXHRResult(xhr: XMLHttpRequest): RequestResult {
+  return {
+    ok: xhr.status >= 200 && xhr.status < 300,
+    status: xhr.status,
+    statusText: xhr.statusText,
+    headers: xhr.getAllResponseHeaders(),
+    data: xhr.responseText,
+    json: <T>() => JSON.parse(xhr.responseText) as T,
+  };
+}
+
+function errorResponse(
+  xhr: XMLHttpRequest,
+  message: string | null = null,
+): RequestResult {
+  return {
+    ok: false,
+    status: xhr.status,
+    statusText: xhr.statusText,
+    headers: xhr.getAllResponseHeaders(),
+    data: message || xhr.statusText,
+    json: <T>() => JSON.parse(message || xhr.statusText) as T,
+  };
+}
+
+export function getRequest(
+  url: string,
+  options: RequestOptions = DEFAULT_REQUEST_OPTIONS,
+) {
+  const headers = options.headers || DEFAULT_REQUEST_OPTIONS.headers;
+
+  return new Promise<RequestResult>((resolve, reject) => {
+    const xhr = new XMLHttpRequest();
+    xhr.open("get", url);
+    xhr.withCredentials = options.withCredentials;
+
+    if (headers) {
+      Object.keys(headers).forEach((key) =>
+        xhr.setRequestHeader(key, headers[key]),
+      );
+    }
+
+    xhr.onload = () => {
+      resolve(parseXHRResult(xhr));
+    };
+
+    xhr.onerror = () => {
+      resolve(errorResponse(xhr, "Failed to make request."));
+    };
+
+    xhr.ontimeout = () => {
+      resolve(errorResponse(xhr, "Request took longer than expected."));
+    };
+
+    xhr.send();
+  });
+}


### PR DESCRIPTION
This adds a custom fetcher to our Vault instances, and allows for the boolean option `withCredentials` to be distilled down to the `customFetcher` using axios.get().