### PR TITLE
Fix zIndex issue on audio (sound) canvases.

### DIFF
--- a/src/components/Player/AudioVisualizer.styled.tsx
+++ b/src/components/Player/AudioVisualizer.styled.tsx
@@ -4,4 +4,5 @@ export const AudioVisualizerWrapper = styled("canvas", {
   position: "absolute",
   width: "100%",
   height: "100%",
+  zIndex: "0",
 });

--- a/src/components/Player/Player.styled.tsx
+++ b/src/components/Player/Player.styled.tsx
@@ -14,5 +14,7 @@ export const PlayerWrapper = styled("div", {
     objectFit: "contain",
     width: "100%",
     height: "100%",
+    position: "relative",
+    zIndex: "1",
   },
 });


### PR DESCRIPTION
## What does this do?

This fixes an issue on Audio canvases where the visualizer canvas has overlaps the the `<video>` element playing the canvas. zIndex properties have been adjusted to ensure the audio visualizer renders below the player which has a transparent background. 