### PR TITLE
Updata Metadata docs.

### DIFF
--- a/pages/docs/label.mdx
+++ b/pages/docs/label.mdx
@@ -114,7 +114,7 @@ The `Label` component can be rendered as ` span`, `h1`, `h2`, `h3`, `h4`, `h5`, 
   </Tab>
   <Tab>
     ```html
-    <span class="c-PJLV custom-label-class" id="custom-label-id">
+    <span class="c-PJLV custom-label-class">
       Self-Portrait Dedicated to Paul Gauguin
     </span>
     ```

--- a/pages/docs/metadata.mdx
+++ b/pages/docs/metadata.mdx
@@ -18,13 +18,111 @@ export function DynamicCode({ children, lang }) {
   );
 }
 
+export const metadata = [
+  {
+    label: {
+      none: ["Alternate Title"],
+    },
+    value: {
+      none: [
+        "Volume 7. The Yakima. The Klickitat. Salishan tribes of the interior. The Kutenai",
+      ],
+    },
+  },
+  {
+    label: {
+      none: ["Contributor"],
+    },
+    value: {
+      none: [
+        "Curtis, Edward S., 1868-1952 (Author)",
+        "Curtis, Edward S., 1868-1952 (Illustrator)",
+        "Curtis, Edward S., 1868-1952 (Publisher)",
+        "Hodge, Frederick Webb, 1864-1956 (Editor)",
+        "Roosevelt, Theodore, 1858-1919 (Author of introduction, etc.)",
+        "Morgan, J. Pierpont (John Pierpont), 1837-1913 (Patron)",
+        "John Andrew & Son (Printmaker)",
+        "Plimpton Press (Publisher)",
+      ],
+    },
+  },
+];
+
 # Metadata
 
 An ordered list of descriptions to be displayed to the user when they interact with the resource, given as pairs of human readable `label` and `value` entries.
 
-<IIIFBadge href="https://iiif.io/api/presentation/3.0/#metadata" />
+<IIIFBadge
+  href="https://iiif.io/api/presentation/3.0/#metadata"
+  text={["metadata"]}
+/>
 
-## React Usage
+<Tabs items={["Code", "Example", "HTML"]}>
+  <Tab>
+    ```jsx
+    <IIIF.Metadata
+      metadata={[
+        {
+          label: {
+            none: ["Creator"],
+          },
+          value: {
+            none: ["Fava, Antonio, 1949-"],
+          },
+        },
+        {
+          label: {
+            none: ["Date"],
+          },
+          value: {
+            none: ["2012"],
+          },
+        },
+      ]}
+    />
+    ```
+  </Tab>
+  <Tab>
+    <IIIF.Metadata
+      metadata={[
+        {
+          label: {
+            none: ["Creator"],
+          },
+          value: {
+            none: ["Fava, Antonio, 1949-"],
+          },
+        },
+        {
+          label: {
+            none: ["Date"],
+          },
+          value: {
+            none: ["2012"],
+          },
+        },
+      ]}
+    />
+  </Tab>
+  <Tab>
+    ```html
+    <dl class="c-PJLV">
+      <div role="group" data-label="creator">
+        <dt class="c-PJLV">Creator</dt>
+        <dd class="c-PJLV">Fava, Antonio, 1949-</dd>
+      </div>
+      <div role="group" data-label="date">
+        <dt class="c-PJLV">Date</dt>
+        <dd class="c-PJLV">2012</dd>
+      </div>
+    </dl>
+    ```
+  </Tab>
+</Tabs>
+
+## Usage
+
+### React
 
 ```jsx
 import { Primitives as IIIF } from "@samvera/clover-iiif";
@@ -36,185 +134,267 @@ const CustomMetadata = ({ metadata }) => {
 export default CustomMetadata;
 ```
 
-## Example
+## API Reference
 
-<Tabs items={["Code", "Example", "Rendered HTML"]}>
+| Prop                   | Type                                                       | Default | Required |
+| ---------------------- | ---------------------------------------------------------- | ------- | -------- |
+| `as`                   | `dl`                                                       | `dl`    | --       |
+| `metadata`             | [metadata](https://iiif.io/api/presentation/3.0/#metadata) | --      | **Yes**  |
+| `customValueContent`   | `PrimitivesCustomValueContent[]`                           | --      | --       |
+| `customValueDelimiter` | string?                                                    | `,`     | --       |
+| `className`            | `string`, `undefined`                                      | --      | --       |
+| `style`                | `CSSProperties`, `undefined`                               | --      | --       |
+| `lang`                 | `string`, `undefined`                                      | --      | --       |
+| `title`                | `string`, `undefined`                                      | --      | --       |
+| `data-*`               | `string`, `undefined`                                      | --      | --       |
+| `aria-*`               | `AriaAttributes`, `undefined`                              | --      | --       |
+
+### HTML Attributes
+
+`Metadata`, like all Clover IIIF primitives accept common [HTMLElement](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement) attributes. Use the JSX style `className` prop to add custom classes. The same attribute methodology can be used for `id`, `style`, `title`, `data-*`, and `aria-*` props.
+
+<Tabs items={["Code", "Example", "HTML"]}>
   <Tab>
     ```jsx
-<IIIF.Metadata
-  metadata={[
-    {
-      label: {
-        none: ["Alternate Title"],
-      },
-      value: {
-        none: [
-          "Volume 7. The Yakima. The Klickitat. Salishan tribes of the interior. The Kutenai",
-        ],
-      },
-    },
-    {
-      label: {
-        none: ["Contributor"],
-      },
-      value: {
-        none: [
-          "Curtis, Edward S., 1868-1952 (Author)",
-          "Curtis, Edward S., 1868-1952 (Illustrator)",
-          "Curtis, Edward S., 1868-1952 (Publisher)",
-          "Hodge, Frederick Webb, 1864-1956 (Editor)",
-          "Roosevelt, Theodore, 1858-1919 (Author of introduction, etc.)",
-          "Morgan, J. Pierpont (John Pierpont), 1837-1913 (Patron)",
-          "John Andrew & Son (Printmaker)",
-          "Plimpton Press (Publisher)",
-        ],
-      },
-    },
-    {
-      label: {
-        none: ["Cultural Context"],
-      },
-      value: {
-        none: [
-          "Content on this site is drawn from a historical source which includes materials that may contain offensive images or language reflecting the nature of Settler Colonialism in America. Such materials should be viewed in the context of the time and place in which they were created. The images and text in this site are presented as specific, original artifacts recording the attitudes, perspectives and beliefs of a different era. Northwestern University does not endorse the views expressed in this collection which may contain images and text offensive to some researchers.",
-        ],
-      },
-    },
-    {
-      label: {
-        none: ["Date"],
-      },
-      value: {
-        none: ["1910"],
-      },
-    },
-    {
-      label: {
-        none: ["Department"],
-      },
-      value: {
-        none: ["Charles Deering McCormick Library of Special Collections"],
-      },
-    },
-    {
-      label: {
-        none: ["Dimensions"],
-      },
-      value: {
-        none: ["12.1 x 18.6 cm [image size], 16 x 21 cm [plate size]"],
-      },
-    },
-    {
-      label: {
-        none: ["Genre"],
-      },
-      value: {
-        none: ["photomechanical prints", "photogravures (prints)"],
-      },
-    },
-    {
-      label: {
-        none: ["Last Modified"],
-      },
-      value: {
-        none: ["2023-04-24T19:19:13.647175Z"],
-      },
-    },
-    {
-      label: {
-        none: ["Language"],
-      },
-      value: {
-        none: ["English"],
-      },
-    },
-    {
-      label: {
-        none: ["Location"],
-      },
-      value: {
-        none: ["Washington (State)--Seattle", "Massachusetts--Norwood"],
-      },
-    },
-    {
-      label: {
-        none: ["Materials"],
-      },
-      value: {
-        none: ["1 photogravure : brown ink"],
-      },
-    },
-    {
-      label: {
-        none: ["Rights Statement"],
-      },
-      value: {
-        none: ["No Copyright - United States"],
-      },
-    },
-    {
-      label: {
-        none: ["Series"],
-      },
-      value: {
-        none: [
-          "Edward S. Curtis's The North American Indian--Volume 7. The Yakima. The Klickitat. Salishan tribes of the interior. The Kutenai",
-        ],
-      },
-    },
-    {
-      label: {
-        none: ["Source"],
-      },
-      value: {
-        none: [
-          "The North American Indian (1907-1930) v.07, The Yakima. The Klickitat. Salishan tribes of the interior. The Kutenai ([Seattle] : E.S. Curtis ; [Cambridge, Mass. : The University Press], 1911), Facing page 100",
-        ],
-      },
-    },
-    {
-      label: {
-        none: ["Subject"],
-      },
-      value: {
-        none: [
-          "Washington (State)",
-          "Montana",
-          "Idaho",
-          "Indigenous peoples of the Northwest Plateau",
-          "Alberta",
-          "Yakama Indians",
-          "Klikitat Indians",
-          "Salishan Indians",
-          "Kootenai Indians",
-          "Salish Indians",
-          "Kalispel Indians",
-          "Spokane Indians",
-        ],
-      },
-    },
-    {
-      label: {
-        none: ["Technique"],
-      },
-      value: {
-        none: ["photomechanical processes", "photogravure (process)"],
-      },
-    },
-  ]}
-/>
-;
-
-```
-  </Tab>
-
-  <Tab>
-    <MetadataExample />
+    <IIIF.Metadata
+      metadata={[
+        {
+          label: {
+            none: ["Creator"],
+          },
+          value: {
+            none: ["Fava, Antonio, 1949-"],
+          },
+        },
+        {
+          label: {
+            none: ["Date"],
+          },
+          value: {
+            none: ["2012"],
+          },
+        },
+      ]}
+      style={{ color: "red" }}
+    />
+    ```
   </Tab>
   <Tab>
-    <DynamicCode lang="html">
-      <RenderedHTML />
-    </DynamicCode>
+    <IIIF.Metadata
+      metadata={[
+        {
+          label: {
+            none: ["Creator"],
+          },
+          value: {
+            none: ["Fava, Antonio, 1949-"],
+          },
+        },
+        {
+          label: {
+            none: ["Date"],
+          },
+          value: {
+            none: ["2012"],
+          },
+        },
+      ]}
+      style={{ color: "red" }}
+    />
+  </Tab>
+  <Tab>
+    ```html
+    <dl style="color: red;" class="c-PJLV">
+      <div role="group" data-label="creator">
+        <dt class="c-PJLV">Creator</dt>
+        <dd class="c-PJLV">Fava, Antonio, 1949-</dd>
+      </div>
+      <div role="group" data-label="date">
+        <dt class="c-PJLV">Date</dt>
+        <dd class="c-PJLV">2012</dd>
+      </div>
+    </dl>
+    ```
   </Tab>
 </Tabs>
+
+### Language
+
+Additional to being rendered to the DOM like other attributes, the value of [`lang`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/lang) will couple with [InternationalString](https://github.com/IIIF-Commons/presentation-3-types/blob/main/iiif/descriptive.d.ts#L6-L8) props to output the denoted `label`, `value`, `summary` entries. If `lang` is undefined, entries will default to the first entry in the array index. The value of `lang` should be a two letter [BCP 47](https://datatracker.ietf.org/doc/html/rfc5646) language code.
+
+<Tabs items={["Code", "Example", "HTML"]}>
+  <Tab>
+    ```jsx
+    <IIIF.Metadata
+      metadata={[
+        {
+          label: {
+            en: ["Associated"],
+            de: ["Beteiligte"],
+          },
+          value: {
+            en: ["Jan Brueghel the Elder"],
+            de: ["Jan (der Ältere) Brueghel"],
+          },
+        },
+        {
+          label: {
+            en: ["Technique"],
+            de: ["Technik"],
+          },
+          value: {
+            en: ["Oil", "copper"],
+            de: ["Öl", "Kupfer"],
+          },
+        },
+      ]}
+      lang="de"
+    />
+    ```
+  </Tab>
+  <Tab>
+    <IIIF.Metadata
+      metadata={[
+        {
+          label: {
+            en: ["Associated"],
+            de: ["Beteiligte"],
+          },
+          value: {
+            en: ["Jan Brueghel the Elder"],
+            de: ["Jan (der Ältere) Brueghel"],
+          },
+        },
+        {
+          label: {
+            en: ["Technique"],
+            de: ["Technik"],
+          },
+          value: {
+            en: ["Oil", "copper"],
+            de: ["Öl", "Kupfer"],
+          },
+        },
+      ]}
+      lang="de"
+    />
+  </Tab>
+  <Tab>
+    ```html
+    <dl lang="de" class="c-PJLV">
+      <div role="group" data-label="associated">
+        <dt lang="de" class="c-PJLV">
+          Beteiligte
+        </dt>
+        <dd lang="de" class="c-PJLV">
+          Jan (der Ältere) Brueghel
+        </dd>
+      </div>
+      <div role="group" data-label="technique">
+        <dt lang="de" class="c-PJLV">
+          Technik
+        </dt>
+        <dd lang="de" class="c-PJLV">
+          Öl, Kupfer
+        </dd>
+      </div>
+    </dl>
+    ```
+  </Tab>
+</Tabs>
+
+### Custom Values
+
+If a consuming application requires rendering specific `metadata` item `values` in a custom pattern, the `customValueContent` prop can be used. The pattern requires `matchingLabel` following https://iiif.io/api/presentation/3.0/#label and `Content` as a `ReactElement` carrying `props`. The element set for `Content` must map `props.value` to the appropriate code in the custom pattern.
+
+In the example below, the value of **Pantaloon** with a matching `label` of `{ none: ["Subject"] }` would be rendered as `<dd><a href="https://example.org/?subject=Pantaloon">Pantaloon</a><dd>`, while the `value` entry of **comic masks** would render simply as `<dd>comic masks</dd>`.
+
+```jsx
+const metadata = [
+  {
+    label: { none: ["Genre"] },
+    value: { none: ["comic masks"] },
+  },
+  {
+    label: { none: ["Subject"] },
+    value: { none: ["Pantaloon"] },
+  },
+];
+
+const CustomValueSubject = (props) => (
+  <a href={encodeURI(`https://example.org/?subject=${props.value}`)}>
+    {props.value}
+  </a>
+);
+
+const customValueContent = [
+  {
+    matchingLabel: { none: ["Subject"] },
+    Content: <CustomValueSubject />,
+  },
+];
+
+return <Metadata metadata={metadata} customValueContent={customValueContent} />;
 ```
+
+### Custom Delimiter
+
+<Tabs items={["Code", "Example", "HTML"]}>
+  <Tab>
+    ```jsx
+    <IIIF.Metadata
+      metadata={[
+        {
+          label: {
+            none: ["Subject"],
+          },
+          value: {
+            none: [
+              "Masks",
+              "Commedia dell'arte",
+              "Italian drama (Comedy)",
+              "Zanni (Fictitious character)",
+            ],
+          },
+        },
+      ]}
+      customValueDelimiter="<br/>"
+    />
+    ```
+  </Tab>
+  <Tab>
+    <IIIF.Metadata
+      metadata={[
+        {
+          label: {
+            none: ["Subject"],
+          },
+          value: {
+            none: [
+              "Masks",
+              "Commedia dell'arte",
+              "Italian drama (Comedy)",
+              "Zanni (Fictitious character)",
+            ],
+          },
+        },
+      ]}
+      customValueDelimiter="<br/>"
+    />
+  </Tab> 
+  <Tab>
+    ```html
+    <dl class="c-PJLV">
+      <div role="group" data-label="subject">
+        <dt class="c-PJLV">Subject</dt>
+        <dd class="c-PJLV">
+          Masks<br>
+          Commedia dell'arte<br>
+          Italian drama (Comedy)<br>
+          Zanni (Fictitious character)
+        </dd>
+      </div>
+    </dl>
+    ```
+  </Tab>
+</Tabs>


### PR DESCRIPTION
This updates the Metadata docs.

---

I did this as-is for now but noticed an issue with how `metadata` outputs to `dl`, `dt`, `dd` elements that we may want to fix.

Issue is that each individual value entry does not have its own `dd` element. I think if we should probably fix this if we want to stick to semantic HTML as much as possible. This definitely is related to the customDelimiter.

**Current**

```html
<dl>
  <div role="group" data-label="subject">
    <dt>Subject</dt>
    <dd>Masks, Commedia dell'arte,  Italian drama (Comedy),  Zanni (Fictitious character)</dd>
  </div>
</dl>
```
**Proposed**
```html
<dl>
  <div role="group" data-label="subject">
    <dt>Subject</dt>
    <dd>Masks</dd>
    <dd>Commedia dell'arte</dd>
    <dd>Italian drama (Comedy)</dd>
    <dd>Zanni (Fictitious character)</dd>
  </div>
</dl>
```
