### PR TITLE
Add rotate and full screen controls.

### DIFF
--- a/src/components/ImageViewer/Button.styled.tsx
+++ b/src/components/ImageViewer/Button.styled.tsx
@@ -33,10 +33,28 @@ const Item = styled("button", {
     backgroundColor: "$accent",
   },
 
-  "&#zoomReset": {
+  "&#rotateRight": {
     "&:hover, &:focus": {
       svg: {
         rotate: "45deg",
+      },
+    },
+  },
+
+  "&#rotateLeft": {
+    transform: "scaleX(-1)",
+
+    "&:hover, &:focus": {
+      svg: {
+        rotate: "45deg",
+      },
+    },
+  },
+
+  "&#reset": {
+    "&:hover, &:focus": {
+      svg: {
+        rotate: "-15deg",
       },
     },
   },

--- a/src/components/ImageViewer/Controls.styled.tsx
+++ b/src/components/ImageViewer/Controls.styled.tsx
@@ -5,6 +5,7 @@ const Wrapper = styled("div", {
   zIndex: "1",
   top: "1rem",
   right: "1rem",
+  display: "flex",
 });
 
 export { Wrapper };

--- a/src/components/ImageViewer/Controls.test.tsx
+++ b/src/components/ImageViewer/Controls.test.tsx
@@ -4,7 +4,7 @@ import Controls from "@/components/ImageViewer/Controls";
 
 describe("Controls component", () => {
   it("renders", () => {
-    render(<Controls />);
+    render(<Controls options={{}} />);
     const controls = screen.getByTestId("openseadragon-controls");
     expect(controls);
   });

--- a/src/components/ImageViewer/Controls.tsx
+++ b/src/components/ImageViewer/Controls.tsx
@@ -1,56 +1,97 @@
 import React from "react";
 import Button from "@/components/ImageViewer/Button";
+import { Options } from "openseadragon";
 import { Wrapper } from "@/components/ImageViewer/Controls.styled";
 
-const Controls: React.FC = () => {
-  const ZoomIn = () => {
-    return (
+const ZoomIn = () => {
+  return (
+    <path
+      strokeLinecap="round"
+      strokeMiterlimit="10"
+      strokeWidth="45"
+      d="M256 112v288M400 256H112"
+    />
+  );
+};
+
+const ZoomOut = () => {
+  return (
+    <path
+      strokeLinecap="round"
+      strokeMiterlimit="10"
+      strokeWidth="45"
+      d="M400 256H112"
+    />
+  );
+};
+
+const ZoomFullScreen = () => {
+  return (
+    <path
+      fill="none"
+      stroke="currentColor"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      strokeWidth="32"
+      d="M432 320v112H320M421.8 421.77L304 304M80 192V80h112M90.2 90.23L208 208M320 80h112v112M421.77 90.2L304 208M192 432H80V320M90.23 421.8L208 304"
+    />
+  );
+};
+
+const Reset = () => {
+  return (
+    <path d="M448 440a16 16 0 01-12.61-6.15c-22.86-29.27-44.07-51.86-73.32-67C335 352.88 301 345.59 256 344.23V424a16 16 0 01-27 11.57l-176-168a16 16 0 010-23.14l176-168A16 16 0 01256 88v80.36c74.14 3.41 129.38 30.91 164.35 81.87C449.32 292.44 464 350.9 464 424a16 16 0 01-16 16z" />
+  );
+};
+
+const Rotate = () => {
+  return (
+    <>
       <path
+        fill="none"
         strokeLinecap="round"
         strokeMiterlimit="10"
         strokeWidth="45"
-        d="M256 112v288M400 256H112"
+        d="M400 148l-21.12-24.57A191.43 191.43 0 00240 64C134 64 48 150 48 256s86 192 192 192a192.09 192.09 0 00181.07-128"
       />
-    );
-  };
+      <path d="M464 97.42V208a16 16 0 01-16 16H337.42c-14.26 0-21.4-17.23-11.32-27.31L436.69 86.1C446.77 76 464 83.16 464 97.42z" />
+    </>
+  );
+};
 
-  const ZoomOut = () => {
-    return (
-      <path
-        strokeLinecap="round"
-        strokeMiterlimit="10"
-        strokeWidth="45"
-        d="M400 256H112"
-      />
-    );
-  };
-
-  const ZoomReset = () => {
-    return (
-      <>
-        <path
-          fill="none"
-          strokeLinecap="round"
-          strokeMiterlimit="10"
-          strokeWidth="45"
-          d="M400 148l-21.12-24.57A191.43 191.43 0 00240 64C134 64 48 150 48 256s86 192 192 192a192.09 192.09 0 00181.07-128"
-        />
-        <path d="M464 97.42V208a16 16 0 01-16 16H337.42c-14.26 0-21.4-17.23-11.32-27.31L436.69 86.1C446.77 76 464 83.16 464 97.42z" />
-      </>
-    );
-  };
-
+const Controls = ({ options }: { options: Options }) => {
   return (
     <Wrapper data-testid="openseadragon-controls" id="openseadragon-controls">
-      <Button id="zoomIn" label="zoom in">
-        <ZoomIn />
-      </Button>
-      <Button id="zoomOut" label="zoom in">
-        <ZoomOut />
-      </Button>
-      <Button id="zoomReset" label="reset zoom">
-        <ZoomReset />
-      </Button>
+      {options.showZoomControl && (
+        <>
+          <Button id="zoomIn" label="zoom in">
+            <ZoomIn />
+          </Button>
+          <Button id="zoomOut" label="zoom in">
+            <ZoomOut />
+          </Button>
+        </>
+      )}
+      {options.showFullPageControl && (
+        <Button id="fullPage" label="full page">
+          <ZoomFullScreen />
+        </Button>
+      )}
+      {options.showRotationControl && (
+        <>
+          <Button id="rotateRight" label="rotate right">
+            <Rotate />
+          </Button>
+          <Button id="rotateLeft" label="rotate left">
+            <Rotate />
+          </Button>
+        </>
+      )}
+      {options.showHomeControl && (
+        <Button id="reset" label="reset">
+          <Reset />
+        </Button>
+      )}
     </Wrapper>
   );
 };

--- a/src/components/ImageViewer/OSD.tsx
+++ b/src/components/ImageViewer/OSD.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from "react";
-import OpenSeadragon from "openseadragon";
+import OpenSeadragon, { Options } from "openseadragon";
 import {
   Navigator,
   Viewport,
@@ -24,14 +24,20 @@ const OSD: React.FC<OSDProps> = ({ uri, imageType }) => {
 
   const instance = uuidv4();
 
-  const config = {
+  const config: Options = {
     id: `openseadragon-viewport-${instance}`,
     loadTilesWithAjax: true,
-    homeButton: "zoomReset",
-    showFullPageControl: false,
+    fullPageButton: "fullPage",
+    homeButton: "reset",
+    rotateLeftButton: "rotateLeft",
+    rotateRightButton: "rotateRight",
     zoomInButton: "zoomIn",
     zoomOutButton: "zoomOut",
     showNavigator: true,
+    showFullPageControl: true,
+    showHomeControl: true,
+    showRotationControl: true,
+    showZoomControl: true,
     navigatorBorderColor: "transparent",
     navigatorId: `openseadragon-navigator-${instance}`,
     gestureSettingsMouse: {
@@ -79,7 +85,7 @@ const OSD: React.FC<OSDProps> = ({ uri, imageType }) => {
         height: configOptions.canvasHeight,
       }}
     >
-      <Controls />
+      <Controls options={config} />
       <Navigator id={`openseadragon-navigator-${instance}`} />
       <Viewport id={`openseadragon-viewport-${instance}`} />
     </Wrapper>


### PR DESCRIPTION
## What does this do?

![image](https://user-images.githubusercontent.com/7376450/211417812-5b86d503-cb48-4943-8712-5e8e3dfb917d.png)

This adds new control functionality to the OpenSeadragon image viewer in Clover. 

- Adds a full screen button
- Adds rotate left and rotate right buttons (note that the icon was previously the "reset")
- Adds a new reset icon that resembles an undo

All of these icons can also now be controlled by boolean values in options.openSeadragon:

```
showFullPageControl: boolean;
showHomeControl: boolean;
showRotationControl: boolean;
showZoomControl: boolean;
``` 