### PR TITLE
Apply WebKit canvas label line clamping.

### DIFF
--- a/src/components/Media/Thumbnail.styled.tsx
+++ b/src/components/Media/Thumbnail.styled.tsx
@@ -85,6 +85,7 @@ const Item = styled(RadioGroup.Item, {
       display: "-webkit-box",
       overflow: "hidden",
       MozBoxOrient: "vertical",
+      WebkitBoxOrient: "vertical",
       WebkitLineClamp: "5",
 
       "@sm": {


### PR DESCRIPTION
## What does this do?

![image](https://user-images.githubusercontent.com/7376450/224121692-504beea9-2899-40d0-bfa4-6dad69cfc860.png)


Well, this is a very fix that adds in WebkitBoxOrient property to work alongside the existing line clamp property. This apparently had been working in FireFox already and now should work in Safari, Chrome, and other WebKit browsers. Canvas labels are limited to 5 lines and have `...` ellipsis for overflow.

To review, see http://127.0.0.1:8080/?iiif-content=https://api.dc.library.northwestern.edu/api/v2/works/eb0af039-0fe8-4dbb-96f8-836d4b6b32db?as=iiif