### PR TITLE
Add withCredentials param to xhrSetup in HLS config.

### DIFF
--- a/src/components/Player/Player.tsx
+++ b/src/components/Player/Player.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import Hls from "hls.js";
+import Hls, { HlsConfig } from "hls.js";
 import { PlayerWrapper } from "@/components/Player/Player.styled";
 import { IIIFExternalWebResource } from "@iiif/presentation-3";
 import { LabeledResource } from "@/hooks/use-iiif/getSupplementingResources";
@@ -59,8 +59,14 @@ const Player: React.FC<PlayerProps> = ({ painting, resources }) => {
      */
     if (painting.id.split(".").pop() !== "m3u8") return;
 
+    const config = {
+      xhrSetup: function (xhr, url) {
+        xhr.withCredentials = configOptions.withCredentials; // do send cookies
+      },
+    } as HlsConfig;
+
     // Bind hls.js package to our <video /> element and then load the media source
-    const hls = new Hls();
+    const hls = new Hls(config);
     hls.attachMedia(playerRef.current);
     hls.on(Hls.Events.MEDIA_ATTACHED, function () {
       hls.loadSource(painting.id as string);

--- a/src/components/Player/Player.tsx
+++ b/src/components/Player/Player.tsx
@@ -59,9 +59,12 @@ const Player: React.FC<PlayerProps> = ({ painting, resources }) => {
      */
     if (painting.id.split(".").pop() !== "m3u8") return;
 
+    // Construct HLS.js config
     const config = {
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      // @ts-ignore
       xhrSetup: function (xhr, url) {
-        xhr.withCredentials = configOptions.withCredentials; // do send cookies
+        xhr.withCredentials = configOptions.withCredentials;
       },
     } as HlsConfig;
 


### PR DESCRIPTION
## What does this do?

This work updates the **xhrSetup** (`xhr.withCredentials`) on the HLS.js config, passing the boolean value set in the `configOptions.withCredentials` prop on the Clover component. The passing of this acts very similar to how we handle withCredential requests in sub components using OpenSeadragon.

## How should we review?
To truly verify, we really need to be able to request along with cookies, however, as a temporary test, you can update the `withCredentials` value to `true` in dev.tsx. All HLS requests will now be completed withCredentials (see developer tools requests). My suggestion is that if this code looks good, we push out a release candidate that can be tested in our staging environment.