### PR TITLE
Experiment with Scroll component.

### DIFF
--- a/build/build.mjs
+++ b/build/build.mjs
@@ -33,6 +33,13 @@ const buildOptions = {
       fileName: "index",
     },
   },
+  scroll: {
+    lib: {
+      name: "CloverIIIFScroll",
+      entry: "./src/components/Scroll/index.tsx",
+      fileName: "index",
+    },
+  },
 };
 
 (async () => {

--- a/build/root.mjs
+++ b/build/root.mjs
@@ -1,8 +1,9 @@
 import Image from "./image";
 import Primitives from "./primitives";
+import Scroll from "./scroll";
 import Slider from "./slider";
 import Viewer from "./viewer";
 
-export { Image, Primitives, Slider, Viewer };
+export { Image, Primitives, Scroll, Slider, Viewer };
 
 export default Viewer; 

--- a/build/root.umd.js
+++ b/build/root.umd.js
@@ -1,5 +1,8 @@
+// @ts-nocheck
+
 const Image = require("./image");
 const Primitives = require("./primitives");
+const Scroll = require("./scroll");
 const Slider = require("./slider");
 const Viewer = require("./viewer");
 
@@ -7,6 +10,7 @@ module.exports = {
   default: Viewer,
   Image,
   Primitives,
+  Scroll,
   Slider,
   Viewer,
 };

--- a/docs/components/CustomManifest/CustomManifest.tsx
+++ b/docs/components/CustomManifest/CustomManifest.tsx
@@ -5,7 +5,7 @@ import React, { useState } from "react";
 import { styled } from "src/styles/stitches.config";
 import { useRouter } from "next/router";
 
-const CustomManifest = () => {
+const CustomManifest = ({ placeholder }: { placeholder: string }) => {
   const [iiifContent, setIiifContent] = useState("");
   const router = useRouter();
 
@@ -29,7 +29,7 @@ const CustomManifest = () => {
         <Form.Field name="iiifContent" onChange={handleChange}>
           <Form.Label>IIIF Manifest or Collection</Form.Label>
           <Form.Control
-            placeholder="IIIF Manifest or Collection"
+            placeholder={placeholder}
             defaultValue={router?.query?.["iiif-content"]}
             className="nx-block nx-w-full nx-appearance-none nx-rounded-lg nx-px-3 nx-py-2 nx-transition-colors nx-text-base nx-leading-tight md:nx-text-sm nx-bg-black/[.05] dark:nx-bg-gray-50/10 focus:nx-bg-white dark:focus:nx-bg-dark placeholder:nx-text-gray-500 dark:placeholder:nx-text-gray-400 contrast-more:nx-border contrast-more:nx-border-current"
           />

--- a/docs/components/DynamicImports/Scroll.tsx
+++ b/docs/components/DynamicImports/Scroll.tsx
@@ -1,0 +1,37 @@
+import { useEffect, useState } from "react";
+
+import dynamic from "next/dynamic";
+import { useRouter } from "next/router";
+
+// todo: set this as a constant somewhere?
+const defaultIiifContent =
+  "http://localhost:3000/manifest/annotations/commenting.json";
+
+const Scroll = dynamic(() => import("src/components/Scroll"), {
+  ssr: false,
+});
+
+const CloverScroll = ({
+  iiifContent = defaultIiifContent,
+  options,
+}: {
+  iiifContent: string;
+  options;
+}) => {
+  const [iiifResource, setIiifResource] = useState<string>();
+
+  const router = useRouter();
+  const { "iiif-content": iiifContentParam } = router.query;
+
+  useEffect(() => {
+    iiifResource
+      ? setIiifResource(iiifContentParam as string)
+      : setIiifResource(iiifContent);
+  }, [iiifContentParam]);
+
+  if (!iiifResource) return null;
+
+  return <Scroll iiifContent={iiifResource} options={options} />;
+};
+
+export default CloverScroll;

--- a/docs/components/TitleComponent.tsx
+++ b/docs/components/TitleComponent.tsx
@@ -1,0 +1,37 @@
+import React, { CSSProperties } from "react";
+
+interface TitleComponentProps {
+  title: string;
+  type: string;
+}
+
+const betaBadgeStyling: CSSProperties = {
+  position: "relative",
+  top: "-1px",
+  right: "0",
+
+  backgroundColor:
+    "hsl(var(--nextra-primary-hue), var(--nextra-primary-saturation), 32%)",
+  color: "white",
+  borderRadius: "6px",
+  padding: "2px 4px",
+  fontSize: "0.7222rem",
+  fontWeight: "700",
+  marginLeft: "10px",
+};
+
+const isBeta = ["Scroll"];
+
+const TitleComponent: React.FC<TitleComponentProps> = ({ title }) => {
+  if (isBeta.includes(title))
+    return (
+      <span>
+        {title}
+        <span style={betaBadgeStyling}>Beta</span>
+      </span>
+    );
+
+  return <span>{title}</span>;
+};
+
+export default TitleComponent;

--- a/package.json
+++ b/package.json
@@ -23,6 +23,11 @@
       "require": "./dist/primitives/index.umd.js",
       "types": "./dist/primitives/index.d.ts"
     },
+    "./scroll": {
+      "import": "./dist/scroll/index.mjs",
+      "require": "./dist/scroll/index.umd.js",
+      "types": "./dist/scroll/index.d.ts"
+    },
     "./slider": {
       "import": "./dist/slider/index.mjs",
       "require": "./dist/slider/index.umd.js",
@@ -74,6 +79,7 @@
     "@radix-ui/react-switch": "^1.0.3",
     "@radix-ui/react-tabs": "^1.0.4",
     "@stitches/react": "^1.2.8",
+    "flexsearch": "^0.7.11",
     "hls.js": "^1.5.3",
     "node-webvtt": "^1.9.4",
     "openseadragon": "^2.4.2",
@@ -89,6 +95,7 @@
     "@testing-library/jest-dom": "^6.4.1",
     "@testing-library/react": "^14.2.1",
     "@testing-library/user-event": "^14.5.2",
+    "@types/flexsearch": "^0.7.6",
     "@types/node": "20.11.16",
     "@types/openseadragon": "^3.0.10",
     "@types/react": "^18.2.51",

--- a/pages/docs/_meta.json
+++ b/pages/docs/_meta.json
@@ -5,9 +5,13 @@
     "type": "separator",
     "title": "IIIF Components"
   },
-  "viewer": "Viewer",
   "image": "Image",
+  "scroll": {
+    "title": "Scroll",
+    "type": "doc"
+  },
   "slider": "Slider",
+  "viewer": "Viewer",
   "--primitives": {
     "type": "separator",
     "title": "IIIF Primitives"

--- a/pages/docs/scroll.mdx
+++ b/pages/docs/scroll.mdx
@@ -1,0 +1,122 @@
+---
+title: Scroll
+---
+
+import Scroll from "docs/components/DynamicImports/Scroll";
+import IIIFBadge from "docs/components/IIIFBadge";
+import { Tabs, Tab } from "nextra/components";
+
+# Scroll
+
+A UI component rendering a vertical scrolling articles that output individual Canvases, basic descriptive properties, and Annotations with `commenting` motivations with support for `transcribing` and `translating` motivations.
+
+<IIIFBadge
+  href="https://iiif.io/api/presentation/3.0/#21-defined-types"
+  text={["Manifest"]}
+/>
+
+---
+
+<Scroll
+  iiifContent="https://digital.lib.utk.edu/assemble/manifest/civilwar/5390"
+  options={{ offset: 90 }}
+/>
+
+## Features
+
+Provide a [IIIF Presentation API](https://iiif.io/api/presentation/3.0/) Manifest and the component:
+
+- Renders the Canvases of a IIIF Manifest as HTML5 `article` elements
+- Outputs `Annotation` textual content along with `OpenSeadragon` for images
+- Automatically creates a client-side search index for full-text search of Annotations
+- Supports vertical scrolling and textual discovery with a fixed **Search...** input
+- Supports `commenting`, `transcribing`, and `translating` motivations
+
+## Installation
+
+<Tabs items={["npm", "yarn", "pnpm"]}>
+  {/* prettier-ignore */}
+  <Tab>
+    ```shell
+      npm install @samvera/clover-iiif
+    ```
+  </Tab>
+  {/* prettier-ignore */}
+  <Tab>
+    ```shell
+      yarn add @samvera/clover-iiif
+    ```
+  </Tab>
+  {/* prettier-ignore */}
+  <Tab>
+    ```shell
+      pnpm install @samvera/clover-iiif
+    ```
+  </Tab>
+</Tabs>
+
+## Usage
+
+### React
+
+Add the `Scroll` component to your `jsx` or `tsx` code.
+
+```jsx
+import Viewer from "@samvera/clover-iiif/scroll";
+```
+
+Render `Scroll` with a IIIF Manifest URI. The only required prop is the `iiifContent`, which is the URI of the IIIF Manifest.
+
+<Tabs items={["Code", "Preview"]}>
+  <Tab>
+    ```jsx
+    <Scroll iiifContent="https://digital.lib.utk.edu/assemble/manifest/civilwar/5390" />
+    ```
+  </Tab>
+  <Tab>
+    <Scroll iiifContent="https://digital.lib.utk.edu/assemble/manifest/civilwar/5390" />
+  </Tab>
+</Tabs>
+
+### Next.js
+
+Implementation with Next.js requires a [dynamic import](https://nextjs.org/docs/advanced-features/dynamic-import) utilizing `next/dynamic`. This is due to Next's node compilation method creating issue with an `OpenSeadragon` (a dependency of Clover IIIF) assumption of a browser `document` object.
+
+```jsx
+import dynamic from "next/dynamic";
+
+const Scroll = dynamic(
+  () => import("@samvera/clover-iiif").then((Clover) => Clover.Scroll),
+  {
+    ssr: false,
+  },
+);
+
+const MyCustomScroll = () => {
+  const iiifContent =
+    "https://digital.lib.utk.edu/assemble/manifest/civilwar/5390";
+
+  return <Scroll iiifContent={iiifContent} />;
+};
+```
+
+## API Reference
+
+`Scroll` can configured through an `options` prop, which will serve as a object for common options.
+
+| Prop             | Type     | Required | Default |
+| ---------------- | -------- | -------- | ------- |
+| `iiifContent`    | `string` | Yes      |         |
+| `options`        | `object` | No       |         |
+| `options.offset` | `number` | No       | `0`     |
+
+### Offset
+
+The `options.offset` refers to the number of pixels to offset the fixed **Search...** input when scrolling vertically. This is useful when the `Scroll` is rendered within a page with a fixed header.
+
+```jsx
+<Scroll
+  iiifContent="https://digital.lib.utk.edu/assemble/manifest/civilwar/5390"
+  options={{ offset: 90 }}
+/>
+```

--- a/pages/docs/scroll/_meta.json
+++ b/pages/docs/scroll/_meta.json
@@ -1,0 +1,9 @@
+{
+  "demo": {
+    "title": "Demo",
+    "theme": {
+      "sidebar": false,
+      "layout": "full"
+    }
+  }
+}

--- a/pages/docs/scroll/demo.mdx
+++ b/pages/docs/scroll/demo.mdx
@@ -1,0 +1,21 @@
+import Scroll from "docs/components/DynamicImports/Scroll";
+import IIIFBadge from "docs/components/IIIFBadge";
+import CallToAction from "docs/components/CallToAction";
+import CustomManifest from "docs/components/CustomManifest/CustomManifest";
+
+## Scroll
+
+<br />
+
+<CallToAction href="/docs/scroll" text="Docs" size="small" />
+
+<CustomManifest placeholder="IIIF Manifest" />
+
+A UI component rendering vertical scrolling articles that output individual Canvases, basic descriptive properties, and Annotations with `commenting` motivations with support for `transcribing` and `translating` motivations.
+
+---
+
+<Scroll
+  iiifContent="https://digital.lib.utk.edu/assemble/manifest/civilwar/5756"
+  options={{ offset: 90 }}
+/>

--- a/pages/docs/viewer/demo.mdx
+++ b/pages/docs/viewer/demo.mdx
@@ -5,9 +5,10 @@ import CallToAction from "docs/components/CallToAction";
 ## Viewer
 
 <br />
+
 <CallToAction href="/docs/viewer" text="Docs" size="small" />
 
-<CustomManifest />
+<CustomManifest placeholder="IIIF Manifest or Collection" />
 
 A UI component that renders a multicanvas IIIF item viewer with pan-zoom support for `Image` via [OpenSeadragon](https://openseadragon.github.io/) and `Video` and `Sound` content resources using the [HTML video element](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/video).
 

--- a/pages/index.mdx
+++ b/pages/index.mdx
@@ -1,9 +1,10 @@
 import HomepageHeader from "docs/components/HomepageHeader";
 import Splash, { StyledGrid } from "docs/components/Splash/Splash";
 import SplashElement from "docs/components/Splash/Element";
-import Viewer from "docs/components/DynamicImports/Viewer";
 import Image from "docs/components/DynamicImports/Image";
+import Scroll from "docs/components/DynamicImports/Scroll";
 import Slider from "src/components/Slider";
+import Viewer from "docs/components/DynamicImports/Viewer";
 import {
   Homepage,
   Label,
@@ -42,6 +43,18 @@ import "swiper/css/pagination";
   >
     ```jsx
     <Viewer iiifContent="https://api.dc.library.northwestern.edu/api/v2/works/71153379-4283-43be-8b0f-4e7e3bfda275?as=iiif" />
+    ```
+  </SplashElement>
+  <SplashElement
+    text="Scroll"
+    css={{ height: "860px" }}
+    component={
+      <Scroll iiifContent="https://digital.lib.utk.edu/assemble/manifest/civilwar/5390" />
+    }
+    href="docs/scroll"
+  >
+    ```jsx
+    <Scroll iiifContent="https://digital.lib.utk.edu/assemble/manifest/civilwar/5390" />
     ```
   </SplashElement>
   <SplashElement

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,7 +13,7 @@ dependencies:
     version: 0.9.22
   '@iiif/vault-helpers':
     specifier: ^0.10.0
-    version: 0.10.0(@atlas-viewer/iiif-image-api@2.1.1)(@iiif/vault@0.9.22)(i18next@23.8.2)(react-dom@18.2.0)(react@18.2.0)
+    version: 0.10.0(@atlas-viewer/iiif-image-api@2.1.1)(@iiif/vault@0.9.22)(i18next@23.7.13)(react-dom@18.2.0)(react@18.2.0)
   '@radix-ui/react-aspect-ratio':
     specifier: ^1.0.3
     version: 1.0.3(@types/react-dom@18.2.18)(@types/react@18.2.51)(react-dom@18.2.0)(react@18.2.0)
@@ -41,6 +41,9 @@ dependencies:
   '@stitches/react':
     specifier: ^1.2.8
     version: 1.2.8(react@18.2.0)
+  flexsearch:
+    specifier: ^0.7.11
+    version: 0.7.11
   hls.js:
     specifier: ^1.5.3
     version: 1.5.3
@@ -81,7 +84,10 @@ devDependencies:
     version: 14.2.1(react-dom@18.2.0)(react@18.2.0)
   '@testing-library/user-event':
     specifier: ^14.5.2
-    version: 14.5.2(@testing-library/dom@9.3.4)
+    version: 14.5.2(@testing-library/dom@9.3.3)
+  '@types/flexsearch':
+    specifier: ^0.7.6
+    version: 0.7.6
   '@types/node':
     specifier: 20.11.16
     version: 20.11.16
@@ -99,7 +105,7 @@ devDependencies:
     version: 2.9.5
   '@typescript-eslint/eslint-plugin':
     specifier: ^6.20.0
-    version: 6.20.0(@typescript-eslint/parser@6.20.0)(eslint@8.56.0)(typescript@5.3.3)
+    version: 6.20.0(@typescript-eslint/parser@6.17.0)(eslint@8.56.0)(typescript@5.3.3)
   '@vitejs/plugin-react':
     specifier: ^4.2.1
     version: 4.2.1(vite@5.0.12)
@@ -135,7 +141,7 @@ devDependencies:
     version: 15.2.1
   next:
     specifier: ^14.1.0
-    version: 14.1.0(@babel/core@7.23.9)(react-dom@18.2.0)(react@18.2.0)
+    version: 14.1.0(@babel/core@7.23.7)(react-dom@18.2.0)(react@18.2.0)
   nextra:
     specifier: ^2.13.3
     version: 2.13.3(next@14.1.0)(react-dom@18.2.0)(react@18.2.0)
@@ -174,8 +180,8 @@ packages:
     engines: {node: '>=0.10.0'}
     dev: true
 
-  /@adobe/css-tools@4.3.3:
-    resolution: {integrity: sha512-rE0Pygv0sEZ4vBWHlAgJLGDU7Pm8xoO6p3wsEceb7GYAjScrOHpEo8KK/eVkAcnSM+slAEtXjA2JpdjLp4fJQQ==}
+  /@adobe/css-tools@4.3.2:
+    resolution: {integrity: sha512-DA5a1C0gD/pLOvhv33YMrbf2FK3oUzwNl9oOJqE4XVjuEtt6XIakRcsd7eLiOSPkp1kTRQGICTA8cKra/vFbjw==}
     dev: true
 
   /@ampproject/remapping@2.2.1:
@@ -183,7 +189,7 @@ packages:
     engines: {node: '>=6.0.0'}
     dependencies:
       '@jridgewell/gen-mapping': 0.3.3
-      '@jridgewell/trace-mapping': 0.3.22
+      '@jridgewell/trace-mapping': 0.3.20
     dev: true
 
   /@asamuzakjp/dom-selector@2.0.2:
@@ -214,20 +220,20 @@ packages:
     engines: {node: '>=6.9.0'}
     dev: true
 
-  /@babel/core@7.23.9:
-    resolution: {integrity: sha512-5q0175NOjddqpvvzU+kDiSOAk4PfdO6FvwCWoQ6RO7rTzEe8vlo+4HVfcnAREhD4npMs0e9uZypjTwzZPCf/cw==}
+  /@babel/core@7.23.7:
+    resolution: {integrity: sha512-+UpDgowcmqe36d4NwqvKsyPMlOLNGMsfMmQ5WGCu+siCe3t3dfe9njrzGfdN4qq+bcNUt0+Vw6haRxBOycs4dw==}
     engines: {node: '>=6.9.0'}
     dependencies:
       '@ampproject/remapping': 2.2.1
       '@babel/code-frame': 7.23.5
       '@babel/generator': 7.23.6
       '@babel/helper-compilation-targets': 7.23.6
-      '@babel/helper-module-transforms': 7.23.3(@babel/core@7.23.9)
-      '@babel/helpers': 7.23.9
-      '@babel/parser': 7.23.9
-      '@babel/template': 7.23.9
-      '@babel/traverse': 7.23.9
-      '@babel/types': 7.23.9
+      '@babel/helper-module-transforms': 7.23.3(@babel/core@7.23.7)
+      '@babel/helpers': 7.23.7
+      '@babel/parser': 7.23.6
+      '@babel/template': 7.22.15
+      '@babel/traverse': 7.23.7
+      '@babel/types': 7.23.6
       convert-source-map: 2.0.0
       debug: 4.3.4
       gensync: 1.0.0-beta.2
@@ -241,9 +247,9 @@ packages:
     resolution: {integrity: sha512-qrSfCYxYQB5owCmGLbl8XRpX1ytXlpueOb0N0UmQwA073KZxejgQTzAmJezxvpwQD9uGtK2shHdi55QT+MbjIw==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.23.9
+      '@babel/types': 7.23.6
       '@jridgewell/gen-mapping': 0.3.3
-      '@jridgewell/trace-mapping': 0.3.22
+      '@jridgewell/trace-mapping': 0.3.20
       jsesc: 2.5.2
     dev: true
 
@@ -253,7 +259,7 @@ packages:
     dependencies:
       '@babel/compat-data': 7.23.5
       '@babel/helper-validator-option': 7.23.5
-      browserslist: 4.22.3
+      browserslist: 4.22.2
       lru-cache: 5.1.1
       semver: 6.3.1
     dev: true
@@ -267,31 +273,31 @@ packages:
     resolution: {integrity: sha512-OErEqsrxjZTJciZ4Oo+eoZqeW9UIiOcuYKRJA4ZAgV9myA+pOXhhmpfNCKjEH/auVfEYVFJ6y1Tc4r0eIApqiw==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/template': 7.23.9
-      '@babel/types': 7.23.9
+      '@babel/template': 7.22.15
+      '@babel/types': 7.23.6
     dev: true
 
   /@babel/helper-hoist-variables@7.22.5:
     resolution: {integrity: sha512-wGjk9QZVzvknA6yKIUURb8zY3grXCcOZt+/7Wcy8O2uctxhplmUPkOdlgoNhmdVee2c92JXbf1xpMtVNbfoxRw==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.23.9
+      '@babel/types': 7.23.6
     dev: true
 
   /@babel/helper-module-imports@7.22.15:
     resolution: {integrity: sha512-0pYVBnDKZO2fnSPCrgM/6WMc7eS20Fbok+0r88fp+YtWVLZrp4CkafFGIp+W0VKw4a22sgebPT99y+FDNMdP4w==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.23.9
+      '@babel/types': 7.23.6
     dev: true
 
-  /@babel/helper-module-transforms@7.23.3(@babel/core@7.23.9):
+  /@babel/helper-module-transforms@7.23.3(@babel/core@7.23.7):
     resolution: {integrity: sha512-7bBs4ED9OmswdfDzpz4MpWgSrV7FXlc3zIagvLFjS5H+Mk7Snr21vQ6QwrsoCGMfNC4e4LQPdoULEt4ykz0SRQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0
     dependencies:
-      '@babel/core': 7.23.9
+      '@babel/core': 7.23.7
       '@babel/helper-environment-visitor': 7.22.20
       '@babel/helper-module-imports': 7.22.15
       '@babel/helper-simple-access': 7.22.5
@@ -308,14 +314,14 @@ packages:
     resolution: {integrity: sha512-n0H99E/K+Bika3++WNL17POvo4rKWZ7lZEp1Q+fStVbUi8nxPQEBOlTmCOxW/0JsS56SKKQ+ojAe2pHKJHN35w==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.23.9
+      '@babel/types': 7.23.6
     dev: true
 
   /@babel/helper-split-export-declaration@7.22.6:
     resolution: {integrity: sha512-AsUnxuLhRYsisFiaJwvp1QF+I3KjD5FOxut14q/GzovUe6orHLesW2C7d754kRm53h5gqrz6sFl6sxc4BVtE/g==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.23.9
+      '@babel/types': 7.23.6
     dev: true
 
   /@babel/helper-string-parser@7.23.4:
@@ -333,13 +339,13 @@ packages:
     engines: {node: '>=6.9.0'}
     dev: true
 
-  /@babel/helpers@7.23.9:
-    resolution: {integrity: sha512-87ICKgU5t5SzOT7sBMfCOZQ2rHjRU+Pcb9BoILMYz600W6DkVRLFBPwQ18gwUVvggqXivaUakpnxWQGbpywbBQ==}
+  /@babel/helpers@7.23.7:
+    resolution: {integrity: sha512-6AMnjCoC8wjqBzDHkuqpa7jAKwvMo4dC+lr/TFBz+ucfulO1XMpDnwWPGBNwClOKZ8h6xn5N81W/R5OrcKtCbQ==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/template': 7.23.9
-      '@babel/traverse': 7.23.9
-      '@babel/types': 7.23.9
+      '@babel/template': 7.22.15
+      '@babel/traverse': 7.23.7
+      '@babel/types': 7.23.6
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -353,51 +359,51 @@ packages:
       js-tokens: 4.0.0
     dev: true
 
-  /@babel/parser@7.23.9:
-    resolution: {integrity: sha512-9tcKgqKbs3xGJ+NtKF2ndOBBLVwPjl1SHxPQkd36r3Dlirw3xWUeGaTbqr7uGZcTaxkVNwc+03SVP7aCdWrTlA==}
+  /@babel/parser@7.23.6:
+    resolution: {integrity: sha512-Z2uID7YJ7oNvAI20O9X0bblw7Qqs8Q2hFy0R9tAfnfLkp5MW0UH9eUvnDSnFwKZ0AvgS1ucqR4KzvVHgnke1VQ==}
     engines: {node: '>=6.0.0'}
     hasBin: true
     dependencies:
-      '@babel/types': 7.23.9
+      '@babel/types': 7.23.6
     dev: true
 
-  /@babel/plugin-transform-react-jsx-self@7.23.3(@babel/core@7.23.9):
+  /@babel/plugin-transform-react-jsx-self@7.23.3(@babel/core@7.23.7):
     resolution: {integrity: sha512-qXRvbeKDSfwnlJnanVRp0SfuWE5DQhwQr5xtLBzp56Wabyo+4CMosF6Kfp+eOD/4FYpql64XVJ2W0pVLlJZxOQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.23.9
+      '@babel/core': 7.23.7
       '@babel/helper-plugin-utils': 7.22.5
     dev: true
 
-  /@babel/plugin-transform-react-jsx-source@7.23.3(@babel/core@7.23.9):
+  /@babel/plugin-transform-react-jsx-source@7.23.3(@babel/core@7.23.7):
     resolution: {integrity: sha512-91RS0MDnAWDNvGC6Wio5XYkyWI39FMFO+JK9+4AlgaTH+yWwVTsw7/sn6LK0lH7c5F+TFkpv/3LfCJ1Ydwof/g==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.23.9
+      '@babel/core': 7.23.7
       '@babel/helper-plugin-utils': 7.22.5
     dev: true
 
-  /@babel/runtime@7.23.9:
-    resolution: {integrity: sha512-0CX6F+BI2s9dkUqr08KFrAIZgNFj75rdBU/DjCyYLIaV/quFjkk6T+EJ2LkZHyZTbEV4L5p97mNkUsHl2wLFAw==}
+  /@babel/runtime@7.23.7:
+    resolution: {integrity: sha512-w06OXVOFso7LcbzMiDGt+3X7Rh7Ho8MmgPoWU3rarH+8upf+wSU/grlGbWzQyr3DkdN6ZeuMFjpdwW0Q+HxobA==}
     engines: {node: '>=6.9.0'}
     dependencies:
       regenerator-runtime: 0.14.1
 
-  /@babel/template@7.23.9:
-    resolution: {integrity: sha512-+xrD2BWLpvHKNmX2QbpdpsBaWnRxahMwJjO+KZk2JOElj5nSmKezyS1B4u+QbHMTX69t4ukm6hh9lsYQ7GHCKA==}
+  /@babel/template@7.22.15:
+    resolution: {integrity: sha512-QPErUVm4uyJa60rkI73qneDacvdvzxshT3kksGqlGWYdOTIUOwJ7RDUL8sGqslY1uXWSL6xMFKEXDS3ox2uF0w==}
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/code-frame': 7.23.5
-      '@babel/parser': 7.23.9
-      '@babel/types': 7.23.9
+      '@babel/parser': 7.23.6
+      '@babel/types': 7.23.6
     dev: true
 
-  /@babel/traverse@7.23.9:
-    resolution: {integrity: sha512-I/4UJ9vs90OkBtY6iiiTORVMyIhJ4kAVmsKo9KFc8UOxMeUfi2hvtIBsET5u9GizXE6/GFSuKCTNfgCswuEjRg==}
+  /@babel/traverse@7.23.7:
+    resolution: {integrity: sha512-tY3mM8rH9jM0YHFGyfC0/xf+SB5eKUu7HPj7/k3fpi9dAlsMc5YbQvDi0Sh2QTPXqMhyaAtzAr807TIyfQrmyg==}
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/code-frame': 7.23.5
@@ -406,16 +412,16 @@ packages:
       '@babel/helper-function-name': 7.23.0
       '@babel/helper-hoist-variables': 7.22.5
       '@babel/helper-split-export-declaration': 7.22.6
-      '@babel/parser': 7.23.9
-      '@babel/types': 7.23.9
+      '@babel/parser': 7.23.6
+      '@babel/types': 7.23.6
       debug: 4.3.4
       globals: 11.12.0
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@babel/types@7.23.9:
-    resolution: {integrity: sha512-dQjSq/7HaSjRM43FFGnv5keM2HsxpmyV1PfaSVm0nzzjwwTmjOe6J4bC8e3+pTEIgHaHj+1ZlLThRJ2auc/w1Q==}
+  /@babel/types@7.23.6:
+    resolution: {integrity: sha512-+uarb83brBzPKN38NX1MkB6vb6+mwvR6amUulqAE7ccQw1pEl+bCia9TbdG1lsnFP7lZySvUn37CHyXQdfTwzg==}
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/helper-string-parser': 7.23.4
@@ -661,7 +667,7 @@ packages:
       debug: 4.3.4
       espree: 9.6.1
       globals: 13.24.0
-      ignore: 5.3.1
+      ignore: 5.3.0
       import-fresh: 3.3.0
       js-yaml: 4.1.0
       minimatch: 3.1.2
@@ -675,52 +681,51 @@ packages:
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dev: true
 
-  /@floating-ui/core@1.6.0:
-    resolution: {integrity: sha512-PcF++MykgmTj3CIyOQbKA/hDzOAiqI3mhuoN44WRCopIs1sgoDoU4oty4Jtqaj/y3oDU6fnVSm4QG0a3t5i0+g==}
+  /@floating-ui/core@1.5.2:
+    resolution: {integrity: sha512-Ii3MrfY/GAIN3OhXNzpCKaLxHQfJF9qvwq/kEJYdqDxeIHa01K8sldugal6TmeeXl+WMvhv9cnVzUTaFFJF09A==}
     dependencies:
-      '@floating-ui/utils': 0.2.1
+      '@floating-ui/utils': 0.1.6
     dev: false
 
-  /@floating-ui/dom@1.6.1:
-    resolution: {integrity: sha512-iA8qE43/H5iGozC3W0YSnVSW42Vh522yyM1gj+BqRwVsTNOyr231PsXDaV04yT39PsO0QL2QpbI/M0ZaLUQgRQ==}
+  /@floating-ui/dom@1.5.3:
+    resolution: {integrity: sha512-ClAbQnEqJAKCJOEbbLo5IUlZHkNszqhuxS4fHAVxRPXPya6Ysf2G8KypnYcOTpx6I8xcgF9bbHb6g/2KpbV8qA==}
     dependencies:
-      '@floating-ui/core': 1.6.0
-      '@floating-ui/utils': 0.2.1
+      '@floating-ui/core': 1.5.2
+      '@floating-ui/utils': 0.1.6
     dev: false
 
-  /@floating-ui/react-dom@2.0.8(react-dom@18.2.0)(react@18.2.0):
-    resolution: {integrity: sha512-HOdqOt3R3OGeTKidaLvJKcgg75S6tibQ3Tif4eyd91QnIJWr0NLvoXFpJA/j8HqkFSL68GDca9AuyWEHlhyClw==}
+  /@floating-ui/react-dom@2.0.4(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-CF8k2rgKeh/49UrnIBs4BdxPUV6vize/Db1d/YbCLyp9GiVZ0BEwf5AiDSxJRCr6yOkGqTFHtmrULxkEfYZ7dQ==}
     peerDependencies:
       react: '>=16.8.0'
       react-dom: '>=16.8.0'
     dependencies:
-      '@floating-ui/dom': 1.6.1
+      '@floating-ui/dom': 1.5.3
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
     dev: false
 
-  /@floating-ui/utils@0.2.1:
-    resolution: {integrity: sha512-9TANp6GPoMtYzQdt54kfAyMmz1+osLlXdg2ENroU7zzrtflTLrrC/lgrIfaSe+Wu0b89GKccT7vxXA0MoAIO+Q==}
+  /@floating-ui/utils@0.1.6:
+    resolution: {integrity: sha512-OfX7E2oUDYxtBvsuS4e/jSn4Q9Qb6DzgeYtsAdkPZ47znpoNsMgZw0+tVijiv3uGNR6dgNlty6r9rzIzHjtd/A==}
     dev: false
 
-  /@headlessui/react@1.7.18(react-dom@18.2.0)(react@18.2.0):
-    resolution: {integrity: sha512-4i5DOrzwN4qSgNsL4Si61VMkUcWbcSKueUV7sFhpHzQcSShdlHENE5+QBntMSRvHt8NyoFO2AGG8si9lq+w4zQ==}
+  /@headlessui/react@1.7.17(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-4am+tzvkqDSSgiwrsEpGWqgGo9dz8qU5M3znCkC4PgkpY4HcCZzEDEvozltGGGHIKl9jbXbZPSH5TWn4sWJdow==}
     engines: {node: '>=10'}
     peerDependencies:
       react: ^16 || ^17 || ^18
       react-dom: ^16 || ^17 || ^18
     dependencies:
-      '@tanstack/react-virtual': 3.0.2(react-dom@18.2.0)(react@18.2.0)
       client-only: 0.0.1
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
     dev: true
 
-  /@humanwhocodes/config-array@0.11.14:
-    resolution: {integrity: sha512-3T8LkOmg45BV5FICb15QQMsyUSWrQ8AygVfC7ZG32zOalnqrilm018ZVCw0eapXux8FtA33q8PSRSstjee3jSg==}
+  /@humanwhocodes/config-array@0.11.13:
+    resolution: {integrity: sha512-JSBDMiDKSzQVngfRjOdFXgFfklaXI4K9nLF49Auh21lmBWRLIK3+xTErTWD4KU54pb6coM6ESE7Awz/FNU3zgQ==}
     engines: {node: '>=10.10.0'}
     dependencies:
-      '@humanwhocodes/object-schema': 2.0.2
+      '@humanwhocodes/object-schema': 2.0.1
       debug: 4.3.4
       minimatch: 3.1.2
     transitivePeerDependencies:
@@ -732,8 +737,8 @@ packages:
     engines: {node: '>=12.22'}
     dev: true
 
-  /@humanwhocodes/object-schema@2.0.2:
-    resolution: {integrity: sha512-6EwiSjwWYP7pTckG6I5eyFANjPhmPjUX9JRLUSfNPC7FX7zK9gyZAfUEaECL6ALTpGX5AjnBq3C9XmVWPitNpw==}
+  /@humanwhocodes/object-schema@2.0.1:
+    resolution: {integrity: sha512-dvuCeX5fC9dXgJn9t+X5atfmgQAzUOWqS1254Gh0m6i8wKd10ebXkfNKiRK+1GWi/yTvvLDHpoxLr0xxxeslWw==}
     dev: true
 
   /@iiif/parser@1.1.2:
@@ -741,7 +746,7 @@ packages:
     dependencies:
       '@iiif/presentation-2': 1.0.4(@iiif/presentation-3@1.1.3)
       '@iiif/presentation-3': 1.1.3
-      '@types/geojson': 7946.0.14
+      '@types/geojson': 7946.0.13
     dev: false
 
   /@iiif/presentation-2@1.0.4(@iiif/presentation-3@1.1.3):
@@ -755,9 +760,9 @@ packages:
   /@iiif/presentation-3@1.1.3:
     resolution: {integrity: sha512-Ek+25nkQouo0pXAqCsWYbAeS4jLDEBQA7iul2jzgnvoJrucxDQN2lXyNLgOUDRqpTdSqJ69iz5lm6DLaxil+Nw==}
     dependencies:
-      '@types/geojson': 7946.0.14
+      '@types/geojson': 7946.0.13
 
-  /@iiif/vault-helpers@0.10.0(@atlas-viewer/iiif-image-api@2.1.1)(@iiif/vault@0.9.22)(i18next@23.8.2)(react-dom@18.2.0)(react@18.2.0):
+  /@iiif/vault-helpers@0.10.0(@atlas-viewer/iiif-image-api@2.1.1)(@iiif/vault@0.9.22)(i18next@23.7.13)(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-gnjTPcZJMIDjwU5K8HYNU8Iix49Awmsr7IhIyxA5ZCqugnLjHvJUOmOvT7q1NRd6ia4+09wxx+EMH0D9mt4cxQ==}
     peerDependencies:
       '@atlas-viewer/iiif-image-api': ^2.1.1
@@ -770,7 +775,7 @@ packages:
     optionalDependencies:
       abs-svg-path: 0.1.1
       parse-svg-path: 0.1.2
-      react-i18next: 11.18.6(i18next@23.8.2)(react-dom@18.2.0)(react@18.2.0)
+      react-i18next: 11.18.6(i18next@23.7.13)(react-dom@18.2.0)(react@18.2.0)
       svg-arc-to-cubic-bezier: 3.2.0
     transitivePeerDependencies:
       - i18next
@@ -822,7 +827,7 @@ packages:
     dependencies:
       '@jridgewell/set-array': 1.1.2
       '@jridgewell/sourcemap-codec': 1.4.15
-      '@jridgewell/trace-mapping': 0.3.22
+      '@jridgewell/trace-mapping': 0.3.20
     dev: true
 
   /@jridgewell/resolve-uri@3.1.1:
@@ -839,15 +844,15 @@ packages:
     resolution: {integrity: sha512-UTYAUj/wviwdsMfzoSJspJxbkH5o1snzwX0//0ENX1u/55kkZZkcTZP6u9bwKGkv+dkk9at4m1Cpt0uY80kcpQ==}
     dependencies:
       '@jridgewell/gen-mapping': 0.3.3
-      '@jridgewell/trace-mapping': 0.3.22
+      '@jridgewell/trace-mapping': 0.3.20
     dev: true
 
   /@jridgewell/sourcemap-codec@1.4.15:
     resolution: {integrity: sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==}
     dev: true
 
-  /@jridgewell/trace-mapping@0.3.22:
-    resolution: {integrity: sha512-Wf963MzWtA2sjrNt+g18IAln9lKnlRp+K2eH4jjIoF1wYeq3aMREpG09xhlhdzS0EjwU7qmUJYangWa+151vZw==}
+  /@jridgewell/trace-mapping@0.3.20:
+    resolution: {integrity: sha512-R8LcPeWZol2zR8mmH3JeKQ6QRCFb7XgUhV9ZlGhHLGyg4wpPiPZNQOOWhFZhxKw8u//yTbNGI42Bx/3paXEQ+Q==}
     dependencies:
       '@jridgewell/resolve-uri': 3.1.1
       '@jridgewell/sourcemap-codec': 1.4.15
@@ -856,8 +861,8 @@ packages:
   /@mdx-js/mdx@2.3.0:
     resolution: {integrity: sha512-jLuwRlz8DQfQNiUCJR50Y09CGPq3fLtmtUQfVrj79E0JWu3dvsVcxVIcfhR5h0iXu+/z++zDrYeiJqifRynJkA==}
     dependencies:
-      '@types/estree-jsx': 1.0.4
-      '@types/mdx': 2.0.11
+      '@types/estree-jsx': 1.0.3
+      '@types/mdx': 2.0.10
       estree-util-build-jsx: 2.2.2
       estree-util-is-identifier-name: 2.1.0
       estree-util-to-js: 1.2.0
@@ -882,13 +887,13 @@ packages:
     peerDependencies:
       react: '>=16'
     dependencies:
-      '@types/mdx': 2.0.11
+      '@types/mdx': 2.0.10
       '@types/react': 18.2.51
       react: 18.2.0
     dev: true
 
-  /@napi-rs/simple-git-android-arm-eabi@0.1.16:
-    resolution: {integrity: sha512-dbrCL0Pl5KZG7x7tXdtVsA5CO6At5ohDX3myf5xIYn9kN4jDFxsocl8bNt6Vb/hZQoJd8fI+k5VlJt+rFhbdVw==}
+  /@napi-rs/simple-git-android-arm-eabi@0.1.9:
+    resolution: {integrity: sha512-9D4JnfePMpgL4pg9aMUX7/TIWEUQ+Tgx8n3Pf8TNCMGjUbImJyYsDSLJzbcv9wH7srgn4GRjSizXFJHAPjzEug==}
     engines: {node: '>= 10'}
     cpu: [arm]
     os: [android]
@@ -896,8 +901,8 @@ packages:
     dev: true
     optional: true
 
-  /@napi-rs/simple-git-android-arm64@0.1.16:
-    resolution: {integrity: sha512-xYz+TW5J09iK8SuTAKK2D5MMIsBUXVSs8nYp7HcMi8q6FCRO7yJj96YfP9PvKsc/k64hOyqGmL5DhCzY9Cu1FQ==}
+  /@napi-rs/simple-git-android-arm64@0.1.9:
+    resolution: {integrity: sha512-Krilsw0gPrrASZzudNEl9pdLuNbhoTK0j7pUbfB8FRifpPdFB/zouwuEm0aSnsDXN4ftGrmGG82kuiR/2MeoPg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [android]
@@ -905,8 +910,8 @@ packages:
     dev: true
     optional: true
 
-  /@napi-rs/simple-git-darwin-arm64@0.1.16:
-    resolution: {integrity: sha512-XfgsYqxhUE022MJobeiX563TJqyQyX4FmYCnqrtJwAfivESVeAJiH6bQIum8dDEYMHXCsG7nL8Ok0Dp8k2m42g==}
+  /@napi-rs/simple-git-darwin-arm64@0.1.9:
+    resolution: {integrity: sha512-H/F09nDgYjv4gcFrZBgdTKkZEepqt0KLYcCJuUADuxkKupmjLdecMhypXLk13AzvLW4UQI7NlLTLDXUFLyr2BA==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [darwin]
@@ -914,8 +919,8 @@ packages:
     dev: true
     optional: true
 
-  /@napi-rs/simple-git-darwin-x64@0.1.16:
-    resolution: {integrity: sha512-tkEVBhD6vgRCbeWsaAQqM3bTfpIVGeitamPPRVSbsq8qgzJ5Dx6ZedH27R7KSsA/uao7mZ3dsrNLXbu1Wy5MzA==}
+  /@napi-rs/simple-git-darwin-x64@0.1.9:
+    resolution: {integrity: sha512-jBR2xS9nVPqmHv0TWz874W0m/d453MGrMeLjB+boK5IPPLhg3AWIZj0aN9jy2Je1BGVAa0w3INIQJtBBeB6kFA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [darwin]
@@ -923,8 +928,8 @@ packages:
     dev: true
     optional: true
 
-  /@napi-rs/simple-git-linux-arm-gnueabihf@0.1.16:
-    resolution: {integrity: sha512-R6VAyNnp/yRaT7DV1Ao3r67SqTWDa+fNq2LrNy0Z8gXk2wB9ZKlrxFtLPE1WSpWknWtyRDLpRlsorh7Evk7+7w==}
+  /@napi-rs/simple-git-linux-arm-gnueabihf@0.1.9:
+    resolution: {integrity: sha512-3n0+VpO4YfZxndZ0sCvsHIvsazd+JmbSjrlTRBCnJeAU1/sfos3skNZtKGZksZhjvd+3o+/GFM8L7Xnv01yggA==}
     engines: {node: '>= 10'}
     cpu: [arm]
     os: [linux]
@@ -932,8 +937,8 @@ packages:
     dev: true
     optional: true
 
-  /@napi-rs/simple-git-linux-arm64-gnu@0.1.16:
-    resolution: {integrity: sha512-LAGI0opFKw/HBMCV2qIBK3uWSEW9h4xd2ireZKLJy8DBPymX6NrWIamuxYNyCuACnFdPRxR4LaRFy4J5ZwuMdw==}
+  /@napi-rs/simple-git-linux-arm64-gnu@0.1.9:
+    resolution: {integrity: sha512-lIzf0KHU2SKC12vMrWwCtysG2Sdt31VHRPMUiz9lD9t3xwVn8qhFSTn5yDkTeG3rgX6o0p5EKalfQN5BXsJq2w==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
@@ -941,8 +946,8 @@ packages:
     dev: true
     optional: true
 
-  /@napi-rs/simple-git-linux-arm64-musl@0.1.16:
-    resolution: {integrity: sha512-I57Ph0F0Yn2KW93ep+V1EzKhACqX0x49vvSiapqIsdDA2PifdEWLc1LJarBolmK7NKoPqKmf6lAKKO9lhiZzkg==}
+  /@napi-rs/simple-git-linux-arm64-musl@0.1.9:
+    resolution: {integrity: sha512-KQozUoNXrxrB8k741ncWXSiMbjl1AGBGfZV21PANzUM8wH4Yem2bg3kfglYS/QIx3udspsT35I9abu49n7D1/w==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
@@ -950,8 +955,8 @@ packages:
     dev: true
     optional: true
 
-  /@napi-rs/simple-git-linux-x64-gnu@0.1.16:
-    resolution: {integrity: sha512-AZYYFY2V7hlcQASPEOWyOa3e1skzTct9QPzz0LiDM3f/hCFY/wBaU2M6NC5iG3d2Kr38heuyFS/+JqxLm5WaKA==}
+  /@napi-rs/simple-git-linux-x64-gnu@0.1.9:
+    resolution: {integrity: sha512-O/Niui5mnHPcK3iYC3ui8wgERtJWsQ3Y74W/09t0bL/3dgzGMl4oQt0qTj9dWCsnoGsIEYHPzwCBp/2vqYp/pw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
@@ -959,8 +964,8 @@ packages:
     dev: true
     optional: true
 
-  /@napi-rs/simple-git-linux-x64-musl@0.1.16:
-    resolution: {integrity: sha512-9TyMcYSBJwjT8jwjY9m24BZbu7ozyWTjsmYBYNtK3B0Um1Ov6jthSNneLVvouQ6x+k3Ow+00TiFh6bvmT00r8g==}
+  /@napi-rs/simple-git-linux-x64-musl@0.1.9:
+    resolution: {integrity: sha512-L9n+e8Wn3hKr3RsIdY8GaB+ry4xZ4BaGwyKExgoB8nDGQuRUY9oP6p0WA4hWfJvJnU1H6hvo36a5UFPReyBO7A==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
@@ -968,8 +973,8 @@ packages:
     dev: true
     optional: true
 
-  /@napi-rs/simple-git-win32-arm64-msvc@0.1.16:
-    resolution: {integrity: sha512-uslJ1WuAHCYJWui6xjsyT47SjX6KOHDtClmNO8hqKz1pmDSNY7AjyUY8HxvD1lK9bDnWwc4JYhikS9cxCqHybw==}
+  /@napi-rs/simple-git-win32-arm64-msvc@0.1.9:
+    resolution: {integrity: sha512-Z6Ja/SZK+lMvRWaxj7wjnvSbAsGrH006sqZo8P8nxKUdZfkVvoCaAWr1r0cfkk2Z3aijLLtD+vKeXGlUPH6gGQ==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [win32]
@@ -977,8 +982,8 @@ packages:
     dev: true
     optional: true
 
-  /@napi-rs/simple-git-win32-x64-msvc@0.1.16:
-    resolution: {integrity: sha512-SoEaVeCZCDF1MP+M9bMSXsZWgEjk4On9GWADO5JOulvzR1bKjk0s9PMHwe/YztR9F0sJzrCxwtvBZowhSJsQPg==}
+  /@napi-rs/simple-git-win32-x64-msvc@0.1.9:
+    resolution: {integrity: sha512-VAZj1UvC+R2MjKOD3I/Y7dmQlHWAYy4omhReQJRpbCf+oGCBi9CWiIduGqeYEq723nLIKdxP7XjaO0wl1NnUww==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [win32]
@@ -986,21 +991,21 @@ packages:
     dev: true
     optional: true
 
-  /@napi-rs/simple-git@0.1.16:
-    resolution: {integrity: sha512-C5wRPw9waqL2jk3jEDeJv+f7ScuO3N0a39HVdyFLkwKxHH4Sya4ZbzZsu2JLi6eEqe7RuHipHL6mC7B2OfYZZw==}
+  /@napi-rs/simple-git@0.1.9:
+    resolution: {integrity: sha512-qKzDS0+VjMvVyU28px+C6zlD1HKy83NIdYzfMQWa/g/V1iG/Ic8uwrS2ihHfm7mp7X0PPrmINLiTTi6ieUIKfw==}
     engines: {node: '>= 10'}
     optionalDependencies:
-      '@napi-rs/simple-git-android-arm-eabi': 0.1.16
-      '@napi-rs/simple-git-android-arm64': 0.1.16
-      '@napi-rs/simple-git-darwin-arm64': 0.1.16
-      '@napi-rs/simple-git-darwin-x64': 0.1.16
-      '@napi-rs/simple-git-linux-arm-gnueabihf': 0.1.16
-      '@napi-rs/simple-git-linux-arm64-gnu': 0.1.16
-      '@napi-rs/simple-git-linux-arm64-musl': 0.1.16
-      '@napi-rs/simple-git-linux-x64-gnu': 0.1.16
-      '@napi-rs/simple-git-linux-x64-musl': 0.1.16
-      '@napi-rs/simple-git-win32-arm64-msvc': 0.1.16
-      '@napi-rs/simple-git-win32-x64-msvc': 0.1.16
+      '@napi-rs/simple-git-android-arm-eabi': 0.1.9
+      '@napi-rs/simple-git-android-arm64': 0.1.9
+      '@napi-rs/simple-git-darwin-arm64': 0.1.9
+      '@napi-rs/simple-git-darwin-x64': 0.1.9
+      '@napi-rs/simple-git-linux-arm-gnueabihf': 0.1.9
+      '@napi-rs/simple-git-linux-arm64-gnu': 0.1.9
+      '@napi-rs/simple-git-linux-arm64-musl': 0.1.9
+      '@napi-rs/simple-git-linux-x64-gnu': 0.1.9
+      '@napi-rs/simple-git-linux-x64-musl': 0.1.9
+      '@napi-rs/simple-git-win32-arm64-msvc': 0.1.9
+      '@napi-rs/simple-git-win32-x64-msvc': 0.1.9
     dev: true
 
   /@next/env@14.1.0:
@@ -1112,7 +1117,7 @@ packages:
     engines: {node: '>= 8'}
     dependencies:
       '@nodelib/fs.scandir': 2.1.5
-      fastq: 1.17.0
+      fastq: 1.16.0
     dev: true
 
   /@pkgjs/parseargs@0.11.0:
@@ -1133,13 +1138,13 @@ packages:
   /@radix-ui/number@1.0.1:
     resolution: {integrity: sha512-T5gIdVO2mmPW3NNhjNgEP3cqMXjXL9UbO0BzWcXfvdBs+BohbQxvd/K5hSVKmn9/lbTdsQVKbUcP5WLCwvUbBg==}
     dependencies:
-      '@babel/runtime': 7.23.9
+      '@babel/runtime': 7.23.7
     dev: false
 
   /@radix-ui/primitive@1.0.1:
     resolution: {integrity: sha512-yQ8oGX2GVsEYMWGxcovu1uGWPCxV5BFfeeYxqPmuAzUyLT9qmaMXSAhXpb0WrspIeqYzdJpkh2vHModJPgRIaw==}
     dependencies:
-      '@babel/runtime': 7.23.9
+      '@babel/runtime': 7.23.7
     dev: false
 
   /@radix-ui/react-arrow@1.0.3(@types/react-dom@18.2.18)(@types/react@18.2.51)(react-dom@18.2.0)(react@18.2.0):
@@ -1155,7 +1160,7 @@ packages:
       '@types/react-dom':
         optional: true
     dependencies:
-      '@babel/runtime': 7.23.9
+      '@babel/runtime': 7.23.7
       '@radix-ui/react-primitive': 1.0.3(@types/react-dom@18.2.18)(@types/react@18.2.51)(react-dom@18.2.0)(react@18.2.0)
       '@types/react': 18.2.51
       '@types/react-dom': 18.2.18
@@ -1176,7 +1181,7 @@ packages:
       '@types/react-dom':
         optional: true
     dependencies:
-      '@babel/runtime': 7.23.9
+      '@babel/runtime': 7.23.7
       '@radix-ui/react-primitive': 1.0.3(@types/react-dom@18.2.18)(@types/react@18.2.51)(react-dom@18.2.0)(react@18.2.0)
       '@types/react': 18.2.51
       '@types/react-dom': 18.2.18
@@ -1197,7 +1202,7 @@ packages:
       '@types/react-dom':
         optional: true
     dependencies:
-      '@babel/runtime': 7.23.9
+      '@babel/runtime': 7.23.7
       '@radix-ui/primitive': 1.0.1
       '@radix-ui/react-compose-refs': 1.0.1(@types/react@18.2.51)(react@18.2.0)
       '@radix-ui/react-context': 1.0.1(@types/react@18.2.51)(react@18.2.0)
@@ -1225,7 +1230,7 @@ packages:
       '@types/react-dom':
         optional: true
     dependencies:
-      '@babel/runtime': 7.23.9
+      '@babel/runtime': 7.23.7
       '@radix-ui/react-compose-refs': 1.0.1(@types/react@18.2.51)(react@18.2.0)
       '@radix-ui/react-context': 1.0.1(@types/react@18.2.51)(react@18.2.0)
       '@radix-ui/react-primitive': 1.0.3(@types/react-dom@18.2.18)(@types/react@18.2.51)(react-dom@18.2.0)(react@18.2.0)
@@ -1245,7 +1250,7 @@ packages:
       '@types/react':
         optional: true
     dependencies:
-      '@babel/runtime': 7.23.9
+      '@babel/runtime': 7.23.7
       '@types/react': 18.2.51
       react: 18.2.0
     dev: false
@@ -1259,7 +1264,7 @@ packages:
       '@types/react':
         optional: true
     dependencies:
-      '@babel/runtime': 7.23.9
+      '@babel/runtime': 7.23.7
       '@types/react': 18.2.51
       react: 18.2.0
     dev: false
@@ -1273,7 +1278,7 @@ packages:
       '@types/react':
         optional: true
     dependencies:
-      '@babel/runtime': 7.23.9
+      '@babel/runtime': 7.23.7
       '@types/react': 18.2.51
       react: 18.2.0
     dev: false
@@ -1291,7 +1296,7 @@ packages:
       '@types/react-dom':
         optional: true
     dependencies:
-      '@babel/runtime': 7.23.9
+      '@babel/runtime': 7.23.7
       '@radix-ui/primitive': 1.0.1
       '@radix-ui/react-compose-refs': 1.0.1(@types/react@18.2.51)(react@18.2.0)
       '@radix-ui/react-primitive': 1.0.3(@types/react-dom@18.2.18)(@types/react@18.2.51)(react-dom@18.2.0)(react@18.2.0)
@@ -1312,7 +1317,7 @@ packages:
       '@types/react':
         optional: true
     dependencies:
-      '@babel/runtime': 7.23.9
+      '@babel/runtime': 7.23.7
       '@types/react': 18.2.51
       react: 18.2.0
     dev: false
@@ -1330,7 +1335,7 @@ packages:
       '@types/react-dom':
         optional: true
     dependencies:
-      '@babel/runtime': 7.23.9
+      '@babel/runtime': 7.23.7
       '@radix-ui/react-compose-refs': 1.0.1(@types/react@18.2.51)(react@18.2.0)
       '@radix-ui/react-primitive': 1.0.3(@types/react-dom@18.2.18)(@types/react@18.2.51)(react-dom@18.2.0)(react@18.2.0)
       '@radix-ui/react-use-callback-ref': 1.0.1(@types/react@18.2.51)(react@18.2.0)
@@ -1353,7 +1358,7 @@ packages:
       '@types/react-dom':
         optional: true
     dependencies:
-      '@babel/runtime': 7.23.9
+      '@babel/runtime': 7.23.7
       '@radix-ui/primitive': 1.0.1
       '@radix-ui/react-compose-refs': 1.0.1(@types/react@18.2.51)(react@18.2.0)
       '@radix-ui/react-context': 1.0.1(@types/react@18.2.51)(react@18.2.0)
@@ -1375,7 +1380,7 @@ packages:
       '@types/react':
         optional: true
     dependencies:
-      '@babel/runtime': 7.23.9
+      '@babel/runtime': 7.23.7
       '@radix-ui/react-use-layout-effect': 1.0.1(@types/react@18.2.51)(react@18.2.0)
       '@types/react': 18.2.51
       react: 18.2.0
@@ -1394,7 +1399,7 @@ packages:
       '@types/react-dom':
         optional: true
     dependencies:
-      '@babel/runtime': 7.23.9
+      '@babel/runtime': 7.23.7
       '@radix-ui/react-primitive': 1.0.3(@types/react-dom@18.2.18)(@types/react@18.2.51)(react-dom@18.2.0)(react@18.2.0)
       '@types/react': 18.2.51
       '@types/react-dom': 18.2.18
@@ -1415,7 +1420,7 @@ packages:
       '@types/react-dom':
         optional: true
     dependencies:
-      '@babel/runtime': 7.23.9
+      '@babel/runtime': 7.23.7
       '@radix-ui/primitive': 1.0.1
       '@radix-ui/react-compose-refs': 1.0.1(@types/react@18.2.51)(react@18.2.0)
       '@radix-ui/react-context': 1.0.1(@types/react@18.2.51)(react@18.2.0)
@@ -1450,8 +1455,8 @@ packages:
       '@types/react-dom':
         optional: true
     dependencies:
-      '@babel/runtime': 7.23.9
-      '@floating-ui/react-dom': 2.0.8(react-dom@18.2.0)(react@18.2.0)
+      '@babel/runtime': 7.23.7
+      '@floating-ui/react-dom': 2.0.4(react-dom@18.2.0)(react@18.2.0)
       '@radix-ui/react-arrow': 1.0.3(@types/react-dom@18.2.18)(@types/react@18.2.51)(react-dom@18.2.0)(react@18.2.0)
       '@radix-ui/react-compose-refs': 1.0.1(@types/react@18.2.51)(react@18.2.0)
       '@radix-ui/react-context': 1.0.1(@types/react@18.2.51)(react@18.2.0)
@@ -1480,7 +1485,7 @@ packages:
       '@types/react-dom':
         optional: true
     dependencies:
-      '@babel/runtime': 7.23.9
+      '@babel/runtime': 7.23.7
       '@radix-ui/react-primitive': 1.0.3(@types/react-dom@18.2.18)(@types/react@18.2.51)(react-dom@18.2.0)(react@18.2.0)
       '@types/react': 18.2.51
       '@types/react-dom': 18.2.18
@@ -1501,7 +1506,7 @@ packages:
       '@types/react-dom':
         optional: true
     dependencies:
-      '@babel/runtime': 7.23.9
+      '@babel/runtime': 7.23.7
       '@radix-ui/react-compose-refs': 1.0.1(@types/react@18.2.51)(react@18.2.0)
       '@radix-ui/react-use-layout-effect': 1.0.1(@types/react@18.2.51)(react@18.2.0)
       '@types/react': 18.2.51
@@ -1523,7 +1528,7 @@ packages:
       '@types/react-dom':
         optional: true
     dependencies:
-      '@babel/runtime': 7.23.9
+      '@babel/runtime': 7.23.7
       '@radix-ui/react-slot': 1.0.2(@types/react@18.2.51)(react@18.2.0)
       '@types/react': 18.2.51
       '@types/react-dom': 18.2.18
@@ -1544,7 +1549,7 @@ packages:
       '@types/react-dom':
         optional: true
     dependencies:
-      '@babel/runtime': 7.23.9
+      '@babel/runtime': 7.23.7
       '@radix-ui/primitive': 1.0.1
       '@radix-ui/react-compose-refs': 1.0.1(@types/react@18.2.51)(react@18.2.0)
       '@radix-ui/react-context': 1.0.1(@types/react@18.2.51)(react@18.2.0)
@@ -1574,7 +1579,7 @@ packages:
       '@types/react-dom':
         optional: true
     dependencies:
-      '@babel/runtime': 7.23.9
+      '@babel/runtime': 7.23.7
       '@radix-ui/primitive': 1.0.1
       '@radix-ui/react-collection': 1.0.3(@types/react-dom@18.2.18)(@types/react@18.2.51)(react-dom@18.2.0)(react@18.2.0)
       '@radix-ui/react-compose-refs': 1.0.1(@types/react@18.2.51)(react@18.2.0)
@@ -1603,7 +1608,7 @@ packages:
       '@types/react-dom':
         optional: true
     dependencies:
-      '@babel/runtime': 7.23.9
+      '@babel/runtime': 7.23.7
       '@radix-ui/number': 1.0.1
       '@radix-ui/primitive': 1.0.1
       '@radix-ui/react-collection': 1.0.3(@types/react-dom@18.2.18)(@types/react@18.2.51)(react-dom@18.2.0)(react@18.2.0)
@@ -1640,7 +1645,7 @@ packages:
       '@types/react':
         optional: true
     dependencies:
-      '@babel/runtime': 7.23.9
+      '@babel/runtime': 7.23.7
       '@radix-ui/react-compose-refs': 1.0.1(@types/react@18.2.51)(react@18.2.0)
       '@types/react': 18.2.51
       react: 18.2.0
@@ -1659,7 +1664,7 @@ packages:
       '@types/react-dom':
         optional: true
     dependencies:
-      '@babel/runtime': 7.23.9
+      '@babel/runtime': 7.23.7
       '@radix-ui/primitive': 1.0.1
       '@radix-ui/react-compose-refs': 1.0.1(@types/react@18.2.51)(react@18.2.0)
       '@radix-ui/react-context': 1.0.1(@types/react@18.2.51)(react@18.2.0)
@@ -1686,7 +1691,7 @@ packages:
       '@types/react-dom':
         optional: true
     dependencies:
-      '@babel/runtime': 7.23.9
+      '@babel/runtime': 7.23.7
       '@radix-ui/primitive': 1.0.1
       '@radix-ui/react-context': 1.0.1(@types/react@18.2.51)(react@18.2.0)
       '@radix-ui/react-direction': 1.0.1(@types/react@18.2.51)(react@18.2.0)
@@ -1710,7 +1715,7 @@ packages:
       '@types/react':
         optional: true
     dependencies:
-      '@babel/runtime': 7.23.9
+      '@babel/runtime': 7.23.7
       '@types/react': 18.2.51
       react: 18.2.0
     dev: false
@@ -1724,7 +1729,7 @@ packages:
       '@types/react':
         optional: true
     dependencies:
-      '@babel/runtime': 7.23.9
+      '@babel/runtime': 7.23.7
       '@radix-ui/react-use-callback-ref': 1.0.1(@types/react@18.2.51)(react@18.2.0)
       '@types/react': 18.2.51
       react: 18.2.0
@@ -1739,7 +1744,7 @@ packages:
       '@types/react':
         optional: true
     dependencies:
-      '@babel/runtime': 7.23.9
+      '@babel/runtime': 7.23.7
       '@radix-ui/react-use-callback-ref': 1.0.1(@types/react@18.2.51)(react@18.2.0)
       '@types/react': 18.2.51
       react: 18.2.0
@@ -1754,7 +1759,7 @@ packages:
       '@types/react':
         optional: true
     dependencies:
-      '@babel/runtime': 7.23.9
+      '@babel/runtime': 7.23.7
       '@types/react': 18.2.51
       react: 18.2.0
     dev: false
@@ -1768,7 +1773,7 @@ packages:
       '@types/react':
         optional: true
     dependencies:
-      '@babel/runtime': 7.23.9
+      '@babel/runtime': 7.23.7
       '@types/react': 18.2.51
       react: 18.2.0
     dev: false
@@ -1782,7 +1787,7 @@ packages:
       '@types/react':
         optional: true
     dependencies:
-      '@babel/runtime': 7.23.9
+      '@babel/runtime': 7.23.7
       '@radix-ui/rect': 1.0.1
       '@types/react': 18.2.51
       react: 18.2.0
@@ -1797,7 +1802,7 @@ packages:
       '@types/react':
         optional: true
     dependencies:
-      '@babel/runtime': 7.23.9
+      '@babel/runtime': 7.23.7
       '@radix-ui/react-use-layout-effect': 1.0.1(@types/react@18.2.51)(react@18.2.0)
       '@types/react': 18.2.51
       react: 18.2.0
@@ -1816,7 +1821,7 @@ packages:
       '@types/react-dom':
         optional: true
     dependencies:
-      '@babel/runtime': 7.23.9
+      '@babel/runtime': 7.23.7
       '@radix-ui/react-primitive': 1.0.3(@types/react-dom@18.2.18)(@types/react@18.2.51)(react-dom@18.2.0)(react@18.2.0)
       '@types/react': 18.2.51
       '@types/react-dom': 18.2.18
@@ -1827,115 +1832,115 @@ packages:
   /@radix-ui/rect@1.0.1:
     resolution: {integrity: sha512-fyrgCaedtvMg9NK3en0pnOYJdtfwxUcNolezkNPUsoX57X8oQk+NkqcvzHXD2uKNij6GXmWU9NDru2IWjrO4BQ==}
     dependencies:
-      '@babel/runtime': 7.23.9
+      '@babel/runtime': 7.23.7
     dev: false
 
-  /@rollup/rollup-android-arm-eabi@4.9.6:
-    resolution: {integrity: sha512-MVNXSSYN6QXOulbHpLMKYi60ppyO13W9my1qogeiAqtjb2yR4LSmfU2+POvDkLzhjYLXz9Rf9+9a3zFHW1Lecg==}
+  /@rollup/rollup-android-arm-eabi@4.13.0:
+    resolution: {integrity: sha512-5ZYPOuaAqEH/W3gYsRkxQATBW3Ii1MfaT4EQstTnLKViLi2gLSQmlmtTpGucNP3sXEpOiI5tdGhjdE111ekyEg==}
     cpu: [arm]
     os: [android]
     requiresBuild: true
     dev: true
     optional: true
 
-  /@rollup/rollup-android-arm64@4.9.6:
-    resolution: {integrity: sha512-T14aNLpqJ5wzKNf5jEDpv5zgyIqcpn1MlwCrUXLrwoADr2RkWA0vOWP4XxbO9aiO3dvMCQICZdKeDrFl7UMClw==}
+  /@rollup/rollup-android-arm64@4.13.0:
+    resolution: {integrity: sha512-BSbaCmn8ZadK3UAQdlauSvtaJjhlDEjS5hEVVIN3A4bbl3X+otyf/kOJV08bYiRxfejP3DXFzO2jz3G20107+Q==}
     cpu: [arm64]
     os: [android]
     requiresBuild: true
     dev: true
     optional: true
 
-  /@rollup/rollup-darwin-arm64@4.9.6:
-    resolution: {integrity: sha512-CqNNAyhRkTbo8VVZ5R85X73H3R5NX9ONnKbXuHisGWC0qRbTTxnF1U4V9NafzJbgGM0sHZpdO83pLPzq8uOZFw==}
+  /@rollup/rollup-darwin-arm64@4.13.0:
+    resolution: {integrity: sha512-Ovf2evVaP6sW5Ut0GHyUSOqA6tVKfrTHddtmxGQc1CTQa1Cw3/KMCDEEICZBbyppcwnhMwcDce9ZRxdWRpVd6g==}
     cpu: [arm64]
     os: [darwin]
     requiresBuild: true
     dev: true
     optional: true
 
-  /@rollup/rollup-darwin-x64@4.9.6:
-    resolution: {integrity: sha512-zRDtdJuRvA1dc9Mp6BWYqAsU5oeLixdfUvkTHuiYOHwqYuQ4YgSmi6+/lPvSsqc/I0Omw3DdICx4Tfacdzmhog==}
+  /@rollup/rollup-darwin-x64@4.13.0:
+    resolution: {integrity: sha512-U+Jcxm89UTK592vZ2J9st9ajRv/hrwHdnvyuJpa5A2ngGSVHypigidkQJP+YiGL6JODiUeMzkqQzbCG3At81Gg==}
     cpu: [x64]
     os: [darwin]
     requiresBuild: true
     dev: true
     optional: true
 
-  /@rollup/rollup-linux-arm-gnueabihf@4.9.6:
-    resolution: {integrity: sha512-oNk8YXDDnNyG4qlNb6is1ojTOGL/tRhbbKeE/YuccItzerEZT68Z9gHrY3ROh7axDc974+zYAPxK5SH0j/G+QQ==}
+  /@rollup/rollup-linux-arm-gnueabihf@4.13.0:
+    resolution: {integrity: sha512-8wZidaUJUTIR5T4vRS22VkSMOVooG0F4N+JSwQXWSRiC6yfEsFMLTYRFHvby5mFFuExHa/yAp9juSphQQJAijQ==}
     cpu: [arm]
     os: [linux]
     requiresBuild: true
     dev: true
     optional: true
 
-  /@rollup/rollup-linux-arm64-gnu@4.9.6:
-    resolution: {integrity: sha512-Z3O60yxPtuCYobrtzjo0wlmvDdx2qZfeAWTyfOjEDqd08kthDKexLpV97KfAeUXPosENKd8uyJMRDfFMxcYkDQ==}
+  /@rollup/rollup-linux-arm64-gnu@4.13.0:
+    resolution: {integrity: sha512-Iu0Kno1vrD7zHQDxOmvweqLkAzjxEVqNhUIXBsZ8hu8Oak7/5VTPrxOEZXYC1nmrBVJp0ZcL2E7lSuuOVaE3+w==}
     cpu: [arm64]
     os: [linux]
     requiresBuild: true
     dev: true
     optional: true
 
-  /@rollup/rollup-linux-arm64-musl@4.9.6:
-    resolution: {integrity: sha512-gpiG0qQJNdYEVad+1iAsGAbgAnZ8j07FapmnIAQgODKcOTjLEWM9sRb+MbQyVsYCnA0Im6M6QIq6ax7liws6eQ==}
+  /@rollup/rollup-linux-arm64-musl@4.13.0:
+    resolution: {integrity: sha512-C31QrW47llgVyrRjIwiOwsHFcaIwmkKi3PCroQY5aVq4H0A5v/vVVAtFsI1nfBngtoRpeREvZOkIhmRwUKkAdw==}
     cpu: [arm64]
     os: [linux]
     requiresBuild: true
     dev: true
     optional: true
 
-  /@rollup/rollup-linux-riscv64-gnu@4.9.6:
-    resolution: {integrity: sha512-+uCOcvVmFUYvVDr27aiyun9WgZk0tXe7ThuzoUTAukZJOwS5MrGbmSlNOhx1j80GdpqbOty05XqSl5w4dQvcOA==}
+  /@rollup/rollup-linux-riscv64-gnu@4.13.0:
+    resolution: {integrity: sha512-Oq90dtMHvthFOPMl7pt7KmxzX7E71AfyIhh+cPhLY9oko97Zf2C9tt/XJD4RgxhaGeAraAXDtqxvKE1y/j35lA==}
     cpu: [riscv64]
     os: [linux]
     requiresBuild: true
     dev: true
     optional: true
 
-  /@rollup/rollup-linux-x64-gnu@4.9.6:
-    resolution: {integrity: sha512-HUNqM32dGzfBKuaDUBqFB7tP6VMN74eLZ33Q9Y1TBqRDn+qDonkAUyKWwF9BR9unV7QUzffLnz9GrnKvMqC/fw==}
+  /@rollup/rollup-linux-x64-gnu@4.13.0:
+    resolution: {integrity: sha512-yUD/8wMffnTKuiIsl6xU+4IA8UNhQ/f1sAnQebmE/lyQ8abjsVyDkyRkWop0kdMhKMprpNIhPmYlCxgHrPoXoA==}
     cpu: [x64]
     os: [linux]
     requiresBuild: true
     dev: true
     optional: true
 
-  /@rollup/rollup-linux-x64-musl@4.9.6:
-    resolution: {integrity: sha512-ch7M+9Tr5R4FK40FHQk8VnML0Szi2KRujUgHXd/HjuH9ifH72GUmw6lStZBo3c3GB82vHa0ZoUfjfcM7JiiMrQ==}
+  /@rollup/rollup-linux-x64-musl@4.13.0:
+    resolution: {integrity: sha512-9RyNqoFNdF0vu/qqX63fKotBh43fJQeYC98hCaf89DYQpv+xu0D8QFSOS0biA7cGuqJFOc1bJ+m2rhhsKcw1hw==}
     cpu: [x64]
     os: [linux]
     requiresBuild: true
     dev: true
     optional: true
 
-  /@rollup/rollup-win32-arm64-msvc@4.9.6:
-    resolution: {integrity: sha512-VD6qnR99dhmTQ1mJhIzXsRcTBvTjbfbGGwKAHcu+52cVl15AC/kplkhxzW/uT0Xl62Y/meBKDZvoJSJN+vTeGA==}
+  /@rollup/rollup-win32-arm64-msvc@4.13.0:
+    resolution: {integrity: sha512-46ue8ymtm/5PUU6pCvjlic0z82qWkxv54GTJZgHrQUuZnVH+tvvSP0LsozIDsCBFO4VjJ13N68wqrKSeScUKdA==}
     cpu: [arm64]
     os: [win32]
     requiresBuild: true
     dev: true
     optional: true
 
-  /@rollup/rollup-win32-ia32-msvc@4.9.6:
-    resolution: {integrity: sha512-J9AFDq/xiRI58eR2NIDfyVmTYGyIZmRcvcAoJ48oDld/NTR8wyiPUu2X/v1navJ+N/FGg68LEbX3Ejd6l8B7MQ==}
+  /@rollup/rollup-win32-ia32-msvc@4.13.0:
+    resolution: {integrity: sha512-P5/MqLdLSlqxbeuJ3YDeX37srC8mCflSyTrUsgbU1c/U9j6l2g2GiIdYaGD9QjdMQPMSgYm7hgg0551wHyIluw==}
     cpu: [ia32]
     os: [win32]
     requiresBuild: true
     dev: true
     optional: true
 
-  /@rollup/rollup-win32-x64-msvc@4.9.6:
-    resolution: {integrity: sha512-jqzNLhNDvIZOrt69Ce4UjGRpXJBzhUBzawMwnaDAwyHriki3XollsewxWzOzz+4yOFDkuJHtTsZFwMxhYJWmLQ==}
+  /@rollup/rollup-win32-x64-msvc@4.13.0:
+    resolution: {integrity: sha512-UKXUQNbO3DOhzLRwHSpa0HnhhCgNODvfoPWv2FCXme8N/ANFfhIPMGuOT+QuKd16+B5yxZ0HdpNlqPvTMS1qfw==}
     cpu: [x64]
     os: [win32]
     requiresBuild: true
     dev: true
     optional: true
 
-  /@rushstack/eslint-patch@1.7.2:
-    resolution: {integrity: sha512-RbhOOTCNoCrbfkRyoXODZp75MlpiHMgbE5MEBZAnnnLyQNgrigEj4p0lzsMDyc1zVsJDLrivB58tgg3emX0eEA==}
+  /@rushstack/eslint-patch@1.6.1:
+    resolution: {integrity: sha512-UY+FGM/2jjMkzQLn8pxcHGMaVLh9aEitG3zY2CiY7XHdLiz3bZOwa6oDxNqEMv7zZkV+cj5DOdz0cQ1BP5Hjgw==}
     dev: true
 
   /@sinclair/typebox@0.27.8:
@@ -1956,27 +1961,12 @@ packages:
       tslib: 2.6.2
     dev: true
 
-  /@tanstack/react-virtual@3.0.2(react-dom@18.2.0)(react@18.2.0):
-    resolution: {integrity: sha512-9XbRLPKgnhMwwmuQMnJMv+5a9sitGNCSEtf/AZXzmJdesYk7XsjYHaEDny+IrJzvPNwZliIIDwCRiaUqR3zzCA==}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0 || ^18.0.0
-      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
-    dependencies:
-      '@tanstack/virtual-core': 3.0.0
-      react: 18.2.0
-      react-dom: 18.2.0(react@18.2.0)
-    dev: true
-
-  /@tanstack/virtual-core@3.0.0:
-    resolution: {integrity: sha512-SYXOBTjJb05rXa2vl55TTwO40A6wKu0R5i1qQwhJYNDIqaIGF7D0HsLw+pJAyi2OvntlEIVusx3xtbbgSUi6zg==}
-    dev: true
-
-  /@testing-library/dom@9.3.4:
-    resolution: {integrity: sha512-FlS4ZWlp97iiNWig0Muq8p+3rVDjRiYE+YKGbAqXOu9nwJFFOdL00kFpz42M+4huzYi86vAK1sOOfyOG45muIQ==}
+  /@testing-library/dom@9.3.3:
+    resolution: {integrity: sha512-fB0R+fa3AUqbLHWyxXa2kGVtf1Fe1ZZFr0Zp6AIbIAzXb2mKbEXl+PCQNUOaq5lbTab5tfctfXRNsWXxa2f7Aw==}
     engines: {node: '>=14'}
     dependencies:
       '@babel/code-frame': 7.23.5
-      '@babel/runtime': 7.23.9
+      '@babel/runtime': 7.23.7
       '@types/aria-query': 5.0.4
       aria-query: 5.1.3
       chalk: 4.1.2
@@ -2006,8 +1996,8 @@ packages:
       vitest:
         optional: true
     dependencies:
-      '@adobe/css-tools': 4.3.3
-      '@babel/runtime': 7.23.9
+      '@adobe/css-tools': 4.3.2
+      '@babel/runtime': 7.23.7
       aria-query: 5.3.0
       chalk: 3.0.0
       css.escape: 1.5.1
@@ -2024,20 +2014,20 @@ packages:
       react: ^18.0.0
       react-dom: ^18.0.0
     dependencies:
-      '@babel/runtime': 7.23.9
-      '@testing-library/dom': 9.3.4
+      '@babel/runtime': 7.23.7
+      '@testing-library/dom': 9.3.3
       '@types/react-dom': 18.2.18
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
     dev: true
 
-  /@testing-library/user-event@14.5.2(@testing-library/dom@9.3.4):
+  /@testing-library/user-event@14.5.2(@testing-library/dom@9.3.3):
     resolution: {integrity: sha512-YAh82Wh4TIrxYLmfGcixwD18oIjyC1pFQC2Y01F2lzV2HTMiYrI0nze0FD0ocB//CKS/7jIUgae+adPqxK5yCQ==}
     engines: {node: '>=12', npm: '>=6'}
     peerDependencies:
       '@testing-library/dom': '>=7.21.4'
     dependencies:
-      '@testing-library/dom': 9.3.4
+      '@testing-library/dom': 9.3.3
     dev: true
 
   /@theguild/remark-mermaid@0.0.5(react@18.2.0):
@@ -2045,7 +2035,7 @@ packages:
     peerDependencies:
       react: ^18.2.0
     dependencies:
-      mermaid: 10.8.0
+      mermaid: 10.6.1
       react: 18.2.0
       unist-util-visit: 5.0.0
     transitivePeerDependencies:
@@ -2072,8 +2062,8 @@ packages:
   /@types/babel__core@7.20.5:
     resolution: {integrity: sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==}
     dependencies:
-      '@babel/parser': 7.23.9
-      '@babel/types': 7.23.9
+      '@babel/parser': 7.23.6
+      '@babel/types': 7.23.6
       '@types/babel__generator': 7.6.8
       '@types/babel__template': 7.4.4
       '@types/babel__traverse': 7.20.5
@@ -2082,20 +2072,20 @@ packages:
   /@types/babel__generator@7.6.8:
     resolution: {integrity: sha512-ASsj+tpEDsEiFr1arWrlN6V3mdfjRMZt6LtK/Vp/kreFLnr5QH5+DhvD5nINYZXzwJvXeGq+05iUXcAzVrqWtw==}
     dependencies:
-      '@babel/types': 7.23.9
+      '@babel/types': 7.23.6
     dev: true
 
   /@types/babel__template@7.4.4:
     resolution: {integrity: sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==}
     dependencies:
-      '@babel/parser': 7.23.9
-      '@babel/types': 7.23.9
+      '@babel/parser': 7.23.6
+      '@babel/types': 7.23.6
     dev: true
 
   /@types/babel__traverse@7.20.5:
     resolution: {integrity: sha512-WXCyOcRtH37HAUkpXhUduaxdm82b4GSlyTqajXviN4EfiuPgNYR109xMCKvpl6zPIpua0DGlMEDCq+g8EdoheQ==}
     dependencies:
-      '@babel/types': 7.23.9
+      '@babel/types': 7.23.6
     dev: true
 
   /@types/d3-scale-chromatic@3.0.3:
@@ -2118,8 +2108,8 @@ packages:
       '@types/ms': 0.7.34
     dev: true
 
-  /@types/estree-jsx@1.0.4:
-    resolution: {integrity: sha512-5idy3hvI9lAMqsyilBM+N+boaCf1MgoefbDxN6KEO5aK17TOHwFAYT9sjxzeKAiIWRUBgLxmZ9mPcnzZXtTcRQ==}
+  /@types/estree-jsx@1.0.3:
+    resolution: {integrity: sha512-pvQ+TKeRHeiUGRhvYwRrQ/ISnohKkSJR14fT2yqyZ4e9K5vqc7hrtY2Y1Dw0ZwAzQ6DQsxsaCUuSIIi8v0Cq6w==}
     dependencies:
       '@types/estree': 1.0.5
     dev: true
@@ -2128,17 +2118,21 @@ packages:
     resolution: {integrity: sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==}
     dev: true
 
-  /@types/geojson@7946.0.14:
-    resolution: {integrity: sha512-WCfD5Ht3ZesJUsONdhvm84dmzWOiOzOAqOncN0++w0lBw1o8OuDNJF2McvvCef/yBqb/HYRahp1BYtODFQ8bRg==}
+  /@types/flexsearch@0.7.6:
+    resolution: {integrity: sha512-H5IXcRn96/gaDmo+rDl2aJuIJsob8dgOXDqf8K0t8rWZd1AFNaaspmRsElESiU+EWE33qfbFPgI0OC/B1g9FCA==}
+    dev: true
 
-  /@types/hast@2.3.10:
-    resolution: {integrity: sha512-McWspRw8xx8J9HurkVBfYj0xKoE25tOFlHGdx4MJ5xORQrMGZNqJhVQWaIbm6Oyla5kYOXtDiopzKRJzEOkwJw==}
+  /@types/geojson@7946.0.13:
+    resolution: {integrity: sha512-bmrNrgKMOhM3WsafmbGmC+6dsF2Z308vLFsQ3a/bT8X8Sv5clVYpPars/UPq+sAaJP+5OoLAYgwbkS5QEJdLUQ==}
+
+  /@types/hast@2.3.9:
+    resolution: {integrity: sha512-pTHyNlaMD/oKJmS+ZZUyFUcsZeBZpC0lmGquw98CqRVNgAdJZJeD7GoeLiT6Xbx5rU9VCjSt0RwEvDgzh4obFw==}
     dependencies:
       '@types/unist': 2.0.10
     dev: true
 
-  /@types/hast@3.0.4:
-    resolution: {integrity: sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==}
+  /@types/hast@3.0.3:
+    resolution: {integrity: sha512-2fYGlaDy/qyLlhidX42wAH0KBi2TCjKMH8CHmBXgRlJ3Y+OXTiqsPQ6IWarZKwF1JoUcAJdPogv1d4b0COTpmQ==}
     dependencies:
       '@types/unist': 3.0.2
     dev: true
@@ -2175,8 +2169,8 @@ packages:
       '@types/unist': 3.0.2
     dev: true
 
-  /@types/mdx@2.0.11:
-    resolution: {integrity: sha512-HM5bwOaIQJIQbAYfax35HCKxx7a3KrK3nBtIqJgSOitivTD1y3oW9P3rxY9RkXYPUk7y/AjAohfHKmFpGE79zw==}
+  /@types/mdx@2.0.10:
+    resolution: {integrity: sha512-Rllzc5KHk0Al5/WANwgSPl1/CwjqCy+AZrGd78zuK+jO9aDM6ffblZ+zIjgPNAaEBmlO0RYDvLNh7wD0zKVgEg==}
     dev: true
 
   /@types/ms@0.7.34:
@@ -2229,7 +2223,7 @@ packages:
     resolution: {integrity: sha512-dqId9J8K/vGi5Zr7oo212BGii5m3q5Hxlkwy3WpYuKPklmBEvsbMYYyLxAQpSffdLl/gdW0XUpKWFvYmyoWCoQ==}
     dev: true
 
-  /@typescript-eslint/eslint-plugin@6.20.0(@typescript-eslint/parser@6.20.0)(eslint@8.56.0)(typescript@5.3.3):
+  /@typescript-eslint/eslint-plugin@6.20.0(@typescript-eslint/parser@6.17.0)(eslint@8.56.0)(typescript@5.3.3):
     resolution: {integrity: sha512-fTwGQUnjhoYHeSF6m5pWNkzmDDdsKELYrOBxhjMrofPqCkoC2k3B2wvGHFxa1CTIqkEn88nlW1HVMztjo2K8Hg==}
     engines: {node: ^16.0.0 || >=18.0.0}
     peerDependencies:
@@ -2241,7 +2235,7 @@ packages:
         optional: true
     dependencies:
       '@eslint-community/regexpp': 4.10.0
-      '@typescript-eslint/parser': 6.20.0(eslint@8.56.0)(typescript@5.3.3)
+      '@typescript-eslint/parser': 6.17.0(eslint@8.56.0)(typescript@5.3.3)
       '@typescript-eslint/scope-manager': 6.20.0
       '@typescript-eslint/type-utils': 6.20.0(eslint@8.56.0)(typescript@5.3.3)
       '@typescript-eslint/utils': 6.20.0(eslint@8.56.0)(typescript@5.3.3)
@@ -2249,7 +2243,7 @@ packages:
       debug: 4.3.4
       eslint: 8.56.0
       graphemer: 1.4.0
-      ignore: 5.3.1
+      ignore: 5.3.0
       natural-compare: 1.4.0
       semver: 7.5.4
       ts-api-utils: 1.0.3(typescript@5.3.3)
@@ -2258,8 +2252,8 @@ packages:
       - supports-color
     dev: true
 
-  /@typescript-eslint/parser@6.20.0(eslint@8.56.0)(typescript@5.3.3):
-    resolution: {integrity: sha512-bYerPDF/H5v6V76MdMYhjwmwgMA+jlPVqjSDq2cRqMi8bP5sR3Z+RLOiOMad3nsnmDVmn2gAFCyNgh/dIrfP/w==}
+  /@typescript-eslint/parser@6.17.0(eslint@8.56.0)(typescript@5.3.3):
+    resolution: {integrity: sha512-C4bBaX2orvhK+LlwrY8oWGmSl4WolCfYm513gEccdWZj0CwGadbIADb0FtVEcI+WzUyjyoBj2JRP8g25E6IB8A==}
     engines: {node: ^16.0.0 || >=18.0.0}
     peerDependencies:
       eslint: ^7.0.0 || ^8.0.0
@@ -2268,15 +2262,23 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/scope-manager': 6.20.0
-      '@typescript-eslint/types': 6.20.0
-      '@typescript-eslint/typescript-estree': 6.20.0(typescript@5.3.3)
-      '@typescript-eslint/visitor-keys': 6.20.0
+      '@typescript-eslint/scope-manager': 6.17.0
+      '@typescript-eslint/types': 6.17.0
+      '@typescript-eslint/typescript-estree': 6.17.0(typescript@5.3.3)
+      '@typescript-eslint/visitor-keys': 6.17.0
       debug: 4.3.4
       eslint: 8.56.0
       typescript: 5.3.3
     transitivePeerDependencies:
       - supports-color
+    dev: true
+
+  /@typescript-eslint/scope-manager@6.17.0:
+    resolution: {integrity: sha512-RX7a8lwgOi7am0k17NUO0+ZmMOX4PpjLtLRgLmT1d3lBYdWH4ssBUbwdmc5pdRX8rXon8v9x8vaoOSpkHfcXGA==}
+    engines: {node: ^16.0.0 || >=18.0.0}
+    dependencies:
+      '@typescript-eslint/types': 6.17.0
+      '@typescript-eslint/visitor-keys': 6.17.0
     dev: true
 
   /@typescript-eslint/scope-manager@6.20.0:
@@ -2307,9 +2309,36 @@ packages:
       - supports-color
     dev: true
 
+  /@typescript-eslint/types@6.17.0:
+    resolution: {integrity: sha512-qRKs9tvc3a4RBcL/9PXtKSehI/q8wuU9xYJxe97WFxnzH8NWWtcW3ffNS+EWg8uPvIerhjsEZ+rHtDqOCiH57A==}
+    engines: {node: ^16.0.0 || >=18.0.0}
+    dev: true
+
   /@typescript-eslint/types@6.20.0:
     resolution: {integrity: sha512-MM9mfZMAhiN4cOEcUOEx+0HmuaW3WBfukBZPCfwSqFnQy0grXYtngKCqpQN339X3RrwtzspWJrpbrupKYUSBXQ==}
     engines: {node: ^16.0.0 || >=18.0.0}
+    dev: true
+
+  /@typescript-eslint/typescript-estree@6.17.0(typescript@5.3.3):
+    resolution: {integrity: sha512-gVQe+SLdNPfjlJn5VNGhlOhrXz4cajwFd5kAgWtZ9dCZf4XJf8xmgCTLIqec7aha3JwgLI2CK6GY1043FRxZwg==}
+    engines: {node: ^16.0.0 || >=18.0.0}
+    peerDependencies:
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      '@typescript-eslint/types': 6.17.0
+      '@typescript-eslint/visitor-keys': 6.17.0
+      debug: 4.3.4
+      globby: 11.1.0
+      is-glob: 4.0.3
+      minimatch: 9.0.3
+      semver: 7.5.4
+      ts-api-utils: 1.0.3(typescript@5.3.3)
+      typescript: 5.3.3
+    transitivePeerDependencies:
+      - supports-color
     dev: true
 
   /@typescript-eslint/typescript-estree@6.20.0(typescript@5.3.3):
@@ -2353,6 +2382,14 @@ packages:
       - typescript
     dev: true
 
+  /@typescript-eslint/visitor-keys@6.17.0:
+    resolution: {integrity: sha512-H6VwB/k3IuIeQOyYczyyKN8wH6ed8EwliaYHLxOIhyF0dYEIsN8+Bk3GE19qafeMKyZJJHP8+O1HiFhFLUNKSg==}
+    engines: {node: ^16.0.0 || >=18.0.0}
+    dependencies:
+      '@typescript-eslint/types': 6.17.0
+      eslint-visitor-keys: 3.4.3
+    dev: true
+
   /@typescript-eslint/visitor-keys@6.20.0:
     resolution: {integrity: sha512-E8Cp98kRe4gKHjJD4NExXKz/zOJ1A2hhZc+IMVD6i7w4yjIvh6VyuRI0gRtxAsXtoC35uGMaQ9rjI2zJaXDEAw==}
     engines: {node: ^16.0.0 || >=18.0.0}
@@ -2371,9 +2408,9 @@ packages:
     peerDependencies:
       vite: ^4.2.0 || ^5.0.0
     dependencies:
-      '@babel/core': 7.23.9
-      '@babel/plugin-transform-react-jsx-self': 7.23.3(@babel/core@7.23.9)
-      '@babel/plugin-transform-react-jsx-source': 7.23.3(@babel/core@7.23.9)
+      '@babel/core': 7.23.7
+      '@babel/plugin-transform-react-jsx-self': 7.23.3(@babel/core@7.23.7)
+      '@babel/plugin-transform-react-jsx-source': 7.23.3(@babel/core@7.23.7)
       '@types/babel__core': 7.20.5
       react-refresh: 0.14.0
       vite: 5.0.12(@types/node@20.11.16)(terser@5.27.0)
@@ -2393,7 +2430,7 @@ packages:
       istanbul-lib-report: 3.0.1
       istanbul-lib-source-maps: 4.0.1
       istanbul-reports: 3.1.6
-      magic-string: 0.30.6
+      magic-string: 0.30.5
       magicast: 0.3.3
       picocolors: 1.0.0
       std-env: 3.7.0
@@ -2409,7 +2446,7 @@ packages:
     dependencies:
       '@vitest/spy': 1.2.2
       '@vitest/utils': 1.2.2
-      chai: 4.4.1
+      chai: 4.3.10
     dev: true
 
   /@vitest/runner@1.2.2:
@@ -2417,14 +2454,14 @@ packages:
     dependencies:
       '@vitest/utils': 1.2.2
       p-limit: 5.0.0
-      pathe: 1.1.2
+      pathe: 1.1.1
     dev: true
 
   /@vitest/snapshot@1.2.2:
     resolution: {integrity: sha512-SmGY4saEw1+bwE1th6S/cZmPxz/Q4JWsl7LvbQIky2tKE35US4gd0Mjzqfr84/4OD0tikGWaWdMja/nWL5NIPA==}
     dependencies:
-      magic-string: 0.30.6
-      pathe: 1.1.2
+      magic-string: 0.30.5
+      pathe: 1.1.1
       pretty-format: 29.7.0
     dev: true
 
@@ -2443,7 +2480,7 @@ packages:
       fast-glob: 3.3.2
       fflate: 0.8.1
       flatted: 3.2.9
-      pathe: 1.1.2
+      pathe: 1.1.1
       picocolors: 1.0.0
       sirv: 2.0.4
       vitest: 1.2.2(@types/node@20.11.16)(@vitest/ui@1.2.2)(jsdom@23.2.0)(terser@5.27.0)
@@ -2683,8 +2720,8 @@ packages:
     resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
     dev: true
 
-  /available-typed-arrays@1.0.6:
-    resolution: {integrity: sha512-j1QzY8iPNPG4o4xmO3ptzpRxTciqD3MgEHtifP/YnJpIo58Xu+ne4BejlbkuaLfXn/nz6HFiw29bLpj2PNMdGg==}
+  /available-typed-arrays@1.0.5:
+    resolution: {integrity: sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw==}
     engines: {node: '>= 0.4'}
     dev: true
 
@@ -2733,15 +2770,15 @@ packages:
       fill-range: 7.0.1
     dev: true
 
-  /browserslist@4.22.3:
-    resolution: {integrity: sha512-UAp55yfwNv0klWNapjs/ktHoguxuQNGnOzxYmfnXIS+8AsRDZkSDxg7R1AX3GKzn078SBI5dzwzj/Yx0Or0e3A==}
+  /browserslist@4.22.2:
+    resolution: {integrity: sha512-0UgcrvQmBDvZHFGdYUehrCNIazki7/lUP3kkoi/r3YB2amZbFM9J43ZRkJTXBUZK4gmx56+Sqk9+Vs9mwZx9+A==}
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
     dependencies:
-      caniuse-lite: 1.0.30001583
-      electron-to-chromium: 1.4.655
+      caniuse-lite: 1.0.30001572
+      electron-to-chromium: 1.4.616
       node-releases: 2.0.14
-      update-browserslist-db: 1.0.13(browserslist@4.22.3)
+      update-browserslist-db: 1.0.13(browserslist@4.22.2)
     dev: true
 
   /buffer-from@1.1.2:
@@ -2765,7 +2802,7 @@ packages:
     dependencies:
       function-bind: 1.1.2
       get-intrinsic: 1.2.2
-      set-function-length: 1.2.0
+      set-function-length: 1.1.1
     dev: true
 
   /callsites@3.1.0:
@@ -2773,16 +2810,20 @@ packages:
     engines: {node: '>=6'}
     dev: true
 
-  /caniuse-lite@1.0.30001583:
-    resolution: {integrity: sha512-acWTYaha8xfhA/Du/z4sNZjHUWjkiuoAi2LM+T/aL+kemKQgPT1xBb/YKjlQ0Qo8gvbHsGNplrEJ+9G3gL7i4Q==}
+  /caniuse-lite@1.0.30001572:
+    resolution: {integrity: sha512-1Pbh5FLmn5y4+QhNyJE9j3/7dK44dGB83/ZMjv/qJk86TvDbjk0LosiZo0i0WB0Vx607qMX9jYrn1VLHCkN4rw==}
+    dev: true
+
+  /caniuse-lite@1.0.30001597:
+    resolution: {integrity: sha512-7LjJvmQU6Sj7bL0j5b5WY/3n7utXUJvAe1lxhsHDbLmwX9mdL86Yjtr+5SRCyf8qME4M7pU2hswj0FpyBVCv9w==}
     dev: true
 
   /ccount@2.0.1:
     resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
     dev: true
 
-  /chai@4.4.1:
-    resolution: {integrity: sha512-13sOfMv2+DWduEU+/xbun3LScLoqN17nBeTLUsmDfKdoiC1fr0n9PU4guu4AhRcOVFk/sW8LyZWHuhWtQZiF+g==}
+  /chai@4.3.10:
+    resolution: {integrity: sha512-0UXG04VuVbruMUYbJ6JctvH0YnC/4q3/AkT18q4NaITo91CUm0liMS9VqzT9vZhVQ/1eqPanMWjBM+Juhfb/9g==}
     engines: {node: '>=4'}
     dependencies:
       assertion-error: 1.1.0
@@ -2968,6 +3009,12 @@ packages:
       layout-base: 1.0.2
     dev: true
 
+  /cose-base@2.2.0:
+    resolution: {integrity: sha512-AzlgcsCbUMymkADOJtQm3wO9S3ltPfYOFD5033keQn9NJzIbtnZj+UdBJe7DYml/8TdbtHJW3j58SOnKhWY/5g==}
+    dependencies:
+      layout-base: 2.0.1
+    dev: true
+
   /cross-fetch@4.0.0:
     resolution: {integrity: sha512-e4a5N8lVvuLgAWgnCrLr2PP0YyDOTHa9H/Rj54dirp61qXnNq46m82bRhNqIA5VccJtWBvPTFRV3TtvHUKPB1g==}
     dependencies:
@@ -3021,6 +3068,15 @@ packages:
       cytoscape: ^3.2.0
     dependencies:
       cose-base: 1.0.3
+      cytoscape: 3.28.1
+    dev: true
+
+  /cytoscape-fcose@2.2.0(cytoscape@3.28.1):
+    resolution: {integrity: sha512-ki1/VuRIHFCzxWNrsshHYPs6L7TvLu3DL+TyIGEsRcvVERmxokbf5Gdk7mFxZnTdiGtnA4cfSmjZJMviqSuZrQ==}
+    peerDependencies:
+      cytoscape: ^3.2.0
+    dependencies:
+      cose-base: 2.2.0
       cytoscape: 3.28.1
     dev: true
 
@@ -3084,7 +3140,7 @@ packages:
     resolution: {integrity: sha512-mdjtIZ1XLAM8bm/hx3WwjfHt6Sggek7qH043O8KEjDXN40xi3vx/6pYSVTwLjEgiXQTbvaouWKynLBiUZ6SK6A==}
     engines: {node: '>=12'}
     dependencies:
-      delaunator: 5.0.1
+      delaunator: 5.0.0
     dev: true
 
   /d3-dispatch@3.0.1:
@@ -3392,7 +3448,7 @@ packages:
       side-channel: 1.0.4
       which-boxed-primitive: 1.0.2
       which-collection: 1.0.1
-      which-typed-array: 1.1.14
+      which-typed-array: 1.1.13
     dev: true
 
   /deep-is@0.1.4:
@@ -3422,8 +3478,8 @@ packages:
       object-keys: 1.1.1
     dev: true
 
-  /delaunator@5.0.1:
-    resolution: {integrity: sha512-8nvh+XBe96aCESrGOqMp/84b13H9cdKbG5P2ejQCh4d4sK9RL4371qou9drQjMhvnPmhWl5hnmqbEE0fXr9Xnw==}
+  /delaunator@5.0.0:
+    resolution: {integrity: sha512-AyLvtyJdbv/U1GkiS6gUUzclRoAY4Gs75qkMygJJhU75LW4DNuSF2RMzpxs9jw9Oz1BobHjTdkG3zdP55VxAqw==}
     dependencies:
       robust-predicates: 3.0.2
     dev: true
@@ -3503,8 +3559,8 @@ packages:
     dependencies:
       domelementtype: 2.3.0
 
-  /dompurify@3.0.8:
-    resolution: {integrity: sha512-b7uwreMYL2eZhrSCRC4ahLTeZcPZxSmYfmcQGXGkXiZSNW1X85v+SDM5KsWcpivIiUBH47Ji7NtyUdpLeF5JZQ==}
+  /dompurify@3.0.6:
+    resolution: {integrity: sha512-ilkD8YEnnGh1zJ240uJsW7AzE+2qpbOUYjacomn3AvJ6J4JhKGSZ2nh4wUIXPZrEPppaCLx5jFe8T89Rk8tQ7w==}
     dev: true
 
   /domutils@3.1.0:
@@ -3527,12 +3583,12 @@ packages:
     resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
     dev: true
 
-  /electron-to-chromium@1.4.655:
-    resolution: {integrity: sha512-2yszojF7vIZ68adIOvzV4bku8OZad9w5H9xF3ZAMZjPuOjBarlflUkjN6DggdV+L71WZuKUfKUhov/34+G5QHg==}
+  /electron-to-chromium@1.4.616:
+    resolution: {integrity: sha512-1n7zWYh8eS0L9Uy+GskE0lkBUNK83cXTVJI0pU3mGprFsbfSdAc15VTFbo+A+Bq4pwstmL30AVcEU3Fo463lNg==}
     dev: true
 
-  /elkjs@0.9.1:
-    resolution: {integrity: sha512-JWKDyqAdltuUcyxaECtYG6H4sqysXSLeoXuGUBfRNESMTkj+w+qdb0jya8Z/WI0jVd03WQtCGhS6FOFtlhD5FQ==}
+  /elkjs@0.8.2:
+    resolution: {integrity: sha512-L6uRgvZTH+4OF5NE/MBbzQx/WYpru1xCBE9respNj6qznEewGUIfhzmm7horWWxbNO2M0WckQypGctR8lH79xQ==}
     dev: true
 
   /emoji-regex@10.3.0:
@@ -3565,7 +3621,7 @@ packages:
     dependencies:
       array-buffer-byte-length: 1.0.0
       arraybuffer.prototype.slice: 1.0.2
-      available-typed-arrays: 1.0.6
+      available-typed-arrays: 1.0.5
       call-bind: 1.0.5
       es-set-tostringtag: 2.0.2
       es-to-primitive: 1.2.1
@@ -3585,14 +3641,14 @@ packages:
       is-regex: 1.1.4
       is-shared-array-buffer: 1.0.2
       is-string: 1.0.7
-      is-typed-array: 1.1.13
+      is-typed-array: 1.1.12
       is-weakref: 1.0.2
       object-inspect: 1.13.1
       object-keys: 1.1.1
       object.assign: 4.1.5
       regexp.prototype.flags: 1.5.1
-      safe-array-concat: 1.1.0
-      safe-regex-test: 1.0.2
+      safe-array-concat: 1.0.1
+      safe-regex-test: 1.0.0
       string.prototype.trim: 1.2.8
       string.prototype.trimend: 1.0.7
       string.prototype.trimstart: 1.0.7
@@ -3601,7 +3657,7 @@ packages:
       typed-array-byte-offset: 1.0.0
       typed-array-length: 1.0.4
       unbox-primitive: 1.0.2
-      which-typed-array: 1.1.14
+      which-typed-array: 1.1.13
     dev: true
 
   /es-get-iterator@1.1.3:
@@ -3634,7 +3690,7 @@ packages:
       has-symbols: 1.0.3
       internal-slot: 1.0.6
       iterator.prototype: 1.1.2
-      safe-array-concat: 1.1.0
+      safe-array-concat: 1.0.1
     dev: true
 
   /es-set-tostringtag@2.0.2:
@@ -3642,7 +3698,7 @@ packages:
     engines: {node: '>= 0.4'}
     dependencies:
       get-intrinsic: 1.2.2
-      has-tostringtag: 1.0.2
+      has-tostringtag: 1.0.0
       hasown: 2.0.0
     dev: true
 
@@ -3721,12 +3777,12 @@ packages:
         optional: true
     dependencies:
       '@next/eslint-plugin-next': 14.1.0
-      '@rushstack/eslint-patch': 1.7.2
-      '@typescript-eslint/parser': 6.20.0(eslint@8.56.0)(typescript@5.3.3)
+      '@rushstack/eslint-patch': 1.6.1
+      '@typescript-eslint/parser': 6.17.0(eslint@8.56.0)(typescript@5.3.3)
       eslint: 8.56.0
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@6.20.0)(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1)(eslint@8.56.0)
-      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@6.20.0)(eslint-import-resolver-typescript@3.6.1)(eslint@8.56.0)
+      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@6.17.0)(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1)(eslint@8.56.0)
+      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@6.17.0)(eslint-import-resolver-typescript@3.6.1)(eslint@8.56.0)
       eslint-plugin-jsx-a11y: 6.8.0(eslint@8.56.0)
       eslint-plugin-react: 7.33.2(eslint@8.56.0)
       eslint-plugin-react-hooks: 4.6.0(eslint@8.56.0)
@@ -3755,7 +3811,7 @@ packages:
       - supports-color
     dev: true
 
-  /eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@6.20.0)(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1)(eslint@8.56.0):
+  /eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@6.17.0)(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1)(eslint@8.56.0):
     resolution: {integrity: sha512-xgdptdoi5W3niYeuQxKmzVDTATvLYqhpwmykwsh7f6HIOStGWEIL9iqZgQDF9u9OEzrRwR8no5q2VT+bjAujTg==}
     engines: {node: ^14.18.0 || >=16.0.0}
     peerDependencies:
@@ -3765,8 +3821,8 @@ packages:
       debug: 4.3.4
       enhanced-resolve: 5.15.0
       eslint: 8.56.0
-      eslint-module-utils: 2.8.0(@typescript-eslint/parser@6.20.0)(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1)(eslint@8.56.0)
-      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@6.20.0)(eslint-import-resolver-typescript@3.6.1)(eslint@8.56.0)
+      eslint-module-utils: 2.8.0(@typescript-eslint/parser@6.17.0)(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1)(eslint@8.56.0)
+      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@6.17.0)(eslint-import-resolver-typescript@3.6.1)(eslint@8.56.0)
       fast-glob: 3.3.2
       get-tsconfig: 4.7.2
       is-core-module: 2.13.1
@@ -3778,7 +3834,7 @@ packages:
       - supports-color
     dev: true
 
-  /eslint-module-utils@2.8.0(@typescript-eslint/parser@6.20.0)(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1)(eslint@8.56.0):
+  /eslint-module-utils@2.8.0(@typescript-eslint/parser@6.17.0)(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1)(eslint@8.56.0):
     resolution: {integrity: sha512-aWajIYfsqCKRDgUfjEXNN/JlrzauMuSEy5sbd7WXbtW3EH6A6MpwEh42c7qD+MqQo9QMJ6fWLAeIJynx0g6OAw==}
     engines: {node: '>=4'}
     peerDependencies:
@@ -3799,16 +3855,16 @@ packages:
       eslint-import-resolver-webpack:
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 6.20.0(eslint@8.56.0)(typescript@5.3.3)
+      '@typescript-eslint/parser': 6.17.0(eslint@8.56.0)(typescript@5.3.3)
       debug: 3.2.7
       eslint: 8.56.0
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@6.20.0)(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1)(eslint@8.56.0)
+      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@6.17.0)(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1)(eslint@8.56.0)
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /eslint-plugin-import@2.29.1(@typescript-eslint/parser@6.20.0)(eslint-import-resolver-typescript@3.6.1)(eslint@8.56.0):
+  /eslint-plugin-import@2.29.1(@typescript-eslint/parser@6.17.0)(eslint-import-resolver-typescript@3.6.1)(eslint@8.56.0):
     resolution: {integrity: sha512-BbPC0cuExzhiMo4Ff1BTVwHpjjv28C5R+btTOGaCRC7UEz801up0JadwkeSk5Ued6TG34uaczuVuH6qyy5YUxw==}
     engines: {node: '>=4'}
     peerDependencies:
@@ -3818,7 +3874,7 @@ packages:
       '@typescript-eslint/parser':
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 6.20.0(eslint@8.56.0)(typescript@5.3.3)
+      '@typescript-eslint/parser': 6.17.0(eslint@8.56.0)(typescript@5.3.3)
       array-includes: 3.1.7
       array.prototype.findlastindex: 1.2.3
       array.prototype.flat: 1.3.2
@@ -3827,7 +3883,7 @@ packages:
       doctrine: 2.1.0
       eslint: 8.56.0
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.8.0(@typescript-eslint/parser@6.20.0)(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1)(eslint@8.56.0)
+      eslint-module-utils: 2.8.0(@typescript-eslint/parser@6.17.0)(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1)(eslint@8.56.0)
       hasown: 2.0.0
       is-core-module: 2.13.1
       is-glob: 4.0.3
@@ -3849,7 +3905,7 @@ packages:
     peerDependencies:
       eslint: ^3 || ^4 || ^5 || ^6 || ^7 || ^8
     dependencies:
-      '@babel/runtime': 7.23.9
+      '@babel/runtime': 7.23.7
       aria-query: 5.3.0
       array-includes: 3.1.7
       array.prototype.flatmap: 1.3.2
@@ -3924,7 +3980,7 @@ packages:
       '@eslint-community/regexpp': 4.10.0
       '@eslint/eslintrc': 2.1.4
       '@eslint/js': 8.56.0
-      '@humanwhocodes/config-array': 0.11.14
+      '@humanwhocodes/config-array': 0.11.13
       '@humanwhocodes/module-importer': 1.0.1
       '@nodelib/fs.walk': 1.2.8
       '@ungap/structured-clone': 1.2.0
@@ -3945,7 +4001,7 @@ packages:
       glob-parent: 6.0.2
       globals: 13.24.0
       graphemer: 1.4.0
-      ignore: 5.3.1
+      ignore: 5.3.0
       imurmurhash: 0.1.4
       is-glob: 4.0.3
       is-path-inside: 3.0.3
@@ -4005,7 +4061,7 @@ packages:
   /estree-util-build-jsx@2.2.2:
     resolution: {integrity: sha512-m56vOXcOBuaF+Igpb9OPAy7f9w9OIkb5yhjsZuaPm7HoGi4oTOQi0h2+yZ+AtKklYFZ+rPC4n0wYCJCEU1ONqg==}
     dependencies:
-      '@types/estree-jsx': 1.0.4
+      '@types/estree-jsx': 1.0.3
       estree-util-is-identifier-name: 2.1.0
       estree-walker: 3.0.3
     dev: true
@@ -4017,7 +4073,7 @@ packages:
   /estree-util-to-js@1.2.0:
     resolution: {integrity: sha512-IzU74r1PK5IMMGZXUVZbmiu4A1uhiPgW5hm1GjcOfr4ZzHaMPpLNJjR7HjXiIOzi25nZDrgFTobHTkV5Q6ITjA==}
     dependencies:
-      '@types/estree-jsx': 1.0.4
+      '@types/estree-jsx': 1.0.3
       astring: 1.8.6
       source-map: 0.7.4
     dev: true
@@ -4032,7 +4088,7 @@ packages:
   /estree-util-visit@1.2.1:
     resolution: {integrity: sha512-xbgqcrkIVbIG+lI/gzbvd9SGTJL4zqJKBFttUl5pP27KhAjtMKbX/mQXJ7qgyXpMgVy/zvpm0xoQQaGL8OloOw==}
     dependencies:
-      '@types/estree-jsx': 1.0.4
+      '@types/estree-jsx': 1.0.3
       '@types/unist': 2.0.10
     dev: true
 
@@ -4113,8 +4169,8 @@ packages:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
     dev: true
 
-  /fastq@1.17.0:
-    resolution: {integrity: sha512-zGygtijUMT7jnk3h26kUms3BkSDp4IfIKjmnqI2tvx6nuBfiF1UqOxbnLfzdv+apBy+53oaImsKtMw/xYbW+1w==}
+  /fastq@1.16.0:
+    resolution: {integrity: sha512-ifCoaXsDrsdkWTtiNJX5uzHDsrck5TzfKKDcuFFTIrrc/BS076qgEIfoIy1VeZqViznfKiysPYTh/QeHtnIsYA==}
     dependencies:
       reusify: 1.0.4
     dev: true
@@ -4124,7 +4180,7 @@ packages:
     engines: {node: ^12.20 || >= 14.13}
     dependencies:
       node-domexception: 1.0.0
-      web-streams-polyfill: 3.3.2
+      web-streams-polyfill: 3.2.1
     dev: false
 
   /fflate@0.8.1:
@@ -4165,6 +4221,10 @@ packages:
   /flatted@3.2.9:
     resolution: {integrity: sha512-36yxDn5H7OFZQla0/jFJmbIKTdZAQHngCedGxiMmpNfEZM0sdEeT+WczLQrjK6D7o2aiyLYDnkw0R3JK0Qv1RQ==}
     dev: true
+
+  /flexsearch@0.7.11:
+    resolution: {integrity: sha512-7li2Kv9as1le1QuxK8lflA8D+qsI97wBAu8SPiDFZLtQ1wlakPOo6ytpRvd885tlEJez0qII1DnMpInhee4Y0Q==}
+    dev: false
 
   /flexsearch@0.7.43:
     resolution: {integrity: sha512-c5o/+Um8aqCSOXGcZoqZOm+NqtVwNsvVpWv6lfmSclU954O3wvQKxxK8zj74fPaSJbXpSLTs4PRhh+wnoCXnKg==}
@@ -4371,7 +4431,7 @@ packages:
       array-union: 2.1.0
       dir-glob: 3.0.1
       fast-glob: 3.3.2
-      ignore: 5.3.1
+      ignore: 5.3.0
       merge2: 1.4.1
       slash: 3.0.0
     dev: true
@@ -4439,8 +4499,8 @@ packages:
     engines: {node: '>= 0.4'}
     dev: true
 
-  /has-tostringtag@1.0.2:
-    resolution: {integrity: sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==}
+  /has-tostringtag@1.0.0:
+    resolution: {integrity: sha512-kFjcSNhnlGV1kyoGk7OXKSawH5JOb/LzUc5w9B02hOTO0dfFRjbHQKvg1d6cf3HbeUmtU9VbbV3qzZ2Teh97WQ==}
     engines: {node: '>= 0.4'}
     dependencies:
       has-symbols: 1.0.3
@@ -4465,7 +4525,7 @@ packages:
   /hast-util-from-dom@5.0.0:
     resolution: {integrity: sha512-d6235voAp/XR3Hh5uy7aGLbM3S4KamdW0WEgOaU1YoewnuYw4HXb5eRtv9g65m/RFGEfUY1Mw4UqCc5Y8L4Stg==}
     dependencies:
-      '@types/hast': 3.0.4
+      '@types/hast': 3.0.3
       hastscript: 8.0.0
       web-namespaces: 2.0.1
     dev: true
@@ -4473,7 +4533,7 @@ packages:
   /hast-util-from-html-isomorphic@2.0.0:
     resolution: {integrity: sha512-zJfpXq44yff2hmE0XmwEOzdWin5xwH+QIhMLOScpX91e/NSGPsAzNCvLQDIEPyO2TXi+lBmU6hjLIhV8MwP2kw==}
     dependencies:
-      '@types/hast': 3.0.4
+      '@types/hast': 3.0.3
       hast-util-from-dom: 5.0.0
       hast-util-from-html: 2.0.1
       unist-util-remove-position: 5.0.0
@@ -4482,7 +4542,7 @@ packages:
   /hast-util-from-html@2.0.1:
     resolution: {integrity: sha512-RXQBLMl9kjKVNkJTIO6bZyb2n+cUH8LFaSSzo82jiLT6Tfc+Pt7VQCS+/h3YwG4jaNE2TA2sdJisGWR+aJrp0g==}
     dependencies:
-      '@types/hast': 3.0.4
+      '@types/hast': 3.0.3
       devlop: 1.1.0
       hast-util-from-parse5: 8.0.1
       parse5: 7.1.2
@@ -4493,11 +4553,11 @@ packages:
   /hast-util-from-parse5@8.0.1:
     resolution: {integrity: sha512-Er/Iixbc7IEa7r/XLtuG52zoqn/b3Xng/w6aZQ0xGVxzhw5xUFxcRqdPzP6yFi/4HBYRaifaI5fQ1RH8n0ZeOQ==}
     dependencies:
-      '@types/hast': 3.0.4
+      '@types/hast': 3.0.3
       '@types/unist': 3.0.2
       devlop: 1.1.0
       hastscript: 8.0.0
-      property-information: 6.4.1
+      property-information: 6.4.0
       vfile: 6.0.1
       vfile-location: 5.0.2
       web-namespaces: 2.0.1
@@ -4506,25 +4566,25 @@ packages:
   /hast-util-is-element@3.0.0:
     resolution: {integrity: sha512-Val9mnv2IWpLbNPqc/pUem+a7Ipj2aHacCwgNfTiK0vJKl0LF+4Ba4+v1oPHFpf3bLYmreq0/l3Gud9S5OH42g==}
     dependencies:
-      '@types/hast': 3.0.4
+      '@types/hast': 3.0.3
     dev: true
 
   /hast-util-parse-selector@4.0.0:
     resolution: {integrity: sha512-wkQCkSYoOGCRKERFWcxMVMOcYE2K1AaNLU8DXS9arxnLOUEWbOXKXiJUNzEpqZ3JOKpnha3jkFrumEjVliDe7A==}
     dependencies:
-      '@types/hast': 3.0.4
+      '@types/hast': 3.0.3
     dev: true
 
-  /hast-util-raw@9.0.2:
-    resolution: {integrity: sha512-PldBy71wO9Uq1kyaMch9AHIghtQvIwxBUkv823pKmkTM3oV1JxtsTNYdevMxvUHqcnOAuO65JKU2+0NOxc2ksA==}
+  /hast-util-raw@9.0.1:
+    resolution: {integrity: sha512-5m1gmba658Q+lO5uqL5YNGQWeh1MYWZbZmWrM5lncdcuiXuo5E2HT/CIOp0rLF8ksfSwiCVJ3twlgVRyTGThGA==}
     dependencies:
-      '@types/hast': 3.0.4
+      '@types/hast': 3.0.3
       '@types/unist': 3.0.2
       '@ungap/structured-clone': 1.2.0
       hast-util-from-parse5: 8.0.1
       hast-util-to-parse5: 8.0.0
       html-void-elements: 3.0.0
-      mdast-util-to-hast: 13.1.0
+      mdast-util-to-hast: 13.0.2
       parse5: 7.1.2
       unist-util-position: 5.0.0
       unist-util-visit: 5.0.0
@@ -4537,8 +4597,8 @@ packages:
     resolution: {integrity: sha512-ihhPIUPxN0v0w6M5+IiAZZrn0LH2uZomeWwhn7uP7avZC6TE7lIiEh2yBMPr5+zi1aUCXq6VoYRgs2Bw9xmycQ==}
     dependencies:
       '@types/estree': 1.0.5
-      '@types/estree-jsx': 1.0.4
-      '@types/hast': 2.3.10
+      '@types/estree-jsx': 1.0.3
+      '@types/hast': 2.3.9
       '@types/unist': 2.0.10
       comma-separated-tokens: 2.0.3
       estree-util-attach-comments: 2.1.1
@@ -4546,7 +4606,7 @@ packages:
       hast-util-whitespace: 2.0.1
       mdast-util-mdx-expression: 1.3.2
       mdast-util-mdxjs-esm: 1.3.1
-      property-information: 6.4.1
+      property-information: 6.4.0
       space-separated-tokens: 2.0.2
       style-to-object: 0.4.4
       unist-util-position: 4.0.4
@@ -4558,10 +4618,10 @@ packages:
   /hast-util-to-parse5@8.0.0:
     resolution: {integrity: sha512-3KKrV5ZVI8if87DVSi1vDeByYrkGzg4mEfeu4alwgmmIeARiBLKCZS2uw5Gb6nU9x9Yufyj3iudm6i7nl52PFw==}
     dependencies:
-      '@types/hast': 3.0.4
+      '@types/hast': 3.0.3
       comma-separated-tokens: 2.0.3
       devlop: 1.1.0
-      property-information: 6.4.1
+      property-information: 6.4.0
       space-separated-tokens: 2.0.2
       web-namespaces: 2.0.1
       zwitch: 2.0.4
@@ -4570,7 +4630,7 @@ packages:
   /hast-util-to-text@4.0.0:
     resolution: {integrity: sha512-EWiE1FSArNBPUo1cKWtzqgnuRQwEeQbQtnFJRYV1hb1BWDgrAlBU0ExptvZMM/KSA82cDpm2sFGf3Dmc5Mza3w==}
     dependencies:
-      '@types/hast': 3.0.4
+      '@types/hast': 3.0.3
       '@types/unist': 3.0.2
       hast-util-is-element: 3.0.0
       unist-util-find-after: 5.0.0
@@ -4583,10 +4643,10 @@ packages:
   /hastscript@8.0.0:
     resolution: {integrity: sha512-dMOtzCEd3ABUeSIISmrETiKuyydk1w0pa+gE/uormcTpSYuaNJPbX1NU3JLyscSLjwAQM8bWMhhIlnCqnRvDTw==}
     dependencies:
-      '@types/hast': 3.0.4
+      '@types/hast': 3.0.3
       comma-separated-tokens: 2.0.3
       hast-util-parse-selector: 4.0.0
-      property-information: 6.4.1
+      property-information: 6.4.0
       space-separated-tokens: 2.0.2
     dev: true
 
@@ -4629,8 +4689,8 @@ packages:
       domutils: 3.1.0
       entities: 4.5.0
 
-  /http-proxy-agent@7.0.0:
-    resolution: {integrity: sha512-+ZT+iBxVUQ1asugqnD6oWoRiS25AkjNfG085dKJGtGxkdwLQrMKU5wJr2bOOFAXzKcTuqq+7fZlTMgG3SRfIYQ==}
+  /http-proxy-agent@7.0.2:
+    resolution: {integrity: sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==}
     engines: {node: '>= 14'}
     dependencies:
       agent-base: 7.1.0
@@ -4639,8 +4699,8 @@ packages:
       - supports-color
     dev: true
 
-  /https-proxy-agent@7.0.2:
-    resolution: {integrity: sha512-NmLNjm6ucYwtcUmL7JQC1ZQ57LmHP4lT15FQ8D61nak1rO6DH+fz5qNK2Ap5UN4ZapYICE3/0KodcLYSPsPbaA==}
+  /https-proxy-agent@7.0.4:
+    resolution: {integrity: sha512-wlwpilI7YdjSkWaQ/7omYBMTliDcmCN8OLihO6I9B86g06lMyAoqgoDpV0XqoaPOKj+0DIdAvnsWfyAAhmimcg==}
     engines: {node: '>= 14'}
     dependencies:
       agent-base: 7.1.0
@@ -4660,10 +4720,10 @@ packages:
     hasBin: true
     dev: true
 
-  /i18next@23.8.2:
-    resolution: {integrity: sha512-Z84zyEangrlERm0ZugVy4bIt485e/H8VecGUZkZWrH7BDePG6jT73QdL9EA1tRTTVVMpry/MgWIP1FjEn0DRXA==}
+  /i18next@23.7.13:
+    resolution: {integrity: sha512-DbCPlw6VmURSZa43iOnycxq9o15e+WuBWDBZ3aj+gQZcDz4sgnuKwrcwmP1n8gSSCwCN7CRFGTpnwTd93A16Mg==}
     dependencies:
-      '@babel/runtime': 7.23.9
+      '@babel/runtime': 7.23.7
     dev: false
     optional: true
 
@@ -4674,8 +4734,8 @@ packages:
       safer-buffer: 2.1.2
     dev: true
 
-  /ignore@5.3.1:
-    resolution: {integrity: sha512-5Fytz/IraMjqpwfd34ke28PTVMjZjJG2MPn5t7OE4eUCUNf8BAa7b5WUS9/Qvr6mwOQS7Mk6vdsMno5he+T8Xw==}
+  /ignore@5.3.0:
+    resolution: {integrity: sha512-g7dmpshy+gD7mh88OC9NwSGTKoc3kyLAZQRU1mt53Aw/vnvfXnbC+F/7F7QoYVKbV+KNvJx8wArewKy1vXMtlg==}
     engines: {node: '>= 4'}
     dev: true
 
@@ -4756,7 +4816,7 @@ packages:
     engines: {node: '>= 0.4'}
     dependencies:
       call-bind: 1.0.5
-      has-tostringtag: 1.0.2
+      has-tostringtag: 1.0.0
     dev: true
 
   /is-array-buffer@3.0.2:
@@ -4764,14 +4824,14 @@ packages:
     dependencies:
       call-bind: 1.0.5
       get-intrinsic: 1.2.2
-      is-typed-array: 1.1.13
+      is-typed-array: 1.1.12
     dev: true
 
   /is-async-function@2.0.0:
     resolution: {integrity: sha512-Y1JXKrfykRJGdlDwdKlLpLyMIiWqWvuSd17TvZk68PLAOGOoF4Xyav1z0Xhoi+gCYjZVeC5SI+hYFOfvXmGRCA==}
     engines: {node: '>= 0.4'}
     dependencies:
-      has-tostringtag: 1.0.2
+      has-tostringtag: 1.0.0
     dev: true
 
   /is-bigint@1.0.4:
@@ -4785,7 +4845,7 @@ packages:
     engines: {node: '>= 0.4'}
     dependencies:
       call-bind: 1.0.5
-      has-tostringtag: 1.0.2
+      has-tostringtag: 1.0.0
     dev: true
 
   /is-buffer@2.0.5:
@@ -4808,7 +4868,7 @@ packages:
     resolution: {integrity: sha512-9YQaSxsAiSwcvS33MBk3wTCVnWK+HhF8VZR2jRxehM16QcVOdHqPn4VPHmRK4lSr38n9JriurInLcP90xsYNfQ==}
     engines: {node: '>= 0.4'}
     dependencies:
-      has-tostringtag: 1.0.2
+      has-tostringtag: 1.0.0
     dev: true
 
   /is-decimal@2.0.1:
@@ -4852,7 +4912,7 @@ packages:
     resolution: {integrity: sha512-jsEjy9l3yiXEQ+PsXdmBwEPcOxaXWLspKdplFUVI9vq1iZgIekeC0L167qeu86czQaxed3q/Uzuw0swL0irL8A==}
     engines: {node: '>= 0.4'}
     dependencies:
-      has-tostringtag: 1.0.2
+      has-tostringtag: 1.0.0
     dev: true
 
   /is-glob@4.0.3:
@@ -4879,7 +4939,7 @@ packages:
     resolution: {integrity: sha512-k1U0IRzLMo7ZlYIfzRu23Oh6MiIFasgpb9X76eqfFZAqwH44UI4KTBvBYIZ1dSL9ZzChTB9ShHfLkR4pdW5krQ==}
     engines: {node: '>= 0.4'}
     dependencies:
-      has-tostringtag: 1.0.2
+      has-tostringtag: 1.0.0
     dev: true
 
   /is-number@7.0.0:
@@ -4927,7 +4987,7 @@ packages:
     engines: {node: '>= 0.4'}
     dependencies:
       call-bind: 1.0.5
-      has-tostringtag: 1.0.2
+      has-tostringtag: 1.0.0
     dev: true
 
   /is-set@2.0.2:
@@ -4960,7 +5020,7 @@ packages:
     resolution: {integrity: sha512-tE2UXzivje6ofPW7l23cjDOMa09gb7xlAqG6jG5ej6uPV32TlWP3NKPigtaGeHNu9fohccRYvIiZMfOOnOYUtg==}
     engines: {node: '>= 0.4'}
     dependencies:
-      has-tostringtag: 1.0.2
+      has-tostringtag: 1.0.0
     dev: true
 
   /is-symbol@1.0.4:
@@ -4970,11 +5030,11 @@ packages:
       has-symbols: 1.0.3
     dev: true
 
-  /is-typed-array@1.1.13:
-    resolution: {integrity: sha512-uZ25/bUAlUY5fR4OKT4rZQEBrzQWYV9ZJYGGsUmEJ6thodVJ1HX64ePQ6Z0qPWP+m+Uq6e9UugrE38jeYsDSMw==}
+  /is-typed-array@1.1.12:
+    resolution: {integrity: sha512-Z14TF2JNG8Lss5/HMqt0//T9JeHXttXy5pH/DBU4vi98ozO2btxzq9MwYDZYnKwU8nRsz/+GVFVRDq3DkVuSPg==}
     engines: {node: '>= 0.4'}
     dependencies:
-      which-typed-array: 1.1.14
+      which-typed-array: 1.1.13
     dev: true
 
   /is-weakmap@2.0.1:
@@ -5087,8 +5147,8 @@ packages:
       decimal.js: 10.4.3
       form-data: 4.0.0
       html-encoding-sniffer: 4.0.0
-      http-proxy-agent: 7.0.0
-      https-proxy-agent: 7.0.2
+      http-proxy-agent: 7.0.2
+      https-proxy-agent: 7.0.4
       is-potential-custom-element-name: 1.0.1
       parse5: 7.1.2
       rrweb-cssom: 0.6.0
@@ -5139,8 +5199,8 @@ packages:
     hasBin: true
     dev: true
 
-  /jsonc-parser@3.2.1:
-    resolution: {integrity: sha512-AilxAyFOAcK5wA1+LeaySVBrHsGQvUFCDWXKpZjzaL0PqW+xfBOttn8GNtWKFWqneyMZj41MWF9Kl6iPWLwgOA==}
+  /jsonc-parser@3.2.0:
+    resolution: {integrity: sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w==}
     dev: true
 
   /jsx-ast-utils@3.3.5:
@@ -5195,6 +5255,10 @@ packages:
     resolution: {integrity: sha512-8h2oVEZNktL4BH2JCOI90iD1yXwL6iNW7KcCKT2QZgQJR2vbqDsldCTPRU9NifTCqHZci57XvQQ15YTu+sTYPg==}
     dev: true
 
+  /layout-base@2.0.1:
+    resolution: {integrity: sha512-dp3s92+uNI1hWIpPGH3jK2kxE2lMjdXdr+DH8ynZHpd6PUlH6x6cbuXnoMmiNumznqaNO31xu9e79F0uuZ0JFg==}
+    dev: true
+
   /levn@0.4.1:
     resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
     engines: {node: '>= 0.8.0'}
@@ -5235,7 +5299,7 @@ packages:
       colorette: 2.0.20
       eventemitter3: 5.0.1
       log-update: 6.0.0
-      rfdc: 1.3.1
+      rfdc: 1.3.0
       wrap-ansi: 9.0.0
     dev: true
 
@@ -5243,7 +5307,7 @@ packages:
     resolution: {integrity: sha512-ok6z3qlYyCDS4ZEU27HaU6x/xZa9Whf8jD4ptH5UZTQYZVYeb9bnZ3ojVhiJNLiXK1Hfc0GNbLXcmZ5plLDDBg==}
     engines: {node: '>=14'}
     dependencies:
-      mlly: 1.5.0
+      mlly: 1.4.2
       pkg-types: 1.0.3
     dev: true
 
@@ -5297,8 +5361,8 @@ packages:
       get-func-name: 2.0.2
     dev: true
 
-  /lru-cache@10.2.0:
-    resolution: {integrity: sha512-2bIM8x+VAf6JT4bKAljS1qUWgMsqZRPGJS6FSahIMPVvctcNhyVp7AJu7quxOW9jwkryBReKZY5tY5JYv2n/7Q==}
+  /lru-cache@10.1.0:
+    resolution: {integrity: sha512-/1clY/ui8CzjKFyjdvwPWJUYKiFVXG2I2cY0ssG7h4+hwk+XOIX7ZSG9Q7TW8TW3Kp3BUSqgFWBLgL4PJ+Blag==}
     engines: {node: 14 || >=16.14}
     dev: true
 
@@ -5327,8 +5391,8 @@ packages:
     hasBin: true
     dev: true
 
-  /magic-string@0.30.6:
-    resolution: {integrity: sha512-n62qCLbPjNjyo+owKtveQxZFZTBm+Ms6YoGD23Wew6Vw337PElFNifQpknPruVRQV57kVShPnLGo9vWxVhpPvA==}
+  /magic-string@0.30.5:
+    resolution: {integrity: sha512-7xlpfBaQaP/T6Vh8MO/EqXSW5En6INHEvEXQiuff7Gku0PWjU3uf6w/j9o7O+SpB5fOAkrI5HeoNgwjEO0pFsA==}
     engines: {node: '>=12'}
     dependencies:
       '@jridgewell/sourcemap-codec': 1.4.15
@@ -5337,8 +5401,8 @@ packages:
   /magicast@0.3.3:
     resolution: {integrity: sha512-ZbrP1Qxnpoes8sz47AM0z08U+jW6TyRgZzcWy3Ma3vDhJttwMwAFDMMQFobwdBxByBD46JYmxRzeF7w2+wJEuw==}
     dependencies:
-      '@babel/parser': 7.23.9
-      '@babel/types': 7.23.9
+      '@babel/parser': 7.23.6
+      '@babel/types': 7.23.6
       source-map-js: 1.0.2
     dev: true
 
@@ -5358,11 +5422,11 @@ packages:
     resolution: {integrity: sha512-Z1NL3Tb1M9wH4XESsCDEksWoKTdlUafKc4pt0GRwjUyXaCFZ+dc3g2erqB6zm3szA2IUSi7VnPI+o/9jnxh9hw==}
     dev: true
 
-  /match-sorter@6.3.3:
-    resolution: {integrity: sha512-sgiXxrRijEe0SzHKGX4HouCpfHRPnqteH42UdMEW7BlWy990ZkzcvonJGv4Uu9WE7Y1f8Yocm91+4qFPCbmNww==}
+  /match-sorter@6.3.1:
+    resolution: {integrity: sha512-mxybbo3pPNuA+ZuCUhm5bwNkXrJTbsk5VWbR5wiwz/GC6LIiegBGn2w3O08UG/jdbYLinw51fSQ5xNU1U3MgBw==}
     dependencies:
-      '@babel/runtime': 7.23.9
-      remove-accents: 0.5.0
+      '@babel/runtime': 7.23.7
+      remove-accents: 0.4.2
     dev: true
 
   /mdast-util-definitions@5.1.2:
@@ -5468,8 +5532,8 @@ packages:
   /mdast-util-mdx-expression@1.3.2:
     resolution: {integrity: sha512-xIPmR5ReJDu/DHH1OoIT1HkuybIfRGYRywC+gJtI7qHjCJp/M9jrmBEJW22O8lskDWm562BX2W8TiAwRTb0rKA==}
     dependencies:
-      '@types/estree-jsx': 1.0.4
-      '@types/hast': 2.3.10
+      '@types/estree-jsx': 1.0.3
+      '@types/hast': 2.3.9
       '@types/mdast': 3.0.15
       mdast-util-from-markdown: 1.3.1
       mdast-util-to-markdown: 1.5.0
@@ -5480,8 +5544,8 @@ packages:
   /mdast-util-mdx-jsx@2.1.4:
     resolution: {integrity: sha512-DtMn9CmVhVzZx3f+optVDF8yFgQVt7FghCRNdlIaS3X5Bnym3hZwPbg/XW86vdpKjlc1PVj26SpnLGeJBXD3JA==}
     dependencies:
-      '@types/estree-jsx': 1.0.4
-      '@types/hast': 2.3.10
+      '@types/estree-jsx': 1.0.3
+      '@types/hast': 2.3.9
       '@types/mdast': 3.0.15
       '@types/unist': 2.0.10
       ccount: 2.0.1
@@ -5511,8 +5575,8 @@ packages:
   /mdast-util-mdxjs-esm@1.3.1:
     resolution: {integrity: sha512-SXqglS0HrEvSdUEfoXFtcg7DRl7S2cwOXc7jkuusG472Mmjag34DUDeOJUZtl+BVnyeO1frIgVpHlNRWc2gk/w==}
     dependencies:
-      '@types/estree-jsx': 1.0.4
-      '@types/hast': 2.3.10
+      '@types/estree-jsx': 1.0.3
+      '@types/hast': 2.3.9
       '@types/mdast': 3.0.15
       mdast-util-from-markdown: 1.3.1
       mdast-util-to-markdown: 1.5.0
@@ -5530,7 +5594,7 @@ packages:
   /mdast-util-to-hast@12.3.0:
     resolution: {integrity: sha512-pits93r8PhnIoU4Vy9bjW39M2jJ6/tdHyja9rrot9uujkN7UTU9SDnE6WNJz/IGyQk3XHX6yNNtrBH6cQzm8Hw==}
     dependencies:
-      '@types/hast': 2.3.10
+      '@types/hast': 2.3.9
       '@types/mdast': 3.0.15
       mdast-util-definitions: 5.1.2
       micromark-util-sanitize-uri: 1.2.0
@@ -5540,10 +5604,10 @@ packages:
       unist-util-visit: 4.1.2
     dev: true
 
-  /mdast-util-to-hast@13.1.0:
-    resolution: {integrity: sha512-/e2l/6+OdGp/FB+ctrJ9Avz71AN/GRH3oi/3KAx/kMnoUsD6q0woXlDT8lLEeViVKE7oZxE7RXzvO3T8kF2/sA==}
+  /mdast-util-to-hast@13.0.2:
+    resolution: {integrity: sha512-U5I+500EOOw9e3ZrclN3Is3fRpw8c19SMyNZlZ2IS+7vLsNzb2Om11VpIVOR+/0137GhZsFEF6YiKD5+0Hr2Og==}
     dependencies:
-      '@types/hast': 3.0.4
+      '@types/hast': 3.0.3
       '@types/mdast': 4.0.3
       '@ungap/structured-clone': 1.2.0
       devlop: 1.1.0
@@ -5551,7 +5615,6 @@ packages:
       trim-lines: 3.0.1
       unist-util-position: 5.0.0
       unist-util-visit: 5.0.0
-      vfile: 6.0.1
     dev: true
 
   /mdast-util-to-markdown@1.5.0:
@@ -5586,20 +5649,21 @@ packages:
     engines: {node: '>= 8'}
     dev: true
 
-  /mermaid@10.8.0:
-    resolution: {integrity: sha512-9CzfSreRjdDJxX796+jW4zjEq0DVw5xVF0nWsqff8OTbrt+ml0TZ5PyYUjjUZJa2NYxYJZZXewEquxGiM8qZEA==}
+  /mermaid@10.6.1:
+    resolution: {integrity: sha512-Hky0/RpOw/1il9X8AvzOEChfJtVvmXm+y7JML5C//ePYMy0/9jCEmW1E1g86x9oDfW9+iVEdTV/i+M6KWRNs4A==}
     dependencies:
       '@braintree/sanitize-url': 6.0.4
       '@types/d3-scale': 4.0.8
       '@types/d3-scale-chromatic': 3.0.3
       cytoscape: 3.28.1
       cytoscape-cose-bilkent: 4.1.0(cytoscape@3.28.1)
+      cytoscape-fcose: 2.2.0(cytoscape@3.28.1)
       d3: 7.8.5
       d3-sankey: 0.12.3
       dagre-d3-es: 7.0.10
       dayjs: 1.11.10
-      dompurify: 3.0.8
-      elkjs: 0.9.1
+      dompurify: 3.0.6
+      elkjs: 0.8.2
       khroma: 2.1.0
       lodash-es: 4.17.21
       mdast-util-from-markdown: 1.3.1
@@ -5607,7 +5671,7 @@ packages:
       stylis: 4.3.1
       ts-dedent: 2.2.0
       uuid: 9.0.1
-      web-worker: 1.3.0
+      web-worker: 1.2.0
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -5840,8 +5904,8 @@ packages:
       micromark-util-types: 1.1.0
     dev: true
 
-  /micromark-util-character@2.1.0:
-    resolution: {integrity: sha512-KvOVV+X1yLBfs9dCBSopq/+G1PcgT3lAK07mC4BzXi5E7ahzMAF8oIupDDJ6mievI6F+lAATkbQQlQixJfT3aQ==}
+  /micromark-util-character@2.0.1:
+    resolution: {integrity: sha512-3wgnrmEAJ4T+mGXAUfMvMAbxU9RDG43XmGce4j6CwPtVxB3vfwXSZ6KhFwDzZ3mZHhmPimMAXg71veiBGzeAZw==}
     dependencies:
       micromark-util-symbol: 2.0.0
       micromark-util-types: 2.0.0
@@ -5931,7 +5995,7 @@ packages:
   /micromark-util-sanitize-uri@2.0.0:
     resolution: {integrity: sha512-WhYv5UEcZrbAtlsnPuChHUAsu/iBPOVaEVsntLBIdpibO0ddy8OzavZz3iL2xVvBZOpolujSliP65Kq0/7KIYw==}
     dependencies:
-      micromark-util-character: 2.1.0
+      micromark-util-character: 2.0.1
       micromark-util-encode: 2.0.0
       micromark-util-symbol: 2.0.0
     dev: true
@@ -6046,11 +6110,11 @@ packages:
     resolution: {integrity: sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==}
     dev: false
 
-  /mlly@1.5.0:
-    resolution: {integrity: sha512-NPVQvAY1xr1QoVeG0cy8yUYC7FQcOx6evl/RjT1wL5FvzPnzOysoqB/jmx/DhssT2dYa8nxECLAaFI/+gVLhDQ==}
+  /mlly@1.4.2:
+    resolution: {integrity: sha512-i/Ykufi2t1EZ6NaPLdfnZk2AX8cs0d+mTzVKuPfqPKPatxLApaBoxJQ9x1/uckXtrS/U5oisPMDkNs0yQTaBRg==}
     dependencies:
       acorn: 8.11.3
-      pathe: 1.1.2
+      pathe: 1.1.1
       pkg-types: 1.0.3
       ufo: 1.3.2
     dev: true
@@ -6106,7 +6170,7 @@ packages:
       react: '>=16.0.0'
       react-dom: '>=16.0.0'
     dependencies:
-      next: 14.1.0(@babel/core@7.23.9)(react-dom@18.2.0)(react@18.2.0)
+      next: 14.1.0(@babel/core@7.23.7)(react-dom@18.2.0)(react@18.2.0)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
     dev: true
@@ -6118,12 +6182,12 @@ packages:
       react: '*'
       react-dom: '*'
     dependencies:
-      next: 14.1.0(@babel/core@7.23.9)(react-dom@18.2.0)(react@18.2.0)
+      next: 14.1.0(@babel/core@7.23.7)(react-dom@18.2.0)(react@18.2.0)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
     dev: true
 
-  /next@14.1.0(@babel/core@7.23.9)(react-dom@18.2.0)(react@18.2.0):
+  /next@14.1.0(@babel/core@7.23.7)(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-wlzrsbfeSU48YQBjZhDzOwhWhGsy+uQycR8bHAOt1LY1bn3zZEcDyHQOEoN3aWzQ8LHCAJ1nqrWCc9XF2+O45Q==}
     engines: {node: '>=18.17.0'}
     hasBin: true
@@ -6141,12 +6205,12 @@ packages:
       '@next/env': 14.1.0
       '@swc/helpers': 0.5.2
       busboy: 1.6.0
-      caniuse-lite: 1.0.30001583
+      caniuse-lite: 1.0.30001597
       graceful-fs: 4.2.11
       postcss: 8.4.31
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
-      styled-jsx: 5.1.1(@babel/core@7.23.9)(react@18.2.0)
+      styled-jsx: 5.1.1(@babel/core@7.23.7)(react@18.2.0)
     optionalDependencies:
       '@next/swc-darwin-arm64': 14.1.0
       '@next/swc-darwin-x64': 14.1.0
@@ -6170,7 +6234,7 @@ packages:
       react: '>=16.13.1'
       react-dom: '>=16.13.1'
     dependencies:
-      '@headlessui/react': 1.7.18(react-dom@18.2.0)(react@18.2.0)
+      '@headlessui/react': 1.7.17(react-dom@18.2.0)(react@18.2.0)
       '@popperjs/core': 2.11.8
       clsx: 2.1.0
       escape-string-regexp: 5.0.0
@@ -6178,8 +6242,8 @@ packages:
       focus-visible: 5.2.0
       git-url-parse: 13.1.1
       intersection-observer: 0.12.2
-      match-sorter: 6.3.3
-      next: 14.1.0(@babel/core@7.23.9)(react-dom@18.2.0)(react@18.2.0)
+      match-sorter: 6.3.1
+      next: 14.1.0(@babel/core@7.23.7)(react-dom@18.2.0)(react@18.2.0)
       next-seo: 6.4.0(next@14.1.0)(react-dom@18.2.0)(react@18.2.0)
       next-themes: 0.2.1(next@14.1.0)(react-dom@18.2.0)(react@18.2.0)
       nextra: 2.13.3(next@14.1.0)(react-dom@18.2.0)(react@18.2.0)
@@ -6197,10 +6261,10 @@ packages:
       react: '>=16.13.1'
       react-dom: '>=16.13.1'
     dependencies:
-      '@headlessui/react': 1.7.18(react-dom@18.2.0)(react@18.2.0)
+      '@headlessui/react': 1.7.17(react-dom@18.2.0)(react@18.2.0)
       '@mdx-js/mdx': 2.3.0
       '@mdx-js/react': 2.3.0(react@18.2.0)
-      '@napi-rs/simple-git': 0.1.16
+      '@napi-rs/simple-git': 0.1.9
       '@theguild/remark-mermaid': 0.0.5(react@18.2.0)
       '@theguild/remark-npm2yarn': 0.2.1
       clsx: 2.1.0
@@ -6209,7 +6273,7 @@ packages:
       gray-matter: 4.0.3
       katex: 0.16.9
       lodash.get: 4.4.2
-      next: 14.1.0(@babel/core@7.23.9)(react-dom@18.2.0)(react@18.2.0)
+      next: 14.1.0(@babel/core@7.23.7)(react-dom@18.2.0)(react@18.2.0)
       next-mdx-remote: 4.4.1(react-dom@18.2.0)(react@18.2.0)
       p-limit: 3.1.0
       react: 18.2.0
@@ -6513,7 +6577,7 @@ packages:
     resolution: {integrity: sha512-MkhCqzzBEpPvxxQ71Md0b1Kk51W01lrYvlMzSUaIzNsODdd7mqhiimSZlr+VegAz5Z6Vzt9Xg2ttE//XBhH3EQ==}
     engines: {node: '>=16 || 14 >=14.17'}
     dependencies:
-      lru-cache: 10.2.0
+      lru-cache: 10.1.0
       minipass: 7.0.4
     dev: true
 
@@ -6522,8 +6586,8 @@ packages:
     engines: {node: '>=8'}
     dev: true
 
-  /pathe@1.1.2:
-    resolution: {integrity: sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==}
+  /pathe@1.1.1:
+    resolution: {integrity: sha512-d+RQGp0MAYTIaDBIMmOfMwz3E+LOZnxx1HZd5R18mmCZY0QBlK0LDZfPc8FW8Ed2DlvsuE6PRjroDY+wg4+j/Q==}
     dev: true
 
   /pathval@1.1.1:
@@ -6555,9 +6619,9 @@ packages:
   /pkg-types@1.0.3:
     resolution: {integrity: sha512-nN7pYi0AQqJnoLPC9eHFQ8AcyaixBUOwvqc5TDnIKCMEE6I0y8P7OKA7fPexsXGCGxQDl/cmrLAp26LhcwxZ4A==}
     dependencies:
-      jsonc-parser: 3.2.1
-      mlly: 1.5.0
-      pathe: 1.1.2
+      jsonc-parser: 3.2.0
+      mlly: 1.4.2
+      pathe: 1.1.1
     dev: true
 
   /postcss@8.4.31:
@@ -6569,8 +6633,8 @@ packages:
       source-map-js: 1.0.2
     dev: true
 
-  /postcss@8.4.33:
-    resolution: {integrity: sha512-Kkpbhhdjw2qQs2O2DGX+8m5OVqEcbB9HRBvuYM9pgrjEFUg30A9LmXNlTAUj4S9kgtGyrMbTzVjH7E+s5Re2yg==}
+  /postcss@8.4.32:
+    resolution: {integrity: sha512-D/kj5JNu6oo2EIy+XL/26JEDTlIbB8hw85G8StOE6L74RQAVVP5rej6wxCNqyMbR4RkPfqvezVbPw81Ngd6Kcw==}
     engines: {node: ^10 || ^12 || >=14}
     dependencies:
       nanoid: 3.3.7
@@ -6618,8 +6682,8 @@ packages:
       react-is: 16.13.1
     dev: true
 
-  /property-information@6.4.1:
-    resolution: {integrity: sha512-OHYtXfu5aI2sS2LWFSN5rgJjrQ4pCy8i1jubJLe2QvMF8JJ++HXTUIVWFLfXJoaOfvYYjk2SN8J2wFUWIGXT4w==}
+  /property-information@6.4.0:
+    resolution: {integrity: sha512-9t5qARVofg2xQqKtytzt+lZ4d1Qvj8t5B8fEwXK6qOfgRLgH/b13QlgEyDh033NOS31nXeFbYv7CLUDG1CeifQ==}
     dev: true
 
   /protocols@2.0.1:
@@ -6661,11 +6725,11 @@ packages:
     peerDependencies:
       react: '>=16.13.1'
     dependencies:
-      '@babel/runtime': 7.23.9
+      '@babel/runtime': 7.23.7
       react: 18.2.0
     dev: false
 
-  /react-i18next@11.18.6(i18next@23.8.2)(react-dom@18.2.0)(react@18.2.0):
+  /react-i18next@11.18.6(i18next@23.7.13)(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-yHb2F9BiT0lqoQDt8loZ5gWP331GwctHz9tYQ8A2EIEUu+CcEdjBLQWli1USG3RdWQt3W+jqQLg/d4rrQR96LA==}
     requiresBuild: true
     peerDependencies:
@@ -6679,9 +6743,9 @@ packages:
       react-native:
         optional: true
     dependencies:
-      '@babel/runtime': 7.23.9
+      '@babel/runtime': 7.23.7
       html-parse-stringify: 3.0.1
-      i18next: 23.8.2
+      i18next: 23.7.13
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
     dev: false
@@ -6777,7 +6841,7 @@ packages:
   /redux@4.2.1:
     resolution: {integrity: sha512-LAUYz4lc+Do8/g7aeRa8JkyDErK6ekstQaqWQrNRW//MY1TvCEpMtpTWvlQ+FPbWCx+Xixu/6SHt5N0HR+SB4w==}
     dependencies:
-      '@babel/runtime': 7.23.9
+      '@babel/runtime': 7.23.7
     dev: false
 
   /reflect.getprototypeof@1.0.4:
@@ -6807,7 +6871,7 @@ packages:
   /rehype-katex@7.0.0:
     resolution: {integrity: sha512-h8FPkGE00r2XKU+/acgqwWUlyzve1IiOKwsEkg4pDL3k48PiE0Pt+/uLtVHDVkN1yA4iurZN6UES8ivHVEQV6Q==}
     dependencies:
-      '@types/hast': 3.0.4
+      '@types/hast': 3.0.3
       '@types/katex': 0.16.7
       hast-util-from-html-isomorphic: 2.0.0
       hast-util-to-text: 4.0.0
@@ -6822,7 +6886,7 @@ packages:
     peerDependencies:
       shiki: '*'
     dependencies:
-      '@types/hast': 2.3.10
+      '@types/hast': 2.3.9
       hash-obj: 4.0.0
       parse-numeric-range: 1.3.0
       shiki: 0.14.7
@@ -6831,8 +6895,8 @@ packages:
   /rehype-raw@7.0.0:
     resolution: {integrity: sha512-/aE8hCfKlQeA8LmyeyQvQF3eBiLRGNlfBJEvWH7ivp9sBqs7TNqBL5X3v157rM4IFETqDnIOO+z5M/biZbo9Ww==}
     dependencies:
-      '@types/hast': 3.0.4
-      hast-util-raw: 9.0.2
+      '@types/hast': 3.0.3
+      hast-util-raw: 9.0.1
       vfile: 6.0.1
     dev: true
 
@@ -6887,14 +6951,14 @@ packages:
   /remark-rehype@10.1.0:
     resolution: {integrity: sha512-EFmR5zppdBp0WQeDVZ/b66CWJipB2q2VLNFMabzDSGR66Z2fQii83G5gTBbgGEnEEA0QRussvrFHxk1HWGJskw==}
     dependencies:
-      '@types/hast': 2.3.10
+      '@types/hast': 2.3.9
       '@types/mdast': 3.0.15
       mdast-util-to-hast: 12.3.0
       unified: 10.1.2
     dev: true
 
-  /remove-accents@0.5.0:
-    resolution: {integrity: sha512-8g3/Otx1eJaVD12e31UbJj1YzdtVvzH85HV7t+9MJYk/u3XmkOUJ5Ys9wQrf9PCPK8+xn4ymzqYCiZl6QWKn+A==}
+  /remove-accents@0.4.2:
+    resolution: {integrity: sha512-7pXIJqJOq5tFgG1A2Zxti3Ht8jJF337m4sowbuHsW30ZnkQFnDzy9qBNhgzX8ZLW4+UBcXiiR7SwR6pokHsxiA==}
     dev: true
 
   /require-directory@2.1.1:
@@ -6951,8 +7015,8 @@ packages:
     engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
     dev: true
 
-  /rfdc@1.3.1:
-    resolution: {integrity: sha512-r5a3l5HzYlIC68TpmYKlxWjmOP6wiPJ1vWv2HeLhNsRZMrCkxeqxiHlQ21oXmQ4F3SiryXBHhAD7JZqvOJjFmg==}
+  /rfdc@1.3.0:
+    resolution: {integrity: sha512-V2hovdzFbOi77/WajaSMXk2OLm+xNIeQdMMuB7icj7bk6zi2F8GGAxigcnDFpJHbNyNcgyJDiP+8nOrY5cZGrA==}
     dev: true
 
   /rimraf@3.0.2:
@@ -6974,26 +7038,26 @@ packages:
     resolution: {integrity: sha512-IXgzBWvWQwE6PrDI05OvmXUIruQTcoMDzRsOd5CDvHCVLcLHMTSYvOK5Cm46kWqlV3yAbuSpBZdJ5oP5OUoStg==}
     dev: true
 
-  /rollup@4.9.6:
-    resolution: {integrity: sha512-05lzkCS2uASX0CiLFybYfVkwNbKZG5NFQ6Go0VWyogFTXXbR039UVsegViTntkk4OglHBdF54ccApXRRuXRbsg==}
+  /rollup@4.13.0:
+    resolution: {integrity: sha512-3YegKemjoQnYKmsBlOHfMLVPPA5xLkQ8MHLLSw/fBrFaVkEayL51DilPpNNLq1exr98F2B1TzrV0FUlN3gWRPg==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
     dependencies:
       '@types/estree': 1.0.5
     optionalDependencies:
-      '@rollup/rollup-android-arm-eabi': 4.9.6
-      '@rollup/rollup-android-arm64': 4.9.6
-      '@rollup/rollup-darwin-arm64': 4.9.6
-      '@rollup/rollup-darwin-x64': 4.9.6
-      '@rollup/rollup-linux-arm-gnueabihf': 4.9.6
-      '@rollup/rollup-linux-arm64-gnu': 4.9.6
-      '@rollup/rollup-linux-arm64-musl': 4.9.6
-      '@rollup/rollup-linux-riscv64-gnu': 4.9.6
-      '@rollup/rollup-linux-x64-gnu': 4.9.6
-      '@rollup/rollup-linux-x64-musl': 4.9.6
-      '@rollup/rollup-win32-arm64-msvc': 4.9.6
-      '@rollup/rollup-win32-ia32-msvc': 4.9.6
-      '@rollup/rollup-win32-x64-msvc': 4.9.6
+      '@rollup/rollup-android-arm-eabi': 4.13.0
+      '@rollup/rollup-android-arm64': 4.13.0
+      '@rollup/rollup-darwin-arm64': 4.13.0
+      '@rollup/rollup-darwin-x64': 4.13.0
+      '@rollup/rollup-linux-arm-gnueabihf': 4.13.0
+      '@rollup/rollup-linux-arm64-gnu': 4.13.0
+      '@rollup/rollup-linux-arm64-musl': 4.13.0
+      '@rollup/rollup-linux-riscv64-gnu': 4.13.0
+      '@rollup/rollup-linux-x64-gnu': 4.13.0
+      '@rollup/rollup-linux-x64-musl': 4.13.0
+      '@rollup/rollup-win32-arm64-msvc': 4.13.0
+      '@rollup/rollup-win32-ia32-msvc': 4.13.0
+      '@rollup/rollup-win32-x64-msvc': 4.13.0
       fsevents: 2.3.3
     dev: true
 
@@ -7018,8 +7082,8 @@ packages:
       mri: 1.2.0
     dev: true
 
-  /safe-array-concat@1.1.0:
-    resolution: {integrity: sha512-ZdQ0Jeb9Ofti4hbt5lX3T2JcAamT9hfzYU1MNB+z/jaEbB6wfFfPIR/zEORmZqobkCCJhSjodobH6WHNmJ97dg==}
+  /safe-array-concat@1.0.1:
+    resolution: {integrity: sha512-6XbUAseYE2KtOuGueyeobCySj9L4+66Tn6KQMOPQJrAJEowYKW/YR/MGJZl7FdydUdaFu4LYyDZjxf4/Nmo23Q==}
     engines: {node: '>=0.4'}
     dependencies:
       call-bind: 1.0.5
@@ -7028,9 +7092,8 @@ packages:
       isarray: 2.0.5
     dev: true
 
-  /safe-regex-test@1.0.2:
-    resolution: {integrity: sha512-83S9w6eFq12BBIJYvjMux6/dkirb8+4zJRA9cxNBVb7Wq5fJBW+Xze48WqR8pxua7bDuAaaAxtVVd4Idjp1dBQ==}
-    engines: {node: '>= 0.4'}
+  /safe-regex-test@1.0.0:
+    resolution: {integrity: sha512-JBUUzyOgEwXQY1NuPtvcj/qcBDbDmEvWufhlnXZIm75DEHp+afM1r1ujJpJsV/gSM4t59tpDyPi1sd6ZaPFfsA==}
     dependencies:
       call-bind: 1.0.5
       get-intrinsic: 1.2.2
@@ -7049,7 +7112,7 @@ packages:
       htmlparser2: 8.0.2
       is-plain-object: 5.0.0
       parse-srcset: 1.0.2
-      postcss: 8.4.33
+      postcss: 8.4.32
     dev: false
 
   /saxes@6.0.0:
@@ -7091,12 +7154,11 @@ packages:
       lru-cache: 6.0.0
     dev: true
 
-  /set-function-length@1.2.0:
-    resolution: {integrity: sha512-4DBHDoyHlM1IRPGYcoxexgh67y4ueR53FKV1yyxwFMY7aCqcN/38M1+SwZ/qJQ8iLv7+ck385ot4CcisOAPT9w==}
+  /set-function-length@1.1.1:
+    resolution: {integrity: sha512-VoaqjbBJKiWtg4yRcKBQ7g7wnGnLV3M8oLvVWwOk2PdYY6PEFegR1vezXR0tw6fZGF9csVakIRjrJiy2veSBFQ==}
     engines: {node: '>= 0.4'}
     dependencies:
       define-data-property: 1.1.1
-      function-bind: 1.1.2
       get-intrinsic: 1.2.2
       gopd: 1.0.1
       has-property-descriptors: 1.0.1
@@ -7139,7 +7201,7 @@ packages:
     resolution: {integrity: sha512-dNPAPrxSc87ua2sKJ3H5dQ/6ZaY8RNnaAqK+t0eG7p0Soi2ydiqbGOTaZCqaYvA/uZYfS1LJnemt3Q+mSfcPCg==}
     dependencies:
       ansi-sequence-parser: 1.1.1
-      jsonc-parser: 3.2.1
+      jsonc-parser: 3.2.0
       vscode-oniguruma: 1.7.0
       vscode-textmate: 8.0.0
     dev: true
@@ -7391,7 +7453,7 @@ packages:
       inline-style-parser: 0.1.1
     dev: true
 
-  /styled-jsx@5.1.1(@babel/core@7.23.9)(react@18.2.0):
+  /styled-jsx@5.1.1(@babel/core@7.23.7)(react@18.2.0):
     resolution: {integrity: sha512-pW7uC1l4mBZ8ugbiZrcIsiIvVx1UmTfw7UkC3Um2tmfUq9Bhk8IiyEIPl6F8agHgjzku6j0xQEZbfA5uSgSaCw==}
     engines: {node: '>= 12.0.0'}
     peerDependencies:
@@ -7404,7 +7466,7 @@ packages:
       babel-plugin-macros:
         optional: true
     dependencies:
-      '@babel/core': 7.23.9
+      '@babel/core': 7.23.7
       client-only: 0.0.1
       react: 18.2.0
     dev: true
@@ -7489,8 +7551,8 @@ packages:
     resolution: {integrity: sha512-AD5ih2NlSssTCwsMznbvwMZpJ1cbhkGd2uueNxzv2jDlEeZdU04JQfRnggJQ8DrcVBGjAsCKwFBbDlVNtEMlzw==}
     dev: false
 
-  /tinybench@2.6.0:
-    resolution: {integrity: sha512-N8hW3PG/3aOoZAN5V/NSAEDz0ZixDSSt5b/a05iqtpgfLWMSVuCo7w0k2vVvEjdrIoeGqZzweX2WlyioNIHchA==}
+  /tinybench@2.5.1:
+    resolution: {integrity: sha512-65NKvSuAVDP/n4CqH+a9w2kTlLReS9vhsAP06MWx+/89nMinJyB2icyl58RIcqCmIggpojIGeuJGhjU1aGMBSg==}
     dev: true
 
   /tinypool@0.8.2:
@@ -7578,8 +7640,8 @@ packages:
     engines: {node: '>=6.10'}
     dev: true
 
-  /tsconfck@3.0.1(typescript@5.3.3):
-    resolution: {integrity: sha512-7ppiBlF3UEddCLeI1JRx5m2Ryq+xk4JrZuq4EuYXykipebaq1dV0Fhgr1hb7CkmHt32QSgOZlcqVLEtHBG4/mg==}
+  /tsconfck@3.0.3(typescript@5.3.3):
+    resolution: {integrity: sha512-4t0noZX9t6GcPTfBAbIbbIU4pfpCwh0ueq3S4O/5qXI1VwK1outmxhe9dOiEWqMz3MW2LKgDTpqWV+37IWuVbA==}
     engines: {node: ^18 || >=20}
     hasBin: true
     peerDependencies:
@@ -7636,7 +7698,7 @@ packages:
     dependencies:
       call-bind: 1.0.5
       get-intrinsic: 1.2.2
-      is-typed-array: 1.1.13
+      is-typed-array: 1.1.12
     dev: true
 
   /typed-array-byte-length@1.0.0:
@@ -7646,18 +7708,18 @@ packages:
       call-bind: 1.0.5
       for-each: 0.3.3
       has-proto: 1.0.1
-      is-typed-array: 1.1.13
+      is-typed-array: 1.1.12
     dev: true
 
   /typed-array-byte-offset@1.0.0:
     resolution: {integrity: sha512-RD97prjEt9EL8YgAgpOkf3O4IF9lhJFr9g0htQkm0rchFp/Vx7LW5Q8fSXXub7BXAODyUQohRMyOc3faCPd0hg==}
     engines: {node: '>= 0.4'}
     dependencies:
-      available-typed-arrays: 1.0.6
+      available-typed-arrays: 1.0.5
       call-bind: 1.0.5
       for-each: 0.3.3
       has-proto: 1.0.1
-      is-typed-array: 1.1.13
+      is-typed-array: 1.1.12
     dev: true
 
   /typed-array-length@1.0.4:
@@ -7665,7 +7727,7 @@ packages:
     dependencies:
       call-bind: 1.0.5
       for-each: 0.3.3
-      is-typed-array: 1.1.13
+      is-typed-array: 1.1.12
     dev: true
 
   /typesafe-actions@5.1.0:
@@ -7833,13 +7895,13 @@ packages:
     engines: {node: '>= 4.0.0'}
     dev: true
 
-  /update-browserslist-db@1.0.13(browserslist@4.22.3):
+  /update-browserslist-db@1.0.13(browserslist@4.22.2):
     resolution: {integrity: sha512-xebP81SNcPuNpPP3uzeW1NYXxI3rxyJzF3pD6sH4jE7o/IX+WtSpwnVU+qIsDPyk0d3hmFQ7mjqc6AtV604hbg==}
     hasBin: true
     peerDependencies:
       browserslist: '>= 4.21.0'
     dependencies:
-      browserslist: 4.22.3
+      browserslist: 4.22.2
       escalade: 3.1.1
       picocolors: 1.0.0
     dev: true
@@ -7907,7 +7969,7 @@ packages:
     resolution: {integrity: sha512-/EH/sDgxU2eGxajKdwLCDmQ4FWq+kpi3uCmBGpw1xJtnAxEjlD8j8PEiGWpCIMIs3ciNAgH0d3TTJiUkYzyZjA==}
     engines: {node: '>=10.12.0'}
     dependencies:
-      '@jridgewell/trace-mapping': 0.3.22
+      '@jridgewell/trace-mapping': 0.3.20
       '@types/istanbul-lib-coverage': 2.0.6
       convert-source-map: 2.0.0
     dev: true
@@ -7965,7 +8027,7 @@ packages:
     dependencies:
       cac: 6.7.14
       debug: 4.3.4
-      pathe: 1.1.2
+      pathe: 1.1.1
       picocolors: 1.0.0
       vite: 5.0.12(@types/node@20.11.16)(terser@5.27.0)
     transitivePeerDependencies:
@@ -7989,7 +8051,7 @@ packages:
     dependencies:
       debug: 4.3.4
       globrex: 0.1.2
-      tsconfck: 3.0.1(typescript@5.3.3)
+      tsconfck: 3.0.3(typescript@5.3.3)
       vite: 5.0.12(@types/node@20.11.16)(terser@5.27.0)
     transitivePeerDependencies:
       - supports-color
@@ -8026,8 +8088,8 @@ packages:
     dependencies:
       '@types/node': 20.11.16
       esbuild: 0.19.12
-      postcss: 8.4.33
-      rollup: 4.9.6
+      postcss: 8.4.32
+      rollup: 4.13.0
       terser: 5.27.0
     optionalDependencies:
       fsevents: 2.3.3
@@ -8067,17 +8129,17 @@ packages:
       '@vitest/utils': 1.2.2
       acorn-walk: 8.3.2
       cac: 6.7.14
-      chai: 4.4.1
+      chai: 4.3.10
       debug: 4.3.4
       execa: 8.0.1
       jsdom: 23.2.0
       local-pkg: 0.5.0
-      magic-string: 0.30.6
-      pathe: 1.1.2
+      magic-string: 0.30.5
+      pathe: 1.1.1
       picocolors: 1.0.0
       std-env: 3.7.0
       strip-literal: 1.3.0
-      tinybench: 2.6.0
+      tinybench: 2.5.1
       tinypool: 0.8.2
       vite: 5.0.12(@types/node@20.11.16)(terser@5.27.0)
       vite-node: 1.2.2(@types/node@20.11.16)(terser@5.27.0)
@@ -8118,13 +8180,13 @@ packages:
     resolution: {integrity: sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ==}
     dev: true
 
-  /web-streams-polyfill@3.3.2:
-    resolution: {integrity: sha512-3pRGuxRF5gpuZc0W+EpwQRmCD7gRqcDOMt688KmdlDAgAyaB1XlN0zq2njfDNm44XVdIouE7pZ6GzbdyH47uIQ==}
+  /web-streams-polyfill@3.2.1:
+    resolution: {integrity: sha512-e0MO3wdXWKrLbL0DgGnUV7WHVuw9OUvL4hjgnPkIeEvESk74gAITi5G606JtZPp39cd8HA9VQzCIvA49LpPN5Q==}
     engines: {node: '>= 8'}
     dev: false
 
-  /web-worker@1.3.0:
-    resolution: {integrity: sha512-BSR9wyRsy/KOValMgd5kMyr3JzpdeoR9KVId8u5GVlTTAtNChlsE4yTxeY7zMdNSyOmoKBv8NH2qeRY9Tg+IaA==}
+  /web-worker@1.2.0:
+    resolution: {integrity: sha512-PgF341avzqyx60neE9DD+XS26MMNMoUQRz9NOZwW32nPQrF6p77f1htcnjBSEV8BGMKZ16choqUG4hyI0Hx7mA==}
     dev: true
 
   /webidl-conversions@3.0.1:
@@ -8178,7 +8240,7 @@ packages:
     engines: {node: '>= 0.4'}
     dependencies:
       function.prototype.name: 1.1.6
-      has-tostringtag: 1.0.2
+      has-tostringtag: 1.0.0
       is-async-function: 2.0.0
       is-date-object: 1.0.5
       is-finalizationregistry: 1.0.2
@@ -8188,7 +8250,7 @@ packages:
       isarray: 2.0.5
       which-boxed-primitive: 1.0.2
       which-collection: 1.0.1
-      which-typed-array: 1.1.14
+      which-typed-array: 1.1.13
     dev: true
 
   /which-collection@1.0.1:
@@ -8200,15 +8262,15 @@ packages:
       is-weakset: 2.0.2
     dev: true
 
-  /which-typed-array@1.1.14:
-    resolution: {integrity: sha512-VnXFiIW8yNn9kIHN88xvZ4yOWchftKDsRJ8fEPacX/wl1lOvBrhsJ/OeJCXq7B0AaijRuqgzSKalJoPk+D8MPg==}
+  /which-typed-array@1.1.13:
+    resolution: {integrity: sha512-P5Nra0qjSncduVPEAr7xhoF5guty49ArDTwzJ/yNuPIbZppyRxFQsRCWrocxIY+CnMVG+qfbU2FmDKyvSGClow==}
     engines: {node: '>= 0.4'}
     dependencies:
-      available-typed-arrays: 1.0.6
+      available-typed-arrays: 1.0.5
       call-bind: 1.0.5
       for-each: 0.3.3
       gopd: 1.0.1
-      has-tostringtag: 1.0.2
+      has-tostringtag: 1.0.0
     dev: true
 
   /which@1.3.1:

--- a/public/manifest/annotations/commenting.json
+++ b/public/manifest/annotations/commenting.json
@@ -1,0 +1,329 @@
+{
+  "@context": "http://iiif.io/api/presentation/3/context.json",
+  "id": "http://localhost:3000/manifest/annotations/commenting.json",
+  "type": "Manifest",
+  "label": {
+    "none": ["مقامات الدين الثلاثة"]
+  },
+  "metadata": [
+    {
+      "label": {
+        "none": ["Contributor"]
+      },
+      "value": {
+        "none": [
+          "Malik al-Manṣūr, Muḥammad ibn ʻUmar, -1221 (Contributor)",
+          "Paden, John N. (Collector)",
+          "عيسي فري ابو بكر طن ديب كماشي غانه (Contributor)",
+          "`Isa Fari Abu Bakr Dan Dibi, Kumasi Ghana (Contributor)"
+        ]
+      }
+    },
+    {
+      "label": {
+        "none": ["Department"]
+      },
+      "value": {
+        "none": ["Herskovits Library of African Studies"]
+      }
+    },
+    {
+      "label": {
+        "none": ["Dimensions"]
+      },
+      "value": {
+        "none": ["18 x 23 cm"]
+      }
+    },
+    {
+      "label": {
+        "none": ["Genre"]
+      },
+      "value": {
+        "none": ["Prose: response", "نثر: جواب"]
+      }
+    },
+    {
+      "label": {
+        "none": ["Language"]
+      },
+      "value": {
+        "none": ["Arabic"]
+      }
+    },
+    {
+      "label": {
+        "none": ["Materials"]
+      },
+      "value": {
+        "none": ["11 pages"]
+      }
+    },
+    {
+      "label": {
+        "none": ["Rights Statement"]
+      },
+      "value": {
+        "none": ["No Copyright - United States"]
+      }
+    },
+    {
+      "label": {
+        "none": ["Series"]
+      },
+      "value": {
+        "none": [
+          "Arabic Manuscripts from West Africa--The John Paden Collection"
+        ]
+      }
+    },
+    {
+      "label": {
+        "none": ["Subject"]
+      },
+      "value": {
+        "none": ["Belief: foundations", "عقيدة: أصول"]
+      }
+    }
+  ],
+  "items": [
+    {
+      "id": "http://localhost:3000/manifest/annotations/commenting/canvas/2",
+      "type": "Canvas",
+      "height": 2764,
+      "width": 2190,
+      "label": {
+        "none": ["recto"]
+      },
+      "thumbnail": [
+        {
+          "id": "https://iiif.dc.library.northwestern.edu/iiif/2/1a403893-ad64-4de9-8248-56d589baed57/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "format": "image/jpeg",
+          "height": 300,
+          "width": 300,
+          "service": [
+            {
+              "@id": "https://iiif.dc.library.northwestern.edu/iiif/2/1a403893-ad64-4de9-8248-56d589baed57",
+              "@type": "ImageService2",
+              "profile": "http://iiif.io/api/image/2/level2.json"
+            }
+          ]
+        }
+      ],
+      "items": [
+        {
+          "id": "http://localhost:3000/manifest/annotations/commenting/canvas/2/page",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "http://localhost:3000/manifest/annotations/commenting/canvas/2/annotation/0",
+              "type": "Annotation",
+              "motivation": "painting",
+              "target": "http://localhost:3000/manifest/annotations/commenting/canvas/2",
+              "body": {
+                "id": "https://iiif.dc.library.northwestern.edu/iiif/2/1a403893-ad64-4de9-8248-56d589baed57/full/600,/0/default.jpg",
+                "type": "Image",
+                "format": "image/tiff",
+                "height": 2764,
+                "width": 2190,
+                "service": [
+                  {
+                    "@id": "https://iiif.dc.library.northwestern.edu/iiif/2/1a403893-ad64-4de9-8248-56d589baed57",
+                    "@type": "ImageService2",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ],
+      "placeholderCanvas": {
+        "id": "https://api.dc.library.northwestern.edu/api/v2/works/4044e95f-8cf1-45e0-9c94-87722d9a1b3a?as=iiif/canvas/access/2/placeholder",
+        "type": "Canvas",
+        "width": 640,
+        "height": 807,
+        "items": [
+          {
+            "id": "https://api.dc.library.northwestern.edu/api/v2/works/4044e95f-8cf1-45e0-9c94-87722d9a1b3a?as=iiif/canvas/access/2/placeholder/annotation-page/0",
+            "type": "AnnotationPage",
+            "items": [
+              {
+                "id": "https://api.dc.library.northwestern.edu/api/v2/works/4044e95f-8cf1-45e0-9c94-87722d9a1b3a?as=iiif/canvas/access/2/placeholder/annotation/0",
+                "type": "Annotation",
+                "motivation": "painting",
+                "body": {
+                  "id": "https://iiif.dc.library.northwestern.edu/iiif/2/1a403893-ad64-4de9-8248-56d589baed57/full/!640,807/0/default.jpg",
+                  "type": "Image",
+                  "format": "image/tiff",
+                  "width": 640,
+                  "height": 807,
+                  "service": [
+                    {
+                      "@id": "https://iiif.dc.library.northwestern.edu/iiif/2/1a403893-ad64-4de9-8248-56d589baed57",
+                      "@type": "ImageService2",
+                      "profile": "http://iiif.io/api/image/2/level2.json"
+                    }
+                  ]
+                },
+                "target": "https://api.dc.library.northwestern.edu/api/v2/works/4044e95f-8cf1-45e0-9c94-87722d9a1b3a?as=iiif/canvas/access/2/placeholder"
+              }
+            ]
+          }
+        ]
+      },
+      "annotations": [
+        {
+          "id": "http://localhost:3000/manifest/annotations/commenting/canvas/2/annotations",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "http://localhost:3000/manifest/annotations/commenting/canvas/2/annotations/transcription",
+              "type": "Annotation",
+              "motivation": "commenting",
+              "body": {
+                "type": "TextualBody",
+                "language": "ar",
+                "format": "text/plain",
+                "value": "بسم الله الرحمن الرحيم وصلي الله على نبيه الكريم محمد خير الانام وعلى آله وأصحابه النجوم الحمد لله السلام المؤمن المحسن سبحانه هو الملك التواب الرحيم الرقيب المهيمن  .\n\n‏والسلمان على الصراط المستقيم التقي النقي الصادق المخلص المتخلق بالخلق العظيم المراقب المشاهد عين المعرف الأقو العبد المتصف بصفات سيد الأعظم ورضوان الاتم عن ناصر الحق بالحق الهادي إلى صراطك المستقيم وعلى آله حق قدره ومقداره العظيم اما بعد .\n \n‏ فقد وقفت على كتابك الكريم و خطابك السليم أيها المحب الأرضى والقدوة المرتضى عمر بن مالك لطف بنا وبك المالك ووقفت على سؤالكم عن مقامات الدين الثلاث وما لها من المنازل وما حقيقة تلك الخصال وقد تكلم السيد العارف بالله عبيدة ابن انبوجة فيه في الميزاب في مباحث طويلة وحيث لم نجد فيه مقنعا في ذلك فهاك مني ما امكن لي كتبه مما يتعلق به خاطري و نصه.\n"
+              },
+              "target": "http://localhost:3000/manifest/annotations/commenting/canvas/2"
+            },
+            {
+              "id": "http://localhost:3000/manifest/annotations/commenting/canvas/2/annotations/translation",
+              "type": "Annotation",
+              "motivation": "commenting",
+              "body": {
+                "type": "TextualBody",
+                "language": "en",
+                "format": "text/plain",
+                "value": "[Foreword] \n\nIn the Name of God, the Merciful, the Compassionate. May God bless our Noble Prophet Muḥammad, the best of all creation, and his family and his companions, the stars.1 \n\nAll praise is due to God, the (source of) peace, the grantor of faith, the guide to excellence, Exalted is He. He is the King, the Acceptor of Repentance, the Merciful, the Watchful, and the Protector. \n\nMay peace and blessings (al-salāmān) be upon (Muḥammad,) the straight path, the consciously aware, the pure, the truthful, the sincere, endowed with magnificent character, the contemplative, the witness, the source of the most perfect divine knowledge, the servant2 described with the attributes of the Greatest Master. May God’s utmost satisfaction be upon the one who makes the Truth victorious by the Truth, the guide to the straight path, and upon his family, in accordance with his rank and his immense degree.3 \n\nI have received your noble letter and your cogent message, O ʿUmar, son of Mālik,4 most pleasing lover and model of God’s satisfaction, may the Proprietor (al-Mālik)5 treat us and you with kindness. I have also received your questions concerning the three stations (maqāmāt) of religion, the corresponding abodes (manāzil), and the realities of these properties. The knower of God Sayyid ʿUbayda ibn Anbūja spoke about this in (his book) al-Mīzāb6 in long sections. As you have not found there what satisfied you regarding these matters, here is what I was able to write down from my recollection. \n\nThis is the text: "
+              },
+              "target": "http://localhost:3000/manifest/annotations/commenting/canvas/2"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "http://localhost:3000/manifest/annotations/commenting/canvas/3",
+      "type": "Canvas",
+      "height": 2749,
+      "width": 2182,
+      "label": {
+        "none": ["verso"]
+      },
+      "thumbnail": [
+        {
+          "id": "https://iiif.dc.library.northwestern.edu/iiif/2/acc02fba-6537-4c4d-ac78-b8a0cde33178/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "format": "image/jpeg",
+          "height": 300,
+          "width": 300,
+          "service": [
+            {
+              "@id": "https://iiif.dc.library.northwestern.edu/iiif/2/acc02fba-6537-4c4d-ac78-b8a0cde33178",
+              "@type": "ImageService2",
+              "profile": "http://iiif.io/api/image/2/level2.json"
+            }
+          ]
+        }
+      ],
+      "items": [
+        {
+          "id": "http://localhost:3000/manifest/annotations/commenting/canvas/3/page",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "http://localhost:3000/manifest/annotations/commenting/canvas/3/annotation/0",
+              "type": "Annotation",
+              "motivation": "painting",
+              "target": "http://localhost:3000/manifest/annotations/commenting/canvas/3",
+              "body": {
+                "id": "https://iiif.dc.library.northwestern.edu/iiif/2/acc02fba-6537-4c4d-ac78-b8a0cde33178/full/600,/0/default.jpg",
+                "type": "Image",
+                "format": "image/tiff",
+                "height": 2749,
+                "width": 2182,
+                "service": [
+                  {
+                    "@id": "https://iiif.dc.library.northwestern.edu/iiif/2/acc02fba-6537-4c4d-ac78-b8a0cde33178",
+                    "@type": "ImageService2",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ],
+      "placeholderCanvas": {
+        "id": "https://api.dc.library.northwestern.edu/api/v2/works/4044e95f-8cf1-45e0-9c94-87722d9a1b3a?as=iiif/canvas/access/3/placeholder",
+        "type": "Canvas",
+        "width": 640,
+        "height": 806,
+        "items": [
+          {
+            "id": "https://api.dc.library.northwestern.edu/api/v2/works/4044e95f-8cf1-45e0-9c94-87722d9a1b3a?as=iiif/canvas/access/3/placeholder/annotation-page/0",
+            "type": "AnnotationPage",
+            "items": [
+              {
+                "id": "https://api.dc.library.northwestern.edu/api/v2/works/4044e95f-8cf1-45e0-9c94-87722d9a1b3a?as=iiif/canvas/access/3/placeholder/annotation/0",
+                "type": "Annotation",
+                "motivation": "painting",
+                "body": {
+                  "id": "https://iiif.dc.library.northwestern.edu/iiif/2/acc02fba-6537-4c4d-ac78-b8a0cde33178/full/!640,806/0/default.jpg",
+                  "type": "Image",
+                  "format": "image/tiff",
+                  "width": 640,
+                  "height": 806,
+                  "service": [
+                    {
+                      "@id": "https://iiif.dc.library.northwestern.edu/iiif/2/acc02fba-6537-4c4d-ac78-b8a0cde33178",
+                      "@type": "ImageService2",
+                      "profile": "http://iiif.io/api/image/2/level2.json"
+                    }
+                  ]
+                },
+                "target": "https://api.dc.library.northwestern.edu/api/v2/works/4044e95f-8cf1-45e0-9c94-87722d9a1b3a?as=iiif/canvas/access/3/placeholder"
+              }
+            ]
+          }
+        ]
+      },
+      "annotations": [
+        {
+          "id": "http://localhost:3000/manifest/annotations/commenting/canvas/3/annotations",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "http://localhost:3000/manifest/annotations/commenting/canvas/3/annotations/transcription",
+              "type": "Annotation",
+              "motivation": "commenting",
+              "body": {
+                "type": "TextualBody",
+                "language": "ar",
+                "format": "text/plain",
+                "value": "ونصه لا اله الا الله مقامات الدين ثلاث\n الإسلام والإيمان والإحسان. فالإسلام قول لا اله الا الله والإيمان العلم بأنه لا اله الا الله والإحسان الجريان في مقتضى لا اله الا الله وهو أن تقول كلام حال ومقال الله.\n \n‏والكلمة الشريفة هي كلمة التوبة و كلمة التقوى وكلمة الإخلاص و كلمة التوحيد وكلمة الطيبة ولها ثلاثة مراتب \nو مرتبتها الأولى هي مقام الإسلام وهو القيام بمقتضى خطاب الحكمة في حضرة الناسوت \n‏والمرتبة الثانية التي هي العلم بأنه لا اله الا الله هي مقام الايمان\n‏والمرتبة الثالثة التي هي قول الله مقام الإحسان \nفالمقامات إذا متبانية غير متباينة حيث أن المضار على لا اله الا الله\n‏واما المنازل فأول منازل الإسلام التوبة هي الخروج من كفر النعمة فكل نعمة شكرها صرفها في مرضات المنعم و ضد الشكر كفر وقال علماء\n"
+              },
+              "target": "http://localhost:3000/manifest/annotations/commenting/canvas/3"
+            },
+            {
+              "id": "http://localhost:3000/manifest/annotations/commenting/canvas/3/annotations/translation",
+              "type": "Annotation",
+              "motivation": "commenting",
+              "body": {
+                "type": "TextualBody",
+                "language": "en",
+                "format": "text/plain",
+                "value": "[Introduction] \n\n“There is no deity but God” constitutes the three stations of religion, (which are) submission (islām), faith (īmān), and excellence (iḥsān). Submission is pronouncing (the words) “there is no deity but God,” faith is knowing that there is no deity but God, and excellence is moving in accordance with “there is no deity but God,”which means that, when you make an utterance in a spiritual state (ḥāl), what you say is (the word) “God.” \n\nThe noble word (i.e., the phrase “There is no deity but God”) is the word of repentance (tawba), the word of God-consciousness (taqwā), the word of sincerity (ikhlāṣ), the word of Divine Unity (tawḥīd), and the good word. It has three levels (marātib). Its first level is the station of submission, and it is acting in the earthly plane (ḥaḍrat al-nāsūt) according to the exigencies of the speech of wisdom. The second level, which is knowing that there is no deity but God, is the station of faith. The third level, which is uttering the word “God,” is the station of excellence. Thus, the stations are different and (at the same time) not different as they all revolve around “There is no deity but God.” "
+              },
+              "target": "http://localhost:3000/manifest/annotations/commenting/canvas/3"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/public/manifest/annotations/transcribing-translating.json
+++ b/public/manifest/annotations/transcribing-translating.json
@@ -1,0 +1,329 @@
+{
+  "@context": "http://iiif.io/api/presentation/3/context.json",
+  "id": "http://localhost:3000/manifest/annotations/transcribing-translating.json",
+  "type": "Manifest",
+  "label": {
+    "none": ["مقامات الدين الثلاثة"]
+  },
+  "metadata": [
+    {
+      "label": {
+        "none": ["Contributor"]
+      },
+      "value": {
+        "none": [
+          "Malik al-Manṣūr, Muḥammad ibn ʻUmar, -1221 (Contributor)",
+          "Paden, John N. (Collector)",
+          "عيسي فري ابو بكر طن ديب كماشي غانه (Contributor)",
+          "`Isa Fari Abu Bakr Dan Dibi, Kumasi Ghana (Contributor)"
+        ]
+      }
+    },
+    {
+      "label": {
+        "none": ["Department"]
+      },
+      "value": {
+        "none": ["Herskovits Library of African Studies"]
+      }
+    },
+    {
+      "label": {
+        "none": ["Dimensions"]
+      },
+      "value": {
+        "none": ["18 x 23 cm"]
+      }
+    },
+    {
+      "label": {
+        "none": ["Genre"]
+      },
+      "value": {
+        "none": ["Prose: response", "نثر: جواب"]
+      }
+    },
+    {
+      "label": {
+        "none": ["Language"]
+      },
+      "value": {
+        "none": ["Arabic"]
+      }
+    },
+    {
+      "label": {
+        "none": ["Materials"]
+      },
+      "value": {
+        "none": ["11 pages"]
+      }
+    },
+    {
+      "label": {
+        "none": ["Rights Statement"]
+      },
+      "value": {
+        "none": ["No Copyright - United States"]
+      }
+    },
+    {
+      "label": {
+        "none": ["Series"]
+      },
+      "value": {
+        "none": [
+          "Arabic Manuscripts from West Africa--The John Paden Collection"
+        ]
+      }
+    },
+    {
+      "label": {
+        "none": ["Subject"]
+      },
+      "value": {
+        "none": ["Belief: foundations", "عقيدة: أصول"]
+      }
+    }
+  ],
+  "items": [
+    {
+      "id": "http://localhost:3000/manifest/annotations/transcribing-translating/canvas/2",
+      "type": "Canvas",
+      "height": 2764,
+      "width": 2190,
+      "label": {
+        "none": ["recto"]
+      },
+      "thumbnail": [
+        {
+          "id": "https://iiif.dc.library.northwestern.edu/iiif/2/1a403893-ad64-4de9-8248-56d589baed57/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "format": "image/jpeg",
+          "height": 300,
+          "width": 300,
+          "service": [
+            {
+              "@id": "https://iiif.dc.library.northwestern.edu/iiif/2/1a403893-ad64-4de9-8248-56d589baed57",
+              "@type": "ImageService2",
+              "profile": "http://iiif.io/api/image/2/level2.json"
+            }
+          ]
+        }
+      ],
+      "items": [
+        {
+          "id": "http://localhost:3000/manifest/annotations/transcribing-translating/canvas/2/page",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "http://localhost:3000/manifest/annotations/transcribing-translating/canvas/2/annotation/0",
+              "type": "Annotation",
+              "motivation": "painting",
+              "target": "http://localhost:3000/manifest/annotations/transcribing-translating/canvas/2",
+              "body": {
+                "id": "https://iiif.dc.library.northwestern.edu/iiif/2/1a403893-ad64-4de9-8248-56d589baed57/full/600,/0/default.jpg",
+                "type": "Image",
+                "format": "image/tiff",
+                "height": 2764,
+                "width": 2190,
+                "service": [
+                  {
+                    "@id": "https://iiif.dc.library.northwestern.edu/iiif/2/1a403893-ad64-4de9-8248-56d589baed57",
+                    "@type": "ImageService2",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ],
+      "placeholderCanvas": {
+        "id": "https://api.dc.library.northwestern.edu/api/v2/works/4044e95f-8cf1-45e0-9c94-87722d9a1b3a?as=iiif/canvas/access/2/placeholder",
+        "type": "Canvas",
+        "width": 640,
+        "height": 807,
+        "items": [
+          {
+            "id": "https://api.dc.library.northwestern.edu/api/v2/works/4044e95f-8cf1-45e0-9c94-87722d9a1b3a?as=iiif/canvas/access/2/placeholder/annotation-page/0",
+            "type": "AnnotationPage",
+            "items": [
+              {
+                "id": "https://api.dc.library.northwestern.edu/api/v2/works/4044e95f-8cf1-45e0-9c94-87722d9a1b3a?as=iiif/canvas/access/2/placeholder/annotation/0",
+                "type": "Annotation",
+                "motivation": "painting",
+                "body": {
+                  "id": "https://iiif.dc.library.northwestern.edu/iiif/2/1a403893-ad64-4de9-8248-56d589baed57/full/!640,807/0/default.jpg",
+                  "type": "Image",
+                  "format": "image/tiff",
+                  "width": 640,
+                  "height": 807,
+                  "service": [
+                    {
+                      "@id": "https://iiif.dc.library.northwestern.edu/iiif/2/1a403893-ad64-4de9-8248-56d589baed57",
+                      "@type": "ImageService2",
+                      "profile": "http://iiif.io/api/image/2/level2.json"
+                    }
+                  ]
+                },
+                "target": "https://api.dc.library.northwestern.edu/api/v2/works/4044e95f-8cf1-45e0-9c94-87722d9a1b3a?as=iiif/canvas/access/2/placeholder"
+              }
+            ]
+          }
+        ]
+      },
+      "annotations": [
+        {
+          "id": "http://localhost:3000/manifest/annotations/transcribing-translating/canvas/2/annotations",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "http://localhost:3000/manifest/annotations/transcribing-translating/canvas/2/annotations/transcription",
+              "type": "Annotation",
+              "motivation": "transcribing",
+              "body": {
+                "type": "TextualBody",
+                "language": "ar",
+                "format": "text/plain",
+                "value": "بسم الله الرحمن الرحيم وصلي الله على نبيه الكريم محمد خير الانام وعلى آله وأصحابه النجوم الحمد لله السلام المؤمن المحسن سبحانه هو الملك التواب الرحيم الرقيب المهيمن  .\n\n‏والسلمان على الصراط المستقيم التقي النقي الصادق المخلص المتخلق بالخلق العظيم المراقب المشاهد عين المعرف الأقو العبد المتصف بصفات سيد الأعظم ورضوان الاتم عن ناصر الحق بالحق الهادي إلى صراطك المستقيم وعلى آله حق قدره ومقداره العظيم اما بعد .\n \n‏ فقد وقفت على كتابك الكريم و خطابك السليم أيها المحب الأرضى والقدوة المرتضى عمر بن مالك لطف بنا وبك المالك ووقفت على سؤالكم عن مقامات الدين الثلاث وما لها من المنازل وما حقيقة تلك الخصال وقد تكلم السيد العارف بالله عبيدة ابن انبوجة فيه في الميزاب في مباحث طويلة وحيث لم نجد فيه مقنعا في ذلك فهاك مني ما امكن لي كتبه مما يتعلق به خاطري و نصه.\n"
+              },
+              "target": "http://localhost:3000/manifest/annotations/transcribing-translating/canvas/2"
+            },
+            {
+              "id": "http://localhost:3000/manifest/annotations/transcribing-translating/canvas/2/annotations/translation",
+              "type": "Annotation",
+              "motivation": "translating",
+              "body": {
+                "type": "TextualBody",
+                "language": "en",
+                "format": "text/plain",
+                "value": "[Foreword] \n\nIn the Name of God, the Merciful, the Compassionate. May God bless our Noble Prophet Muḥammad, the best of all creation, and his family and his companions, the stars.1 \n\nAll praise is due to God, the (source of) peace, the grantor of faith, the guide to excellence, Exalted is He. He is the King, the Acceptor of Repentance, the Merciful, the Watchful, and the Protector. \n\nMay peace and blessings (al-salāmān) be upon (Muḥammad,) the straight path, the consciously aware, the pure, the truthful, the sincere, endowed with magnificent character, the contemplative, the witness, the source of the most perfect divine knowledge, the servant2 described with the attributes of the Greatest Master. May God’s utmost satisfaction be upon the one who makes the Truth victorious by the Truth, the guide to the straight path, and upon his family, in accordance with his rank and his immense degree.3 \n\nI have received your noble letter and your cogent message, O ʿUmar, son of Mālik,4 most pleasing lover and model of God’s satisfaction, may the Proprietor (al-Mālik)5 treat us and you with kindness. I have also received your questions concerning the three stations (maqāmāt) of religion, the corresponding abodes (manāzil), and the realities of these properties. The knower of God Sayyid ʿUbayda ibn Anbūja spoke about this in (his book) al-Mīzāb6 in long sections. As you have not found there what satisfied you regarding these matters, here is what I was able to write down from my recollection. \n\nThis is the text: "
+              },
+              "target": "http://localhost:3000/manifest/annotations/transcribing-translating/canvas/2"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "http://localhost:3000/manifest/annotations/transcribing-translating/canvas/3",
+      "type": "Canvas",
+      "height": 2749,
+      "width": 2182,
+      "label": {
+        "none": ["verso"]
+      },
+      "thumbnail": [
+        {
+          "id": "https://iiif.dc.library.northwestern.edu/iiif/2/acc02fba-6537-4c4d-ac78-b8a0cde33178/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "format": "image/jpeg",
+          "height": 300,
+          "width": 300,
+          "service": [
+            {
+              "@id": "https://iiif.dc.library.northwestern.edu/iiif/2/acc02fba-6537-4c4d-ac78-b8a0cde33178",
+              "@type": "ImageService2",
+              "profile": "http://iiif.io/api/image/2/level2.json"
+            }
+          ]
+        }
+      ],
+      "items": [
+        {
+          "id": "http://localhost:3000/manifest/annotations/transcribing-translating/canvas/3/page",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "http://localhost:3000/manifest/annotations/transcribing-translating/canvas/3/annotation/0",
+              "type": "Annotation",
+              "motivation": "painting",
+              "target": "http://localhost:3000/manifest/annotations/transcribing-translating/canvas/3",
+              "body": {
+                "id": "https://iiif.dc.library.northwestern.edu/iiif/2/acc02fba-6537-4c4d-ac78-b8a0cde33178/full/600,/0/default.jpg",
+                "type": "Image",
+                "format": "image/tiff",
+                "height": 2749,
+                "width": 2182,
+                "service": [
+                  {
+                    "@id": "https://iiif.dc.library.northwestern.edu/iiif/2/acc02fba-6537-4c4d-ac78-b8a0cde33178",
+                    "@type": "ImageService2",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ],
+      "placeholderCanvas": {
+        "id": "https://api.dc.library.northwestern.edu/api/v2/works/4044e95f-8cf1-45e0-9c94-87722d9a1b3a?as=iiif/canvas/access/3/placeholder",
+        "type": "Canvas",
+        "width": 640,
+        "height": 806,
+        "items": [
+          {
+            "id": "https://api.dc.library.northwestern.edu/api/v2/works/4044e95f-8cf1-45e0-9c94-87722d9a1b3a?as=iiif/canvas/access/3/placeholder/annotation-page/0",
+            "type": "AnnotationPage",
+            "items": [
+              {
+                "id": "https://api.dc.library.northwestern.edu/api/v2/works/4044e95f-8cf1-45e0-9c94-87722d9a1b3a?as=iiif/canvas/access/3/placeholder/annotation/0",
+                "type": "Annotation",
+                "motivation": "painting",
+                "body": {
+                  "id": "https://iiif.dc.library.northwestern.edu/iiif/2/acc02fba-6537-4c4d-ac78-b8a0cde33178/full/!640,806/0/default.jpg",
+                  "type": "Image",
+                  "format": "image/tiff",
+                  "width": 640,
+                  "height": 806,
+                  "service": [
+                    {
+                      "@id": "https://iiif.dc.library.northwestern.edu/iiif/2/acc02fba-6537-4c4d-ac78-b8a0cde33178",
+                      "@type": "ImageService2",
+                      "profile": "http://iiif.io/api/image/2/level2.json"
+                    }
+                  ]
+                },
+                "target": "https://api.dc.library.northwestern.edu/api/v2/works/4044e95f-8cf1-45e0-9c94-87722d9a1b3a?as=iiif/canvas/access/3/placeholder"
+              }
+            ]
+          }
+        ]
+      },
+      "annotations": [
+        {
+          "id": "http://localhost:3000/manifest/annotations/transcribing-translating/canvas/3/annotations",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "http://localhost:3000/manifest/annotations/transcribing-translating/canvas/3/annotations/transcription",
+              "type": "Annotation",
+              "motivation": "transcribing",
+              "body": {
+                "type": "TextualBody",
+                "language": "ar",
+                "format": "text/plain",
+                "value": "ونصه لا اله الا الله مقامات الدين ثلاث\n الإسلام والإيمان والإحسان. فالإسلام قول لا اله الا الله والإيمان العلم بأنه لا اله الا الله والإحسان الجريان في مقتضى لا اله الا الله وهو أن تقول كلام حال ومقال الله.\n \n‏والكلمة الشريفة هي كلمة التوبة و كلمة التقوى وكلمة الإخلاص و كلمة التوحيد وكلمة الطيبة ولها ثلاثة مراتب \nو مرتبتها الأولى هي مقام الإسلام وهو القيام بمقتضى خطاب الحكمة في حضرة الناسوت \n‏والمرتبة الثانية التي هي العلم بأنه لا اله الا الله هي مقام الايمان\n‏والمرتبة الثالثة التي هي قول الله مقام الإحسان \nفالمقامات إذا متبانية غير متباينة حيث أن المضار على لا اله الا الله\n‏واما المنازل فأول منازل الإسلام التوبة هي الخروج من كفر النعمة فكل نعمة شكرها صرفها في مرضات المنعم و ضد الشكر كفر وقال علماء\n"
+              },
+              "target": "http://localhost:3000/manifest/annotations/transcribing-translating/canvas/3"
+            },
+            {
+              "id": "http://localhost:3000/manifest/annotations/transcribing-translating/canvas/3/annotations/translation",
+              "type": "Annotation",
+              "motivation": "translating",
+              "body": {
+                "type": "TextualBody",
+                "language": "en",
+                "format": "text/plain",
+                "value": "[Introduction] \n\n“There is no deity but God” constitutes the three stations of religion, (which are) submission (islām), faith (īmān), and excellence (iḥsān). Submission is pronouncing (the words) “there is no deity but God,” faith is knowing that there is no deity but God, and excellence is moving in accordance with “there is no deity but God,”which means that, when you make an utterance in a spiritual state (ḥāl), what you say is (the word) “God.” \n\nThe noble word (i.e., the phrase “There is no deity but God”) is the word of repentance (tawba), the word of God-consciousness (taqwā), the word of sincerity (ikhlāṣ), the word of Divine Unity (tawḥīd), and the good word. It has three levels (marātib). Its first level is the station of submission, and it is acting in the earthly plane (ḥaḍrat al-nāsūt) according to the exigencies of the speech of wisdom. The second level, which is knowing that there is no deity but God, is the station of faith. The third level, which is uttering the word “God,” is the station of excellence. Thus, the stations are different and (at the same time) not different as they all revolve around “There is no deity but God.” "
+              },
+              "target": "http://localhost:3000/manifest/annotations/transcribing-translating/canvas/3"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/src/components/Scroll/Figure/Caption.test.tsx
+++ b/src/components/Scroll/Figure/Caption.test.tsx
@@ -1,0 +1,30 @@
+import { render, screen } from "@testing-library/react";
+
+import { CanvasNormalized } from "@iiif/presentation-3";
+import Caption from "src/components/Scroll/Figure/Caption";
+import React from "react";
+
+// @ts-ignore
+const canvas: CanvasNormalized = {
+  label: {
+    en: ["Label content for canvas"],
+  },
+  summary: {
+    en: ["Summary content for canvas"],
+  },
+};
+
+const canvasInfo = {
+  current: 1,
+  total: 4,
+};
+
+describe("Caption", () => {
+  it("should render correctly", () => {
+    render(<Caption canvas={canvas} canvasInfo={canvasInfo} />);
+
+    expect(screen.getByText("1 / 4")).toBeInTheDocument();
+    expect(screen.getByText("Label content for canvas")).toBeInTheDocument();
+    expect(screen.getByText("Summary content for canvas")).toBeInTheDocument();
+  });
+});

--- a/src/components/Scroll/Figure/Caption.tsx
+++ b/src/components/Scroll/Figure/Caption.tsx
@@ -1,0 +1,29 @@
+import { Label, Summary } from "src/components/Primitives";
+
+import { CanvasNormalized } from "@iiif/presentation-3";
+import React from "react";
+
+interface FigureCaptionProps {
+  canvas?: CanvasNormalized;
+  canvasInfo: {
+    current: number;
+    total: number;
+  };
+}
+
+const FigureCaption: React.FC<FigureCaptionProps> = ({
+  canvas,
+  canvasInfo: { current, total },
+}) => {
+  return (
+    <figcaption>
+      <em>
+        {current} / {total}
+      </em>
+      {canvas?.label && <Label label={canvas?.label} />}
+      {canvas?.summary && <Summary summary={canvas?.summary} as="p" />}
+    </figcaption>
+  );
+};
+
+export default FigureCaption;

--- a/src/components/Scroll/Figure/Figure.styled.tsx
+++ b/src/components/Scroll/Figure/Figure.styled.tsx
@@ -1,0 +1,18 @@
+import { styled } from "src/styles/stitches.config";
+
+const StyledFigure = styled("figure", {
+  figcaption: {
+    display: "flex",
+    flexDirection: "column",
+    margin: "1.618rem 0 0",
+    opacity: 0.9,
+
+    em: {
+      fontSize: "0.9em",
+      fontStyle: "normal",
+      opacity: 0.7,
+    },
+  },
+});
+
+export { StyledFigure };

--- a/src/components/Scroll/Figure/Figure.tsx
+++ b/src/components/Scroll/Figure/Figure.tsx
@@ -1,0 +1,36 @@
+import React, { useContext } from "react";
+
+import { CanvasNormalized } from "@iiif/presentation-3";
+import FigureCaption from "src/components/Scroll/Figure/Caption";
+import ImageViewer from "src/components/Scroll/Figure/ImageViewer";
+import { ScrollContext } from "src/context/scroll-context";
+import { StyledFigure } from "src/components/Scroll/Figure/Figure.styled";
+import { getPaintingResource } from "src/hooks/use-iiif";
+
+interface CanvasProps {
+  canvas: CanvasNormalized;
+  canvasInfo: {
+    current: number;
+    total: number;
+  };
+}
+
+const ScrollCanvasFigure: React.FC<CanvasProps> = ({ canvas, canvasInfo }) => {
+  const { state } = useContext(ScrollContext);
+  const { vault } = state;
+
+  const painting = getPaintingResource(vault, canvas.id);
+
+  if (!painting) return null;
+
+  return (
+    <StyledFigure>
+      {painting?.map((body) => (
+        <ImageViewer body={body} key={body?.id} label={canvas?.label} />
+      ))}
+      <FigureCaption canvas={canvas} canvasInfo={canvasInfo} />
+    </StyledFigure>
+  );
+};
+
+export default ScrollCanvasFigure;

--- a/src/components/Scroll/Figure/ImageViewer.styled.tsx
+++ b/src/components/Scroll/Figure/ImageViewer.styled.tsx
@@ -1,0 +1,14 @@
+import { styled } from "src/styles/stitches.config";
+
+const StyledImageViewer = styled("div", {
+  width: "100%",
+  height: "400px",
+  background: "#6662",
+  backgroundSize: "contain",
+  color: "white",
+  position: "relative",
+  zIndex: "1",
+  overflow: "hidden",
+});
+
+export { StyledImageViewer };

--- a/src/components/Scroll/Figure/ImageViewer.test.tsx
+++ b/src/components/Scroll/Figure/ImageViewer.test.tsx
@@ -1,0 +1,24 @@
+import { render, screen } from "@testing-library/react";
+
+import { IIIFExternalWebResource } from "@iiif/presentation-3";
+import ImageViewer from "src/components/Scroll/Figure/ImageViewer";
+import React from "react";
+
+const body: IIIFExternalWebResource = {
+  type: "Image",
+  format: "image/jpeg",
+  id: "https://example.com/image.jpg",
+  width: 1000,
+  height: 1000,
+};
+
+describe("ImageViewer", () => {
+  it("should render an OpenSeadragon instance", () => {
+    render(<ImageViewer body={body} />);
+
+    expect(screen.getByTestId("scroll-figure-image")).toBeInTheDocument();
+    expect(
+      screen.getByTestId("clover-iiif-image-openseadragon-viewport"),
+    ).toBeInTheDocument();
+  });
+});

--- a/src/components/Scroll/Figure/ImageViewer.tsx
+++ b/src/components/Scroll/Figure/ImageViewer.tsx
@@ -1,0 +1,27 @@
+import {
+  IIIFExternalWebResource,
+  InternationalString,
+} from "@iiif/presentation-3";
+
+import CloverImage from "src/components/Image";
+import React from "react";
+import { StyledImageViewer } from "src/components/Scroll/Figure/ImageViewer.styled";
+
+interface ImageViewerProps {
+  body: IIIFExternalWebResource;
+  label?: InternationalString | null;
+}
+
+const ImageViewer: React.FC<ImageViewerProps> = ({ body, label }) => {
+  return (
+    <StyledImageViewer data-testid="scroll-figure-image">
+      <CloverImage
+        body={body}
+        openSeadragonConfig={{ showNavigator: false, showHomeControl: false }}
+        {...(label && { label: label })}
+      />
+    </StyledImageViewer>
+  );
+};
+
+export default ImageViewer;

--- a/src/components/Scroll/Items/Body.styled.tsx
+++ b/src/components/Scroll/Items/Body.styled.tsx
@@ -1,0 +1,43 @@
+import { styled } from "src/styles/stitches.config";
+
+const highlightColor = "255, 197, 32"; // #FFC520
+
+const TextualBody = styled("div", {
+  paddingTop: "1.618rem",
+
+  "span.highlight": {
+    position: "relative",
+    fontWeight: "bold",
+
+    "&::before": {
+      top: "0",
+      position: "absolute",
+      display: "inline",
+      content: "",
+      width: "calc(100% + 4px)",
+      height: "calc(100% + 2px) ",
+      marginLeft: "-2px",
+      borderRadius: "3px",
+      border: `1px solid rgba(${highlightColor}, 0.2)`,
+      borderBottom: `1px solid rgba(${highlightColor}, 0.618)`,
+      boxShadow: `1px 1px 1px #6661`,
+    },
+
+    "&::after": {
+      left: "0",
+      top: "0",
+      position: "absolute",
+      display: "inline",
+      content: "",
+      width: "calc(100% + 4px)",
+      height: "calc(100% + 2px) ",
+      marginLeft: "-2px",
+      marginTop: "-1px",
+      borderRadius: "3px",
+      backgroundColor: `rgba(${highlightColor}, 0.2)`,
+      zIndex: -1,
+    },
+  },
+});
+
+export { TextualBody };

--- a/src/components/Scroll/Items/Body.test.tsx
+++ b/src/components/Scroll/Items/Body.test.tsx
@@ -1,0 +1,24 @@
+import { render, screen } from "@testing-library/react";
+
+import Body from "./Body";
+import React from "react";
+
+const body = {
+  id: "https://body-id",
+  format: "text/plain",
+  value:
+    "This is sample body content. \n Second line of body. \n Third line of body.",
+};
+
+describe("Body", () => {
+  it("should render plain text line breaks as HTML breaks", () => {
+    render(<Body body={body} />);
+
+    const renderedBody = screen.getByTestId("scroll-item-body");
+
+    expect(renderedBody).toBeInTheDocument();
+    expect(renderedBody.innerHTML).toBe(
+      "This is sample body content. <br> Second line of body. <br> Third line of body.",
+    );
+  });
+});

--- a/src/components/Scroll/Items/Body.tsx
+++ b/src/components/Scroll/Items/Body.tsx
@@ -1,0 +1,44 @@
+import React, { useContext, useEffect, useState } from "react";
+
+import { ScrollContext } from "src/context/scroll-context";
+import { TextualBody } from "src/components/Scroll/Items/Body.styled";
+
+const ScrollItemBody = ({ body }) => {
+  const [value, setValue] = useState<string>("");
+
+  const { state } = useContext(ScrollContext);
+  const { searchString } = state;
+
+  useEffect(() => {
+    let value = body?.value;
+
+    if (body?.format === "text/plain") {
+      const regex = /\n/g;
+      const newLineToBreak = "<br />";
+      value = value?.replace(regex, newLineToBreak);
+    }
+
+    // search the value for the search string and wrap the matches in a span
+    if (searchString) {
+      const regex = new RegExp(searchString, "gi");
+      value = value?.replace(regex, (match) => {
+        return `<span class="highlight">${match}</span>`;
+      });
+    }
+
+    setValue(value);
+  }, [body, searchString]);
+
+  if (!value) return null;
+
+  return (
+    <TextualBody
+      dangerouslySetInnerHTML={{ __html: value }}
+      data-body-id={body.id}
+      data-testid="scroll-item-body"
+      id={body.id}
+    />
+  );
+};
+
+export default ScrollItemBody;

--- a/src/components/Scroll/Items/Item.tsx
+++ b/src/components/Scroll/Items/Item.tsx
@@ -1,0 +1,74 @@
+import { CanvasNormalized, Reference } from "@iiif/presentation-3";
+import {
+  PageBreak,
+  StyledItem,
+  StyledItemFigure,
+  StyledItemTextualBodies,
+} from "src/components/Scroll/Items/Items.styled";
+
+import { Label } from "src/components/Primitives";
+import React from "react";
+import { ScrollContext } from "src/context/scroll-context";
+import ScrollFigure from "src/components/Scroll/Figure/Figure";
+import ScrollItemBody from "src/components/Scroll/Items/Body";
+
+interface ScrollItemProps {
+  hasItemBreak: boolean;
+  isLastItem: boolean;
+  item: Reference<"Canvas">;
+  itemCount: number;
+  itemNumber: number;
+}
+
+// design svg for page break that  a line with triangles symbolizing a page break
+
+const ScrollItem: React.FC<ScrollItemProps> = ({
+  hasItemBreak,
+  isLastItem,
+  item,
+  itemCount,
+  itemNumber,
+}) => {
+  const { state } = React.useContext(ScrollContext);
+  const { annotations, vault } = state;
+
+  const canvas: CanvasNormalized | undefined = vault?.get(item);
+
+  const annotationBody = annotations
+    ?.filter((annotation) => annotation.target === item.id)
+    ?.map((annotation) => {
+      return annotation?.body?.map((body, index) => (
+        <ScrollItemBody body={body} key={index} />
+      ));
+    });
+
+  const canvasInfo = {
+    current: itemNumber,
+    total: itemCount,
+  };
+
+  return (
+    <StyledItem
+      data-page-break={hasItemBreak}
+      data-page-number={itemNumber}
+      data-last-item={isLastItem}
+    >
+      <StyledItemFigure>
+        {canvas && <ScrollFigure canvas={canvas} canvasInfo={canvasInfo} />}
+      </StyledItemFigure>
+      <StyledItemTextualBodies>
+        {canvas?.label && (
+          <strong>
+            <Label label={canvas?.label} />{" "}
+            {`(${canvasInfo.current} / ${canvasInfo.total})`}
+          </strong>
+        )}
+        <div>{annotationBody ? annotationBody : <p>[Blank]</p>}</div>
+
+        {hasItemBreak && <PageBreak aria-label="Page Break" />}
+      </StyledItemTextualBodies>
+    </StyledItem>
+  );
+};
+
+export default React.memo(ScrollItem);

--- a/src/components/Scroll/Items/Items.styled.tsx
+++ b/src/components/Scroll/Items/Items.styled.tsx
@@ -1,0 +1,82 @@
+import { styled } from "src/styles/stitches.config";
+
+const StyledItem = styled("article", {
+  transition: "all 0.382s ease-in-out",
+  display: "flex",
+  flexDirection: "row",
+  flexWrap: "nowrap",
+  gap: "2.618rem",
+});
+
+const StyledItemFigure = styled("div", {
+  transition: "$all",
+  width: "50%",
+  opacity: 0,
+  transform: "translateX(2.618rem)",
+  zIndex: -1,
+});
+
+const StyledItemTextualBodies = styled("div", {
+  width: "50%",
+  display: "flex",
+  flexDirection: "column",
+  justifyContent: "flex-start",
+});
+
+const PageBreak = styled("hr", {
+  margin: "0",
+  borderColor: "transparent",
+  height: "1.618rem",
+  position: "relative",
+  zIndex: 0,
+  display: "flex",
+  justifyContent: "flex-end",
+  marginTop: "2.618rem",
+
+  "&::before": {
+    content: "attr(aria-label)",
+    position: "absolute",
+    right: "1.618rem",
+    bottom: "0",
+    zIndex: 1,
+    display: "flex",
+    fontSize: "0.7222rem",
+    fontWeight: "400",
+    lineHeight: "1rem",
+    background: "inherit",
+    opacity: 0.7,
+  },
+
+  "&::after": {
+    content: "",
+    width: "100%",
+    position: "absolute",
+    zIndex: 0,
+    height: "1px",
+    background: "#6662",
+  },
+});
+
+const StyledScrollItems = styled("div", {
+  position: "relative",
+  zIndex: "1",
+  display: "flex",
+  flexDirection: "column",
+  gap: "2.618rem",
+
+  "&[data-figures-visible='true']": {
+    [`& ${StyledItemFigure}`]: {
+      opacity: 1,
+      zIndex: 0,
+      transform: "translateX(0)",
+    },
+  },
+});
+
+export {
+  StyledScrollItems,
+  StyledItem,
+  StyledItemFigure,
+  StyledItemTextualBodies,
+  PageBreak,
+};

--- a/src/components/Scroll/Items/Items.tsx
+++ b/src/components/Scroll/Items/Items.tsx
@@ -1,0 +1,39 @@
+import React, { useState } from "react";
+
+import { Reference } from "@iiif/presentation-3";
+import ScrollItem from "src/components/Scroll/Items/Item";
+import ScrollPanel from "src/components/Scroll/Panel/Panel";
+import { StyledScrollItems } from "src/components/Scroll/Items/Items.styled";
+
+const ScrollItems = ({ items }: { items: Reference<"Canvas">[] }) => {
+  const [isPanelExpanded, setIsPanelExpanded] = useState(false);
+
+  const handlePanel = (status) => setIsPanelExpanded(status);
+  return (
+    <>
+      <ScrollPanel
+        isPanelExpanded={isPanelExpanded}
+        handlePanel={handlePanel}
+      />
+      <StyledScrollItems data-figures-visible={!isPanelExpanded}>
+        {items.map((item, index) => {
+          const itemNumber = index + 1;
+          const isLastItem = itemNumber === items.length;
+
+          return (
+            <ScrollItem
+              item={item}
+              hasItemBreak={itemNumber < items.length}
+              isLastItem={isLastItem}
+              key={item.id}
+              itemCount={items.length}
+              itemNumber={itemNumber}
+            />
+          );
+        })}
+      </StyledScrollItems>
+    </>
+  );
+};
+
+export default ScrollItems;

--- a/src/components/Scroll/Layout/Header.tsx
+++ b/src/components/Scroll/Layout/Header.tsx
@@ -1,0 +1,15 @@
+import { InternationalString } from "@iiif/presentation-3";
+import { Label } from "src/components/Primitives";
+import { StyledScrollHeader } from "src/components/Scroll/Layout/Layout.styled";
+
+const ScrollHeader = ({ label }: { label: InternationalString }) => {
+  return (
+    <StyledScrollHeader>
+      <strong>
+        <Label label={label} />
+      </strong>
+    </StyledScrollHeader>
+  );
+};
+
+export default ScrollHeader;

--- a/src/components/Scroll/Layout/Layout.styled.tsx
+++ b/src/components/Scroll/Layout/Layout.styled.tsx
@@ -1,0 +1,55 @@
+import { styled } from "src/styles/stitches.config";
+
+const StyledScrollFixed = styled("div", {
+  display: "flex",
+  flexDirection: "column",
+  justifyContent: "space-between",
+});
+
+const StyledScrollAside = styled("aside", {
+  margin: "0",
+  padding: "0",
+  position: "relative",
+  zIndex: 2,
+  flexGrow: "1",
+  flexShrink: "0",
+
+  [`& ${StyledScrollFixed}`]: {
+    position: "absolute",
+    width: "50%",
+    top: 0,
+  },
+
+  "&.anchor": {
+    [`& ${StyledScrollFixed}`]: {
+      position: "fixed",
+      width: "50%",
+    },
+  },
+});
+
+const StyledScrollHeader = styled("header", {
+  display: "flex",
+  justifyContent: "space-between",
+  fontSize: "1",
+  flexGrow: "1",
+  flexShrink: "0",
+  marginBottom: "1.618rem",
+
+  strong: {
+    fontWeight: "400",
+    fontSize: "1.33rem",
+  },
+});
+
+const StyledScrollWrapper = styled("section", {
+  margin: "0",
+  gap: "1rem",
+});
+
+export {
+  StyledScrollAside,
+  StyledScrollFixed,
+  StyledScrollHeader,
+  StyledScrollWrapper,
+};

--- a/src/components/Scroll/Panel/Panel.styled.tsx
+++ b/src/components/Scroll/Panel/Panel.styled.tsx
@@ -1,0 +1,32 @@
+import { styled } from "src/styles/stitches.config";
+
+const StyledPanel = styled("div", {
+  display: "flex",
+  flexDirection: "column",
+  flexGrow: "1",
+  flexShrink: "0",
+  position: "relative",
+  zIndex: "1",
+  maxWidth: "100%",
+  marginTop: "1rem",
+  transition: "$all",
+
+  variants: {
+    isPanelExpanded: {
+      true: {
+        zIndex: 1,
+        opacity: 1,
+        transform: "translateX(0)",
+      },
+      false: {
+        zIndex: -1,
+        opacity: 0,
+        transform: "translateX(-2.618rem)",
+        transitionDelay: "0",
+        transition: "none",
+      },
+    },
+  },
+});
+
+export { StyledPanel };

--- a/src/components/Scroll/Panel/Panel.test.tsx
+++ b/src/components/Scroll/Panel/Panel.test.tsx
@@ -1,0 +1,23 @@
+import { render, screen } from "@testing-library/react";
+
+import Panel from "./Panel";
+import React from "react";
+
+describe("Panel", () => {
+  it("should render the panel", () => {
+    render(<Panel isPanelExpanded handlePanel={() => {}} />);
+    expect(screen.getByTestId("scroll-panel")).toBeInTheDocument();
+  });
+
+  it("should render the panel results expanded", () => {
+    render(<Panel isPanelExpanded handlePanel={() => {}} />);
+    const results = screen.getByTestId("scroll-panel-results");
+    expect(results).toHaveAttribute("data-panel-expanded", "true");
+  });
+
+  it("should render the panel results hidden", () => {
+    render(<Panel isPanelExpanded={false} handlePanel={() => {}} />);
+    const results = screen.getByTestId("scroll-panel-results");
+    expect(results).toHaveAttribute("data-panel-expanded", "false");
+  });
+});

--- a/src/components/Scroll/Panel/Panel.tsx
+++ b/src/components/Scroll/Panel/Panel.tsx
@@ -1,0 +1,64 @@
+import React, { useContext, useRef } from "react";
+import {
+  StyledScrollAside,
+  StyledScrollFixed,
+} from "src/components/Scroll/Layout/Layout.styled";
+
+import { ScrollContext } from "src/context/scroll-context";
+import ScrollSearchResults from "src/components/Scroll/Panel/Search/Results";
+import SearchForm from "src/components/Scroll/Panel/Search/Form";
+import { StyledPanel } from "src/components/Scroll/Panel/Panel.styled";
+import { useDistanceFromViewportTop } from "src/hooks/useDistanceFromViewportTop";
+
+interface ScrollToggleProps {
+  isPanelExpanded: boolean;
+  handlePanel: (status: boolean) => void;
+}
+
+const ScrollPanel: React.FC<ScrollToggleProps> = ({
+  isPanelExpanded,
+  handlePanel,
+}) => {
+  const scrollAsideRef = useRef<HTMLDivElement>(null);
+
+  const { state } = useContext(ScrollContext);
+  const { options } = state;
+  const { offset } = options;
+
+  const { top } = useDistanceFromViewportTop(scrollAsideRef);
+  const isAnchored = top ? top < offset : false;
+  const articleWidth = scrollAsideRef?.current?.offsetWidth;
+  const panelWidth = articleWidth ? articleWidth * 0.5 : articleWidth;
+  const defaultFormWidth = panelWidth ? panelWidth - 315 : 180;
+
+  const fixedStyles = {
+    top: isAnchored ? offset : 0,
+    width: `calc(${panelWidth}px - 1.318rem)`,
+    maxWidth: isPanelExpanded ? "100%" : `${defaultFormWidth}px`,
+    minWidth: "130px",
+  };
+
+  return (
+    <StyledScrollAside
+      ref={scrollAsideRef}
+      className={isAnchored ? "anchor" : ""}
+      data-testid="scroll-panel"
+    >
+      <StyledScrollFixed style={fixedStyles}>
+        <SearchForm
+          togglePanel={handlePanel}
+          isPanelExpanded={isPanelExpanded}
+        />
+        <StyledPanel
+          data-testid="scroll-panel-results"
+          data-panel-expanded={isPanelExpanded}
+          isPanelExpanded={isPanelExpanded}
+        >
+          <ScrollSearchResults isPanelExpanded={isPanelExpanded} />
+        </StyledPanel>
+      </StyledScrollFixed>
+    </StyledScrollAside>
+  );
+};
+
+export default ScrollPanel;

--- a/src/components/Scroll/Panel/Search/Form.tsx
+++ b/src/components/Scroll/Panel/Search/Form.tsx
@@ -1,0 +1,133 @@
+import React, { useContext, useEffect, useRef } from "react";
+import {
+  StyledSearchBackButton,
+  StyledSearchForm,
+  StyledSearchIcon,
+  StyledSearchInput,
+} from "src/components/Scroll/Panel/Search/Search.styled";
+
+import { ScrollContext } from "src/context/scroll-context";
+
+const SearchIcon: React.FC = () => {
+  return (
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
+      <title>Search</title>
+      <path d="M456.69 421.39L362.6 327.3a173.81 173.81 0 0034.84-104.58C397.44 126.38 319.06 48 222.72 48S48 126.38 48 222.72s78.38 174.72 174.72 174.72A173.81 173.81 0 00327.3 362.6l94.09 94.09a25 25 0 0035.3-35.3zM97.92 222.72a124.8 124.8 0 11124.8 124.8 124.95 124.95 0 01-124.8-124.8z" />
+    </svg>
+  );
+};
+
+const CloseIcon: React.FC = () => {
+  return (
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
+      <title>Close</title>
+      <path d="M289.94 256l95-95A24 24 0 00351 127l-95 95-95-95a24 24 0 00-34 34l95 95-95 95a24 24 0 1034 34l95-95 95 95a24 24 0 0034-34z" />
+    </svg>
+  );
+};
+
+interface PanelToggleProps {
+  togglePanel: (isPanelExpanded: boolean) => void;
+  isPanelExpanded: boolean;
+}
+
+const PanelToggle: React.FC<PanelToggleProps> = ({
+  togglePanel,
+  isPanelExpanded,
+}) => {
+  const { dispatch, state } = useContext(ScrollContext);
+  const { searchString } = state;
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const handleFocus = () =>
+    inputRef.current === document.activeElement && togglePanel(true);
+
+  const focusInput = () => inputRef?.current?.focus();
+
+  const blurInput = () => {
+    inputRef.current?.blur();
+    clearInput();
+    togglePanel(false);
+    dispatch({
+      payload: "",
+      type: "updateSearchString",
+    });
+  };
+
+  const clearInput = () => {
+    if (inputRef.current) {
+      inputRef.current.value = "";
+    }
+  };
+
+  const handleClose = (e) => {
+    e.preventDefault();
+    blurInput();
+  };
+
+  const handleKeyDown = (e) => {
+    if (e.key === "Escape") {
+      e.preventDefault();
+      blurInput();
+    }
+  };
+
+  useEffect(() => {
+    document?.addEventListener("keydown", handleKeyDown);
+
+    return () => {
+      document?.removeEventListener("keydown", handleKeyDown);
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!inputRef?.current) return;
+
+    inputRef.current.addEventListener("focus", handleFocus);
+    inputRef.current.addEventListener("blur", handleFocus);
+
+    return () => {
+      if (inputRef.current) {
+        inputRef.current.removeEventListener("focus", handleFocus);
+        inputRef.current.removeEventListener("blur", handleFocus);
+      }
+    };
+  }, []);
+
+  const handleSearchChange = (e) => {
+    dispatch({
+      payload: e?.target?.value,
+      type: "updateSearchString",
+    });
+  };
+
+  return (
+    <StyledSearchForm
+      id="scroll-search"
+      autoComplete="off"
+      isPanelExpanded={isPanelExpanded}
+    >
+      <StyledSearchIcon onClick={focusInput}>
+        <SearchIcon />
+      </StyledSearchIcon>
+      <StyledSearchInput
+        ref={inputRef}
+        name="clover-search"
+        type="text"
+        placeholder="Search..."
+        defaultValue={searchString}
+        onChange={handleSearchChange}
+      />
+      <StyledSearchBackButton
+        aria-disabled={!isPanelExpanded}
+        aria-label="Close search panel"
+        onClick={handleClose}
+        disabled={!isPanelExpanded}
+      >
+        <CloseIcon />
+      </StyledSearchBackButton>
+    </StyledSearchForm>
+  );
+};
+
+export default PanelToggle;

--- a/src/components/Scroll/Panel/Search/Results.tsx
+++ b/src/components/Scroll/Panel/Search/Results.tsx
@@ -1,0 +1,124 @@
+import {
+  Document as FlexSearchDocumentIndex,
+  IndexOptionsForDocumentSearch,
+} from "flexsearch";
+import React, { useContext } from "react";
+import {
+  StyledSearch,
+  StyledSearchAnnotationInformation,
+  StyledSearchAnnotations,
+  StyledSearchTag,
+} from "src/components/Scroll/Panel/Search/Search.styled";
+
+import { ScrollContext } from "src/context/scroll-context";
+
+const config: IndexOptionsForDocumentSearch<{
+  id: string;
+  content: string;
+}> = {
+  charset: "latin:extra, arabic:extra, cyrillic:extra, cjk:extra",
+  optimize: true,
+  tokenize: "full",
+  resolution: 9,
+  document: {
+    id: "id",
+    index: "content",
+  },
+};
+
+interface ScrollSearchProps {
+  isPanelExpanded: boolean;
+}
+
+const ScrollSearch: React.FC<ScrollSearchProps> = ({ isPanelExpanded }) => {
+  const { state } = useContext(ScrollContext);
+  const { annotations, searchString = "" } = state;
+
+  const index = new FlexSearchDocumentIndex(config);
+  const indexIds: string[] = [];
+  annotations?.forEach((annotation) => {
+    annotation?.body?.forEach((body) => {
+      // @ts-ignore
+      const content = body?.value?.replace(/\n/g, "");
+      indexIds.push(body?.id);
+      index.add({
+        id: body?.id,
+        content,
+      });
+    });
+  });
+
+  function mapAnnotationBodies(array) {
+    return array.map((id) => {
+      return annotations
+        ?.filter((annotation) => {
+          return annotation.body.find((body) => body.id === id);
+        })
+        .map((annotation) => {
+          const bodyIndex = annotation.body.findIndex((body) => body.id === id);
+          return {
+            ...annotation,
+            body: annotation.body[bodyIndex],
+          };
+        })
+        .shift();
+    });
+  }
+
+  const searchResults = index?.search(searchString).reduce((acc, curr) => {
+    return [...new Set([...acc, ...curr.result])];
+  }, []);
+
+  const results = {
+    found: mapAnnotationBodies(searchResults),
+    notFound: mapAnnotationBodies(
+      indexIds.filter((id) => !searchResults.includes(id)),
+    ),
+  };
+
+  const handleScrollToId = (id) => {
+    if (id)
+      document?.getElementById(id)?.scrollIntoView({ behavior: "smooth" });
+  };
+
+  return (
+    <StyledSearch>
+      <StyledSearchAnnotations>
+        {results.found.map((annotation) => {
+          return (
+            <button
+              data-result="true"
+              disabled={!isPanelExpanded}
+              onClick={() => handleScrollToId(annotation.body.id)}
+              key={annotation.id}
+            >
+              <StyledSearchAnnotationInformation>
+                <StyledSearchTag>{annotation.motivation}</StyledSearchTag>
+                <span>{annotation.body.language}</span>
+              </StyledSearchAnnotationInformation>
+              <span>{annotation.body.value.slice(0, 150)}...</span>
+            </button>
+          );
+        })}
+        {results.notFound.map((annotation) => {
+          return (
+            <button
+              data-result="false"
+              disabled={!isPanelExpanded}
+              key={annotation.id}
+              onClick={() => handleScrollToId(annotation.body.id)}
+            >
+              <StyledSearchAnnotationInformation>
+                <StyledSearchTag>{annotation.motivation}</StyledSearchTag>
+                <span>{annotation.body.language}</span>
+              </StyledSearchAnnotationInformation>
+              <span>{annotation.body.value.slice(0, 150)}...</span>
+            </button>
+          );
+        })}
+      </StyledSearchAnnotations>
+    </StyledSearch>
+  );
+};
+
+export default ScrollSearch;

--- a/src/components/Scroll/Panel/Search/Search.styled.tsx
+++ b/src/components/Scroll/Panel/Search/Search.styled.tsx
@@ -1,0 +1,161 @@
+import { styled } from "src/styles/stitches.config";
+
+const highlightColor = "255, 197, 32"; // #FFC520
+
+const StyledSearchTag = styled("span", {
+  fontWeight: "700",
+});
+
+const StyledSearchAnnotationInformation = styled("div", {
+  display: "flex",
+  gap: "0.25rem",
+});
+
+const StyledSearchAnnotations = styled("div", {
+  display: "flex",
+  flexDirection: "column",
+  gap: "0.5rem",
+
+  button: {
+    backgroundColor: "#6660",
+    opacity: "0.7",
+    transition: "$all",
+    padding: "0.5rem 0.618rem",
+    fontSize: "0.9rem",
+    lineHeight: "1.1rem",
+    textAlign: "left",
+    borderRadius: "6px",
+    border: "1px solid #6662",
+    borderBottomWidth: "2px",
+    display: "flex",
+    flexDirection: "column",
+    gap: "0.25rem",
+
+    "&:hover": {
+      opacity: "1",
+      boxShadow: "5px 5px 13px #6662",
+    },
+
+    "&[data-result=true]": {
+      backgroundColor: `rgba(${highlightColor}, 0.2)`,
+      borderColor: `rgba(${highlightColor}, 0.2)`,
+      borderBottomColor: `rgba(${highlightColor}, 0.382)`,
+      opacity: "1",
+
+      "&:hover": {
+        backgroundColor: `rgba(${highlightColor}, 0.382)`,
+      },
+    },
+  },
+});
+
+const StyledSearchInput = styled("input", {
+  margin: "0",
+  padding: "0 1rem 0 2rem",
+  background: "none",
+  zIndex: "2",
+  height: "2rem",
+  marginLeft: "1rem",
+  marginTop: "1rem",
+  justifyContent: "center",
+  display: "flex",
+  alignItems: "center",
+  fontSize: "1rem",
+  borderRadius: "2rem",
+  fontFamily: "inherit",
+  backgroundColor: "$primary",
+  border: "none",
+  color: "$secondary",
+  cursor: "text",
+  filter: "drop-shadow(2px 2px 5px #0003)",
+  transition: "$all",
+  boxSizing: "content-box !important",
+  flexGrow: "0",
+  width: "100%",
+
+  "&:placeholder": {
+    color: "inherit",
+  },
+});
+
+const StyledSearchIcon = styled("span", {
+  position: "absolute",
+  zIndex: "3",
+  width: "2rem",
+  height: "2rem",
+  padding: "8px",
+  marginTop: "1rem",
+  marginLeft: "1rem",
+  color: "$secondary",
+  fill: "$secondary",
+  stroke: "$secondary",
+  transition: "$all",
+  cursor: "text",
+});
+
+const StyledSearchBackButton = styled("button", {
+  opacity: "1",
+  display: "flex",
+  alignItems: "center",
+  borderRadius: "2rem",
+  width: "2rem",
+  height: "2rem",
+  alignSelf: "center",
+  marginTop: "1rem",
+  gap: "0.35rem",
+  backgroundColor: "$accent",
+  fill: "$secondary",
+  flexShrink: "0",
+
+  svg: {
+    padding: "6px",
+    color: "inherit",
+    fill: "inherit",
+  },
+
+  '&[aria-disabled="true"]': {
+    opacity: "0",
+    display: "none",
+  },
+});
+
+const StyledSearchForm = styled("form", {
+  display: "flex",
+  justifyContent: "space-between",
+  gap: "1rem",
+  width: "100%",
+
+  variants: {
+    isPanelExpanded: {
+      true: {
+        [`${StyledSearchIcon}`]: {
+          marginLeft: "0",
+        },
+
+        [`& ${StyledSearchInput}`]: {
+          marginLeft: "0",
+          backgroundColor: "$primary",
+          width: "auto",
+          flexGrow: "1",
+          //
+        },
+      },
+      false: {
+        //
+      },
+    },
+  },
+});
+
+const StyledSearch = styled("div", {});
+
+export {
+  StyledSearch,
+  StyledSearchAnnotations,
+  StyledSearchAnnotationInformation,
+  StyledSearchBackButton,
+  StyledSearchForm,
+  StyledSearchIcon,
+  StyledSearchInput,
+  StyledSearchTag,
+};

--- a/src/components/Scroll/index.tsx
+++ b/src/components/Scroll/index.tsx
@@ -1,0 +1,62 @@
+import React, { useContext, useEffect, useState } from "react";
+import { ScrollContext, ScrollProvider } from "src/context/scroll-context";
+
+import { ManifestNormalized } from "@iiif/presentation-3";
+import ScrollHeader from "src/components/Scroll/Layout/Header";
+import ScrollItems from "src/components/Scroll/Items/Items";
+import { StyledScrollWrapper } from "src/components/Scroll/Layout/Layout.styled";
+import useManifestAnnotations from "src/hooks/useManifestAnnotations";
+
+export interface CloverScrollProps {
+  iiifContent: string;
+  options;
+}
+
+const RenderCloverScroll = ({ iiifContent }: { iiifContent: string }) => {
+  const [manifest, setManifest] = useState<ManifestNormalized>();
+
+  const { state, dispatch } = useContext(ScrollContext);
+  const { vault } = state;
+
+  const annotations = useManifestAnnotations(manifest?.items, vault);
+
+  useEffect(() => {
+    if (!vault) return;
+
+    vault
+      .load(iiifContent)
+      .then((data: ManifestNormalized) => data && setManifest(data))
+      .catch((error: Error) =>
+        console.error(`Manifest ${iiifContent} failed to load: ${error}`),
+      );
+  }, [iiifContent, vault]);
+
+  useEffect(() => {
+    dispatch({
+      type: "updateAnnotations",
+      payload: annotations,
+    });
+  }, [annotations, dispatch]);
+
+  if (!manifest) return null;
+
+  return (
+    <StyledScrollWrapper>
+      {manifest.label && <ScrollHeader label={manifest.label} />}
+      {manifest.items && <ScrollItems items={manifest.items} />}
+    </StyledScrollWrapper>
+  );
+};
+
+const CloverScroll: React.FC<CloverScrollProps> = ({
+  iiifContent,
+  options,
+}) => {
+  return (
+    <ScrollProvider options={options}>
+      <RenderCloverScroll iiifContent={iiifContent} />
+    </ScrollProvider>
+  );
+};
+
+export default CloverScroll;

--- a/src/context/scroll-context.tsx
+++ b/src/context/scroll-context.tsx
@@ -1,0 +1,86 @@
+import { AnnotationNormalized, ManifestNormalized } from "@iiif/presentation-3";
+import React, { Dispatch, createContext, useReducer } from "react";
+
+import { Vault } from "@iiif/vault";
+import { Vault as VaultShape } from "@iiif/vault/dist/index";
+
+interface StateType {
+  annotations?: AnnotationNormalized[];
+  manifest?: ManifestNormalized;
+  searchString?: string;
+  options: {
+    offset: number;
+  };
+  vault?: VaultShape;
+}
+
+interface ActionType {
+  payload?: any;
+  type: string;
+}
+
+const initialState: StateType = {
+  annotations: [],
+  manifest: undefined,
+  searchString: undefined,
+  options: {
+    offset: 0,
+  },
+  vault: new Vault(),
+};
+
+function reducer(state: StateType, action: ActionType): StateType {
+  switch (action.type) {
+    case "updateAnnotations":
+      return {
+        ...state,
+        annotations: action.payload,
+      };
+    case "updateSearchString":
+      return {
+        ...state,
+        searchString: action.payload,
+      };
+    default:
+      return state;
+  }
+}
+
+export const ScrollContext = createContext<{
+  dispatch: Dispatch<ActionType>;
+  state: StateType;
+}>({
+  dispatch: () => null,
+  state: initialState,
+});
+
+interface ScrollProviderProps {
+  annotations?: AnnotationNormalized[];
+  children: React.ReactNode;
+  manifest?: ManifestNormalized;
+  options?: {
+    offset?: number;
+  };
+  vault?: VaultShape;
+}
+
+export const ScrollProvider: React.FC<ScrollProviderProps> = (props) => {
+  const { children, manifest } = props;
+  const options = {
+    ...initialState.options,
+    ...props.options,
+  };
+
+  const [state, dispatch] = useReducer(reducer, initialState);
+
+  return (
+    <ScrollContext.Provider
+      value={{
+        state: { ...state, manifest, options },
+        dispatch,
+      }}
+    >
+      {children}
+    </ScrollContext.Provider>
+  );
+};

--- a/src/hooks/useDistanceFromViewportTop.ts
+++ b/src/hooks/useDistanceFromViewportTop.ts
@@ -1,0 +1,39 @@
+import { useEffect, useState } from "react";
+
+interface Position {
+  top: number;
+  left: number;
+}
+
+/**
+ * Hook that returns an element's distance from the top of the visible window.
+ */
+export const useDistanceFromViewportTop = (
+  ref: React.RefObject<HTMLElement>,
+): Position => {
+  const [position, setPosition] = useState<Position>({ top: 0, left: 0 });
+
+  useEffect(() => {
+    const handleUpdatePosition = () => {
+      if (ref.current) {
+        const rect = ref.current.getBoundingClientRect();
+        setPosition({
+          top: rect.top,
+          left: rect.left,
+        });
+      }
+    };
+
+    // Update position for both scroll and resize events
+    window.addEventListener("scroll", handleUpdatePosition);
+    window.addEventListener("resize", handleUpdatePosition);
+    handleUpdatePosition(); // Call once to set the initial value.
+
+    return () => {
+      window.removeEventListener("scroll", handleUpdatePosition);
+      window.removeEventListener("resize", handleUpdatePosition);
+    };
+  }, [ref]);
+
+  return position;
+};

--- a/src/hooks/useIntersectionObserver.ts
+++ b/src/hooks/useIntersectionObserver.ts
@@ -1,0 +1,47 @@
+import { RefObject, useEffect, useState } from "react";
+
+interface Args extends IntersectionObserverInit {
+  freezeOnceVisible?: boolean;
+}
+
+export function useIntersectionObserver(
+  elementRef: RefObject<Element>,
+  {
+    threshold = 0,
+    root = null,
+    rootMargin = "0%",
+    freezeOnceVisible = false,
+  }: Args,
+): IntersectionObserverEntry | undefined {
+  const [entry, setEntry] = useState<IntersectionObserverEntry>();
+
+  const frozen = entry?.isIntersecting && freezeOnceVisible;
+
+  const updateEntry = ([entry]: IntersectionObserverEntry[]): void => {
+    setEntry(entry);
+  };
+
+  useEffect(() => {
+    const node = elementRef?.current; // DOM Ref
+    const hasIOSupport = !!window.IntersectionObserver;
+
+    if (!hasIOSupport || frozen || !node) return;
+
+    const observerParams = { threshold, root, rootMargin };
+    const observer = new IntersectionObserver(updateEntry, observerParams);
+
+    observer.observe(node);
+
+    return () => observer.disconnect();
+
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [
+    elementRef?.current,
+    JSON.stringify(threshold),
+    root,
+    rootMargin,
+    frozen,
+  ]);
+
+  return entry;
+}

--- a/src/hooks/useManifestAnnotations.ts
+++ b/src/hooks/useManifestAnnotations.ts
@@ -1,0 +1,58 @@
+import {
+  AnnotationNormalized,
+  AnnotationPageNormalized,
+  CanvasNormalized,
+  Reference,
+} from "@iiif/presentation-3";
+import { useEffect, useState } from "react";
+
+const useManifestAnnotations = (items, vault) => {
+  const [processedAnnotations, setProcessedAnnotations] = useState<
+    AnnotationNormalized[]
+  >([]);
+
+  useEffect(() => {
+    if (!vault) return;
+
+    const allAnnotations: AnnotationNormalized[] = [];
+
+    items?.forEach((canvasRef: Reference<"Canvas">) => {
+      const canvas: CanvasNormalized = vault.get(canvasRef);
+      canvas?.annotations?.forEach(
+        (annotationPageRef: Reference<"AnnotationPage">) => {
+          const annotationPage: AnnotationPageNormalized =
+            vault.get(annotationPageRef);
+          annotationPage?.items?.forEach(
+            (annotationRef: Reference<"Annotation">) => {
+              const annotation: AnnotationNormalized = vault.get(annotationRef);
+              if (annotation) {
+                allAnnotations.push({
+                  ...annotation,
+                  body: annotation?.body?.map((bodyRef) => vault.get(bodyRef)),
+                });
+              }
+            },
+          );
+        },
+      );
+    });
+
+    /**
+     * Removes duplicate annotations if they exist
+     */
+    const uniqueAnnotations = allAnnotations.reduce(
+      (accumulator: AnnotationNormalized[], current: AnnotationNormalized) => {
+        if (!accumulator.some((a: AnnotationNormalized) => a.id === current.id))
+          accumulator.push(current);
+        return accumulator;
+      },
+      [],
+    );
+
+    setProcessedAnnotations(uniqueAnnotations);
+  }, [items, vault]);
+
+  return processedAnnotations;
+};
+
+export default useManifestAnnotations;

--- a/src/hooks/useOverlapObserver.ts
+++ b/src/hooks/useOverlapObserver.ts
@@ -1,0 +1,35 @@
+import { RefObject, useEffect, useState } from "react";
+
+const useOverlapObserver = (
+  targetRef: RefObject<HTMLElement>,
+  rootRef: RefObject<HTMLElement>,
+) => {
+  const [isOverlapping, setIsOverlapping] = useState(false);
+
+  useEffect(() => {
+    const target = targetRef?.current;
+    const root = rootRef?.current;
+
+    if (!target || !root) return;
+
+    const observerCallback: IntersectionObserverCallback = (entries) => {
+      entries.forEach((entry) => {
+        setIsOverlapping(entry.isIntersecting);
+      });
+    };
+
+    const observer = new IntersectionObserver(observerCallback, {
+      root: root,
+    });
+
+    observer.observe(target);
+
+    return () => {
+      observer.unobserve(target);
+    };
+  }, [targetRef, rootRef]);
+
+  return isOverlapping;
+};
+
+export default useOverlapObserver;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,7 +1,8 @@
 import Primitives from "src/components/Primitives";
+import Scroll from "src/components/Scroll";
 import Slider from "src/components/Slider";
 import Viewer from "src/components/Viewer";
 
-export { Primitives, Slider, Viewer };
+export { Primitives, Scroll, Slider, Viewer };
 
 export default Viewer;

--- a/theme.config.tsx
+++ b/theme.config.tsx
@@ -1,6 +1,7 @@
 import { DocsThemeConfig } from "nextra-theme-docs";
 import Logo from "./docs/components/Logo";
 import React from "react";
+import TitleComponent from "./docs/components/TitleComponent";
 import { useConfig } from "nextra-theme-docs";
 import { useMemo } from "react";
 import { useRouter } from "next/router";
@@ -68,6 +69,8 @@ const config: DocsThemeConfig = {
   sidebar: {
     autoCollapse: true,
     defaultMenuCollapseLevel: 1,
+    titleComponent: (props) => <TitleComponent {...props} />,
+    toggleButton: true,
   },
 };
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -32,6 +32,10 @@
     "target": "esnext",
     "types": ["vitest/globals"],
   },
+  "paths": {
+    "docs/*": ["docs/*"],
+    "src/*": ["src/*"],
+  },
   "exclude": ["dist", "node_modules", "theme.config.tsx", "vite.*"],
   "include": [
     "next-env.d.ts",
@@ -39,6 +43,6 @@
     "**/*.tsx",
     "../index.ts",
     ".next/types/**/*.ts",
-    "src/setupTests.ts",
+    "src/test.ts",
   ],
 }


### PR DESCRIPTION
This work that introduces the early stages of a `Scroll` component for Clover with some minimal options at first. The Scroll component will render a IIIF Manifest as articles on a page, with each item rendering the Canvas along with textual body annotations.

By default, the Annotations bodies will be indexed client-side via `flexsearch`, effectively allowing end users to search within annotations for a IIIF Manifest. The default configuration for flexsearch is currently hardcoded with simple settings for Latin, Arabic, Cyrillic, and Chinese/Japanese/Korean charsets, but should be made configurable in a future near release.

My goal is release this as 2.7.0.

Some Manifests to test:

- https://iiif-maktaba.dc.rdc-staging.library.northwestern.edu/fac685b6-1658-476c-afd4-4126bec63645.json
- https://digital.lib.utk.edu/assemble/manifest/civilwar/4308