### PR TITLE
Update `poster` attribute on A/V canvases.

### DIFF
--- a/public/fixtures/iiif/manifests/accompanying-canvas.json
+++ b/public/fixtures/iiif/manifests/accompanying-canvas.json
@@ -1,6 +1,6 @@
 {
   "@context": "http://iiif.io/api/presentation/3/context.json",
-  "id": "https://iiif.io/api/cookbook/recipe/0014-accompanyingcanvas/manifest.json",
+  "id": "http://127.0.0.1:8080/fixtures/iiif/manifests/accompanying-canvas.json",
   "type": "Manifest",
   "label": {
     "en": ["Partial audio recording of Gustav Mahler's _Symphony No. 3_"]
@@ -65,7 +65,7 @@
                 "duration": 1985.024,
                 "format": "video/mp4"
               },
-              "target": "https://iiif.io/api/cookbook/recipe/0014-accompanyingcanvas/canvas/page/p1"
+              "target": "https://iiif.io/api/cookbook/recipe/0014-accompanyingcanvas/canvas/p1"
             }
           ]
         }

--- a/public/fixtures/iiif/manifests/accompanying-placeholder-canvas.json
+++ b/public/fixtures/iiif/manifests/accompanying-placeholder-canvas.json
@@ -1,0 +1,102 @@
+{
+  "@context": "http://iiif.io/api/presentation/3/context.json",
+  "id": "http://127.0.0.1:8080/fixtures/iiif/manifests/accompanying-placeholder-canvas.json",
+  "type": "Manifest",
+  "label": {
+    "en": ["Partial audio recording of Gustav Mahler's _Symphony No. 3_"]
+  },
+  "items": [
+    {
+      "id": "https://iiif.io/api/cookbook/recipe/0014-accompanyingcanvas/canvas/p1",
+      "type": "Canvas",
+      "label": {
+        "en": ["Gustav Mahler, Symphony No. 3, CD 1"]
+      },
+      "duration": 1985.024,
+      "accompanyingCanvas": {
+        "id": "https://iiif.io/api/cookbook/recipe/0014-accompanyingcanvas/canvas/accompanying",
+        "type": "Canvas",
+        "label": {
+          "en": ["First page of score for Gustav Mahler, Symphony No. 3"]
+        },
+        "height": 998,
+        "width": 772,
+        "items": [
+          {
+            "id": "https://iiif.io/api/cookbook/recipe/0014-accompanyingcanvas/canvas/accompanying/annotation/page",
+            "type": "AnnotationPage",
+            "items": [
+              {
+                "id": "https://iiif.io/api/cookbook/recipe/0014-accompanyingcanvas/canvas/accompanying/annotation/image",
+                "type": "Annotation",
+                "motivation": "painting",
+                "body": {
+                  "id": "https://iiif.io/api/image/3.0/example/reference/4b45bba3ea612ee46f5371ce84dbcd89-mahler-0/full/,998/0/default.jpg",
+                  "type": "Image",
+                  "format": "image/jpeg",
+                  "height": 998,
+                  "width": 772,
+                  "service": [
+                    {
+                      "id": "https://iiif.io/api/image/3.0/example/reference/4b45bba3ea612ee46f5371ce84dbcd89-mahler-0",
+                      "type": "ImageService3",
+                      "profile": "level1"
+                    }
+                  ]
+                },
+                "target": "https://iiif.io/api/cookbook/recipe/0014-accompanyingcanvas/canvas/accompanying"
+              }
+            ]
+          }
+        ]
+      },
+      "placeholderCanvas": {
+        "id": "https://iiif.io/api/cookbook/recipe/0013-placeholderCanvas/canvas/donizetti/placeholder",
+        "type": "Canvas",
+        "width": 640,
+        "height": 360,
+        "items": [
+          {
+            "id": "https://iiif.io/api/cookbook/recipe/0013-placeholderCanvas/canvas/donizetti/placeholder/1",
+            "type": "AnnotationPage",
+            "items": [
+              {
+                "id": "https://iiif.io/api/cookbook/recipe/0013-placeholderCanvas/canvas/donizetti/placeholder/1-image",
+                "type": "Annotation",
+                "motivation": "painting",
+                "body": {
+                  "id": "https://fixtures.iiif.io/video/indiana/donizetti-elixir/act1-thumbnail.png",
+                  "type": "Image",
+                  "format": "image/png",
+                  "width": 640,
+                  "height": 360
+                },
+                "target": "https://iiif.io/api/cookbook/recipe/0013-placeholderCanvas/canvas/donizetti/placeholder"
+              }
+            ]
+          }
+        ]
+      },
+      "items": [
+        {
+          "id": "https://iiif.io/api/cookbook/recipe/0014-accompanyingcanvas/canvas/page/p1",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://iiif.io/api/cookbook/recipe/0014-accompanyingcanvas/canvas/page/annotation/segment1-audio",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": {
+                "id": "https://fixtures.iiif.io/audio/indiana/mahler-symphony-3/CD1/medium/128Kbps.mp4",
+                "type": "Sound",
+                "duration": 1985.024,
+                "format": "video/mp4"
+              },
+              "target": "https://iiif.io/api/cookbook/recipe/0014-accompanyingcanvas/canvas/p1"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/src/components/Painting/Painting.tsx
+++ b/src/components/Painting/Painting.tsx
@@ -61,7 +61,7 @@ const Painting: React.FC<PaintingProps> = ({
 
   const placeholderCanvas = normalizedCanvas?.placeholderCanvas?.id;
   const hasPlaceholder = Boolean(placeholderCanvas);
-  const showPlaceholder = placeholderCanvas && !isInteractive;
+  const showPlaceholder = placeholderCanvas && !isInteractive && !isMedia;
 
   const handleToggle = () => setIsInteractive(!isInteractive);
 
@@ -72,7 +72,7 @@ const Painting: React.FC<PaintingProps> = ({
         backgroundColor: configOptions.canvasBackgroundColor,
       }}
     >
-      {placeholderCanvas && (
+      {placeholderCanvas && !isMedia && (
         <Toggle
           handleToggle={handleToggle}
           isInteractive={isInteractive}
@@ -80,7 +80,7 @@ const Painting: React.FC<PaintingProps> = ({
         />
       )}
 
-      {showPlaceholder && (
+      {showPlaceholder && !isMedia && (
         <PaintingPlaceholder
           isMedia={isMedia}
           label={normalizedCanvas?.label}
@@ -95,7 +95,6 @@ const Painting: React.FC<PaintingProps> = ({
             <Player
               painting={painting as IIIFExternalWebResource}
               resources={resources}
-              hasPlaceholder={hasPlaceholder}
             />
           ) : (
             painting && (

--- a/src/components/Player/Player.test.tsx
+++ b/src/components/Player/Player.test.tsx
@@ -31,12 +31,6 @@ const mockResources: Array<LabeledResource> = [
 
 xdescribe("Player component", () => {
   it("renders", () => {
-    render(
-      <Player
-        hasPlaceholder={false}
-        painting={mockPainting}
-        resources={mockResources}
-      />,
-    );
+    render(<Player painting={mockPainting} resources={mockResources} />);
   });
 });

--- a/src/dev/manifests.ts
+++ b/src/dev/manifests.ts
@@ -1,5 +1,17 @@
 export const manifests = [
   {
+    url: "http://127.0.0.1:8080/fixtures/iiif/manifests/accompanying-placeholder-canvas.json",
+    label: "accompanying/placeholder canvas",
+  },
+  {
+    url: "http://127.0.0.1:8080/fixtures/iiif/manifests/accompanying-canvas.json",
+    label: "accompanyingCanvas",
+  },
+  {
+    url: "https://iiif.io/api/cookbook/recipe/0013-placeholderCanvas/manifest.json",
+    label: "placeholderCanvas",
+  },
+  {
     url: "https://api.dc.library.northwestern.edu/api/v2/works/71153379-4283-43be-8b0f-4e7e3bfda275?as=iiif",
     label: 'Zagna "lunga"',
   },


### PR DESCRIPTION
## What does this do?

This updates our `<Player />` component for A/V canvases to now utilize any `placeholderCanvas` and/or `accompanyingCanvas` properties as the value for the `poster` attribute. There is potential for these to conflict and some logic has been built in to check for currentTime on the video element. If a conflict exists, the placeholder is used ONLY of if the currentTime is `0`.

## How to review?

The dev instance has three different Manifests to test from. Each of these should render a poster in the Video element. The first one, _accompanying/placeholder canvas_, will render the placeholderCanvas initially and then accompanyingCanvas while playing.

- accompanying/placeholder canvas
- accompanyingCanvas
- placeholderCanvas

Image placeholderCanvases should still function as previously designed with a "placeholder" image rendered initially prior to the OpenSeadragon component being rendered onClick, test w/ https://dcapi.rdc-staging.library.northwestern.edu/api/v2/works/fc73b3ed-2e13-4ec7-9bff-dd540563d7c9?as=iiif 