### PR TITLE
Make OSD controls more usable in smallest viewports.

### DIFF
--- a/src/components/ImageViewer/Button.styled.tsx
+++ b/src/components/ImageViewer/Button.styled.tsx
@@ -13,10 +13,23 @@ const Item = styled("button", {
   color: "white",
   cursor: "pointer",
   marginLeft: "0.618rem",
-  backgroundColor: "#000D",
-  filter: "drop-shadow(5px 5px 5px #0006)",
+  backgroundColor: "$primary",
+  filter: "drop-shadow(2px 2px 5px #0003)",
   transition: "$all",
   boxSizing: "content-box !important",
+
+  "&:first-child": {
+    marginLeft: "0",
+  },
+
+  "@xs": {
+    marginBottom: "0.618rem",
+    marginLeft: "0",
+
+    "&:last-child": {
+      marginBottom: "0",
+    },
+  },
 
   svg: {
     height: "60%",

--- a/src/components/ImageViewer/Controls.styled.tsx
+++ b/src/components/ImageViewer/Controls.styled.tsx
@@ -6,6 +6,11 @@ const Wrapper = styled("div", {
   top: "1rem",
   right: "1rem",
   display: "flex",
+
+  "@xs": {
+    flexDirection: "column",
+    zIndex: "2",
+  },
 });
 
 export { Wrapper };

--- a/src/components/ImageViewer/ImageViewer.styled.tsx
+++ b/src/components/ImageViewer/ImageViewer.styled.tsx
@@ -20,6 +20,11 @@ const Navigator = styled("div", {
     width: "123px",
     height: "76px",
   },
+
+  "@xs": {
+    width: "100px",
+    height: "61.8px",
+  },
 });
 
 const Viewport = styled("div", {


### PR DESCRIPTION
## What does this do?

<img src="https://user-images.githubusercontent.com/7376450/224122200-240d4c54-e3bb-4491-b4ac-204103655129.png" width="200" />

This adds a small styling responsive fix to orient the OpenSeadragon controls vertically at `xs` viewports. The zIndex of the Controls is also now at a higher level than the "Navigator" in the top left, assuring that the controls are always going to be clickable.