### PR TITLE
Support custom request headers, including `"Authorization": "Bearer ${token}"`

### DIFF
--- a/pages/docs/viewer.mdx
+++ b/pages/docs/viewer.mdx
@@ -142,23 +142,24 @@ const MyCustomViewer = () => {
 
 `Viewer` can configured through an `options` prop, which will serve as a object for common options.
 
-| Prop                            | Type                    | Required | Default   |
-| ------------------------------- | ----------------------- | -------- | --------- |
-| `iiifContent`                   | `string`                | Yes      |           |
-| `id` _(deprecated)_             | `string`                | No       |           |
-| `manifestId` _(deprecated)_     | `string`                | No       |           |
-| `canvasIdCallback`              | `function`              | No       |           |
-| `customTheme`                   | `object`                | No       |           |
-| `options`                       | `object`                | No       |           |
-| `options.canvasBackgroundColor` | `string`                | No       | `#1a1d1e` |
-| `options.canvasHeight`          | `string`                | No       | `500px`   |
-| `options.ignoreCaptionLabels`   | `string[]`              | No       | []        |
-| `options.openSeadragon`         | `OpenSeadragon.Options` | No       |           |
-| `options.renderAbout`           | `boolean`               | No       | true      |
-| `options.showIIIFBadge`         | `boolean`               | No       | true      |
-| `options.showInformationToggle` | `boolean`               | No       | true      |
-| `options.showTitle`             | `boolean`               | No       | true      |
-| `options.withCredentials`       | `boolean`               | No       | false     |
+| Prop                            | Type                    | Required | Default                                  |
+| ------------------------------- | ----------------------- | -------- | ---------------------------------------- |
+| `iiifContent`                   | `string`                | Yes      |                                          |
+| `id` _(deprecated)_             | `string`                | No       |                                          |
+| `manifestId` _(deprecated)_     | `string`                | No       |                                          |
+| `canvasIdCallback`              | `function`              | No       |                                          |
+| `customTheme`                   | `object`                | No       |                                          |
+| `options`                       | `object`                | No       |                                          |
+| `options.canvasBackgroundColor` | `string`                | No       | `#1a1d1e`                                |
+| `options.canvasHeight`          | `string`                | No       | `500px`                                  |
+| `options.ignoreCaptionLabels`   | `string[]`              | No       | []                                       |
+| `options.openSeadragon`         | `OpenSeadragon.Options` | No       |                                          |
+| `options.renderAbout`           | `boolean`               | No       | true                                     |
+| `options.requestHeaders`        | `IncomingHttpHeaders`   | No       | `{ "Content-Type": "application/json" }` |
+| `options.showIIIFBadge`         | `boolean`               | No       | true                                     |
+| `options.showInformationToggle` | `boolean`               | No       | true                                     |
+| `options.showTitle`             | `boolean`               | No       | true                                     |
+| `options.withCredentials`       | `boolean`               | No       | false                                    |
 
 - Options `canvasBackgroundColor` and `canvasHeight` will apply to both `<video>` elements and the OpenseaDragon canvas.
 - Options `renderAbout` and `showInformationToggle` relate to rendering Manifest content in an `<aside>` and providing user the choice to close that panel.
@@ -276,4 +277,29 @@ const customTheme = {
 };
 
 return <Viewer iiifContent={iiifContent} customTheme={customTheme} />;
+```
+
+---
+
+### Request Headers
+
+In some cases, a client may need to request Manifest or Collection resources with custom request headers, ex: `Authorization`. This can be done by passing a `requestHeaders` object to the `options` prop. This object will be passed to the request call made by the Viewer. Accepted **header** keys are defined in the [IncomingHttpHeaders](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/node/http.d.ts) interface.
+
+```jsx
+const iiifContent =
+  "https://api.dc.library.northwestern.edu/api/v2/works/8a833741-74a8-40dc-bd1d-c416a3b1bb38?as=iiif";
+
+const token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...";
+
+return (
+  <Viewer
+    iiifContent={iiifContent}
+    options={{
+      requestHeaders: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${token}`,
+      },
+    }}
+  />
+);
 ```

--- a/src/components/Viewer/Navigator/Cue.styled.tsx
+++ b/src/components/Viewer/Navigator/Cue.styled.tsx
@@ -25,7 +25,7 @@ export const Item = styled(RadioGroup.Item, {
   fontFamily: "inherit",
   lineHeight: "1.25em",
   fontSize: "1rem",
-  color: "$primaryMuted",
+  color: "inherit",
   border: "none",
   background: "none",
 

--- a/src/components/Viewer/Navigator/Navigator.styled.tsx
+++ b/src/components/Viewer/Navigator/Navigator.styled.tsx
@@ -1,4 +1,5 @@
 import * as Tabs from "@radix-ui/react-tabs";
+
 import { styled } from "src/styles/stitches.config";
 
 const Wrapper = styled(Tabs.Root, {
@@ -35,7 +36,6 @@ const Trigger = styled(Tabs.Trigger, {
   padding: "0.5rem 1rem",
   background: "none",
   backgroundColor: "transparent",
-  color: "$primaryMuted",
   border: "none",
   fontSize: "1rem",
   marginRight: "1rem",
@@ -49,15 +49,10 @@ const Trigger = styled(Tabs.Trigger, {
     width: "0",
     height: "4px",
     content: "",
-    backgroundColor: "$primaryMuted",
     position: "absolute",
     bottom: "-4px",
     left: "0",
     transition: "$all",
-  },
-
-  "&:hover": {
-    color: "$primary",
   },
 
   "&[data-state='active']": {

--- a/src/components/Viewer/Painting/Painting.styled.tsx
+++ b/src/components/Viewer/Painting/Painting.styled.tsx
@@ -1,6 +1,6 @@
-import { styled } from "src/styles/stitches.config";
-import { ToggleStyled } from "src/components/Viewer/Painting/Toggle.styled";
 import { PlaceholderStyled } from "./Placeholder.styled";
+import { ToggleStyled } from "src/components/Viewer/Painting/Toggle.styled";
+import { styled } from "src/styles/stitches.config";
 
 const PaintingStyled = styled("div", {
   position: "relative",
@@ -12,7 +12,7 @@ const PaintingStyled = styled("div", {
     },
 
     [`${PlaceholderStyled}`]: {
-      backgroundColor: "$secondaryAlt",
+      backgroundColor: "#6662",
 
       img: {
         filter: "brightness(0.85)",

--- a/src/components/Viewer/index.tsx
+++ b/src/components/Viewer/index.tsx
@@ -48,6 +48,7 @@ const CloverViewer: React.FC<CloverViewerProps> = ({
           customFetcher: (url: string) =>
             getRequest(url, {
               withCredentials: options?.withCredentials as boolean,
+              headers: options?.requestHeaders,
             }).then((response) => JSON.parse(response.data)),
         }),
       }}

--- a/src/context/viewer-context.tsx
+++ b/src/context/viewer-context.tsx
@@ -1,6 +1,8 @@
-import { Options as OpenSeadragonOptions } from "openseadragon";
 import React, { useReducer } from "react";
+
 import { CollectionNormalized } from "@iiif/presentation-3";
+import { IncomingHttpHeaders } from "http";
+import { Options as OpenSeadragonOptions } from "openseadragon";
 import { Vault } from "@iiif/vault";
 
 export type ViewerConfigOptions = {
@@ -13,10 +15,11 @@ export type ViewerConfigOptions = {
   showInformationToggle?: boolean;
   showTitle?: boolean;
   withCredentials?: boolean;
+  requestHeaders?: IncomingHttpHeaders;
 };
 
 const defaultConfigOptions = {
-  canvasBackgroundColor: "#e6e8eb",
+  canvasBackgroundColor: "#6662",
   canvasHeight: "61.8vh",
   ignoreCaptionLabels: [],
   openSeadragon: {},
@@ -25,6 +28,7 @@ const defaultConfigOptions = {
   showInformationToggle: true,
   showTitle: true,
   withCredentials: false,
+  requestHeaders: { "Content-Type": "application/json" },
 };
 
 interface ViewerContextStore {

--- a/src/lib/xhr.ts
+++ b/src/lib/xhr.ts
@@ -1,6 +1,8 @@
+import { IncomingHttpHeaders } from "http";
+
 export interface RequestOptions {
   ignoreCache?: boolean;
-  headers?: { [key: string]: string };
+  headers?: IncomingHttpHeaders;
   timeout?: number;
   withCredentials: boolean;
 }
@@ -36,7 +38,7 @@ function parseXHRResult(xhr: XMLHttpRequest): RequestResult {
 
 function errorResponse(
   xhr: XMLHttpRequest,
-  message: string | null = null,
+  message: string | null = null
 ): RequestResult {
   return {
     ok: false,
@@ -50,7 +52,7 @@ function errorResponse(
 
 export function getRequest(
   url: string,
-  options: RequestOptions = DEFAULT_REQUEST_OPTIONS,
+  options: RequestOptions = DEFAULT_REQUEST_OPTIONS
 ) {
   const headers = options.headers || DEFAULT_REQUEST_OPTIONS.headers;
 
@@ -61,7 +63,7 @@ export function getRequest(
 
     if (headers) {
       Object.keys(headers).forEach((key) =>
-        xhr.setRequestHeader(key, headers[key]),
+        xhr.setRequestHeader(key, headers[key])
       );
     }
 


### PR DESCRIPTION
## What does this do?

This adds the ability for customization of the request headers made by the Clover viewer. For example:

Noted in the revised documentation for the VIewer component:

> In some cases, a client may need to request Manifest or Collection resources with custom request headers, ex: `Authorization`. This can be done by passing a `requestHeaders` object to the `options` prop. This object will be passed to the request call made by the Viewer. Accepted **header** keys are defined in the [IncomingHttpHeaders](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/node/http.d.ts) interface.

Example:

```jsx
const iiifContent =
  "https://api.dc.library.northwestern.edu/api/v2/works/8a833741-74a8-40dc-bd1d-c416a3b1bb38?as=iiif";

const token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...";

return (
  <Viewer
    iiifContent={iiifContent}
    options={{
      requestHeaders: {
        "Content-Type": "application/json",
        Authorization: `Bearer ${token}`,
      },
    }}
  />
);
```


Additionally, adjustments were made to allow Viewer navigator component Cues and Tabs to inherit color from the consuming application. The background color of the canvas is also less stark now by using alpha transparency.
