### PR TITLE
fix live reload on dev server

### DIFF
--- a/serve.js
+++ b/serve.js
@@ -43,7 +43,7 @@ const { buildHTML } = require("./utils/html.js");
       interval: 0, // No delay
     })
     // Rebuilds esbuild (incrementally -- see `build.incremental`).
-    .on("all", () => {
+    .on("change", () => {
       builder.rebuild();
     });
 


### PR DESCRIPTION
The dev server is continuously reloading because watch mode is set to `all`. This PR changes the watch to `change`, so it only reloads when there is a change in the file.  Related issue #122 