### PR TITLE
Add non-next dev ability. Address accessibility concerns.

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,6 +8,6 @@
   </head>
   <body>
     <div id="root"></div>
-    <script type="module" src="./index.tsx"></script>
+    <script type="module" src="/src/dev.tsx"></script>
   </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "clean": "rimraf dist",
     "coverage": "vitest --ui --coverage",
     "dev": "next dev",
+    "dev:vite": "vite",
     "prepublishOnly": "npm run build",
     "start": "next start",
     "test": "vitest",

--- a/pages/index.mdx
+++ b/pages/index.mdx
@@ -24,16 +24,16 @@ import "swiper/css/pagination";
 <HomepageHeader />
 <Splash>
   <SplashElement
-    css={{ height: "61.8vh" }}
+    css={{ height: "820px" }}
     text="Viewer"
     component={
       <Viewer
         iiifContent="https://api.dc.library.northwestern.edu/api/v2/works/71153379-4283-43be-8b0f-4e7e3bfda275?as=iiif"
         options={{
-          showTitle: false,
-          showInformationToggle: false,
-          showIIIFBadge: false,
-          canvasBackgroundColor: "transparent"
+          canvasHeight: "600px",
+          informationPanel: {
+            open: true,
+          }
         }}
       />
     }
@@ -45,7 +45,7 @@ import "swiper/css/pagination";
   </SplashElement>
   <SplashElement
     text="Slider"
-    css={{ height: "38.2vh" }}
+    css={{ height: "600px" }}
     component={
       <Slider collectionId="https://api.dc.library.northwestern.edu/api/v2/collections/c373ecd2-2c45-45f2-9f9e-52dc244870bd?as=iiif" />
     }

--- a/src/components/Slider/Header/Control.styled.ts
+++ b/src/components/Slider/Header/Control.styled.ts
@@ -38,12 +38,12 @@ const ControlStyled = styled("button", {
 
   [`&:disabled`]: {
     [`> ${Icon}`]: {
-      backgroundColor: "$secondaryAlt",
+      backgroundColor: "#6663",
       boxShadow: "none",
 
       svg: {
-        fill: "$secondaryMuted",
-        stroke: "$secondaryMuted",
+        fill: "$secondary",
+        stroke: "$secondary",
         filter: "unset",
       },
     },

--- a/src/components/Slider/Header/Header.styled.ts
+++ b/src/components/Slider/Header/Header.styled.ts
@@ -33,7 +33,6 @@ const HeaderStyled = styled("div", {
   },
 
   ".clover-slider-header-homepage": {
-    color: "$accent",
     textDecoration: "none",
   },
 

--- a/src/components/Slider/Header/Header.tsx
+++ b/src/components/Slider/Header/Header.tsx
@@ -76,13 +76,10 @@ const Header: React.FC<HeaderProps> = ({
           </Icon>
         </ControlStyled>
         {hasHomepage && (
-          <Homepage
-            // @ts-ignore
+          <ViewAll
             homepage={homepage}
             className="clover-slider-header-view-all"
-          >
-            <ViewAll />
-          </Homepage>
+          />
         )}
       </HeaderControls>
     </HeaderStyled>

--- a/src/components/Slider/Header/ViewAll.tsx
+++ b/src/components/Slider/Header/ViewAll.tsx
@@ -1,23 +1,24 @@
+import { Homepage } from "src/components/Primitives";
 import React from "react";
 import { styled } from "src/styles/stitches.config";
 
-const ViewAllStyled = styled("span", {
+const ViewAllStyled = styled(Homepage, {
   display: "flex",
-  background: "none",
+  backgroundColor: "$accent",
+  color: "$secondary",
   height: "2rem !important",
   padding: "0 $3",
   margin: "0 0 0 $3",
   borderRadius: "2rem",
-  backgroundColor: "$accent",
-  color: "$secondary",
   cursor: "pointer",
   boxSizing: "content-box !important",
   transition: "$all",
   justifyContent: "center",
   alignItems: "center",
-  fontSize: "0.8333rem",
   lineBreak: "none",
   whiteSpace: "nowrap",
+  textDecoration: "none !important",
+  fontSize: "0.8333rem",
 
   [`&:hover`]: {
     backgroundColor: "$accentAlt",
@@ -29,8 +30,8 @@ const ViewAllStyled = styled("span", {
   },
 });
 
-const ViewAll = () => {
-  return <ViewAllStyled>View All</ViewAllStyled>;
+const ViewAll = (props) => {
+  return <ViewAllStyled {...props}>View All</ViewAllStyled>;
 };
 
 export default ViewAll;

--- a/src/components/Viewer/Viewer/Header.styled.ts
+++ b/src/components/Viewer/Viewer/Header.styled.ts
@@ -59,6 +59,7 @@ const Header = styled("header", {
   backgroundColor: "transparent !important",
   justifyContent: "space-between",
   alignItems: "flex-start",
+  width: "100%",
 
   [`> ${CollectionStyled}`]: {
     flexGrow: "1",
@@ -74,9 +75,10 @@ const Header = styled("header", {
 const HeaderOptions = styled("div", {
   display: "flex",
   alignItems: "flex-end",
+  justifyContent: "flex-end",
   padding: "1rem",
   flexShrink: "0",
-  flexGrow: "0",
+  flexGrow: "1",
 });
 
 export {

--- a/src/components/Viewer/Viewer/Toggle.tsx
+++ b/src/components/Viewer/Viewer/Toggle.tsx
@@ -29,6 +29,8 @@ const Toggle = () => {
         checked={checked}
         onCheckedChange={() => setChecked(!checked)}
         id="information-toggle"
+        aria-label="information panel toggle"
+        name="toggled?"
       >
         <StyledThumb />
       </StyledSwitch>

--- a/src/dev.tsx
+++ b/src/dev.tsx
@@ -1,0 +1,79 @@
+import "swiper/css";
+import "swiper/css/navigation";
+import "swiper/css/pagination";
+
+import {
+  Homepage,
+  Label,
+  Metadata,
+  PartOf,
+  RequiredStatement,
+  SeeAlso,
+  Summary,
+  Thumbnail,
+} from "src/components/Primitives";
+import {
+  IIIFExternalWebResource,
+  InternationalString,
+  Manifest,
+  MetadataItem,
+} from "@iiif/presentation-3";
+import {
+  PrimitivesExternalWebResource,
+  PrimitivesIIIFResource,
+} from "./types/primitives";
+import React, { useEffect, useState } from "react";
+
+import ReactDOM from "react-dom/client";
+import Slider from "src/components/Slider";
+import Viewer from "src/components/Viewer";
+
+const App = () => {
+  const [manifest, setManifest] = useState<Manifest>();
+
+  const manifestId =
+    "https://api.dc.library.northwestern.edu/api/v2/works/71153379-4283-43be-8b0f-4e7e3bfda275?as=iiif";
+  const collectionId =
+    "https://api.dc.library.northwestern.edu/api/v2/collections/c373ecd2-2c45-45f2-9f9e-52dc244870bd?as=iiif";
+
+  useEffect(() => {
+    (async () => {
+      const data = await fetch(manifestId).then((response) => response.json());
+      setManifest(data);
+    })();
+  }, [manifest]);
+
+  if (!manifest) return null;
+
+  return (
+    <div style={{ padding: "1rem" }}>
+      <Viewer iiifContent={manifestId} />
+      <Slider iiifContent={collectionId} />
+      <article>
+        <Label label={manifest.label} as="h1" />
+        <Summary summary={manifest.summary as InternationalString} />
+        <Metadata metadata={manifest.metadata as MetadataItem[]} />
+        <RequiredStatement
+          requiredStatement={manifest.requiredStatement as MetadataItem}
+        />
+        <Homepage
+          homepage={manifest.homepage as PrimitivesExternalWebResource[]}
+        />
+        <PartOf partOf={manifest.partOf as PrimitivesIIIFResource[]} />
+        <SeeAlso
+          seeAlso={manifest.seeAlso as PrimitivesExternalWebResource[]}
+        />
+        <Thumbnail
+          thumbnail={manifest.thumbnail as IIIFExternalWebResource[]}
+          altAsLabel={manifest.label as InternationalString}
+        />
+      </article>
+    </div>
+  );
+};
+
+ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/src/styles/stitches.config.tsx
+++ b/src/styles/stitches.config.tsx
@@ -16,9 +16,9 @@ export const theme = {
      * Key brand color(s).
      * Must contrast to 4.5 or greater with `secondary`.
      */
-    accent: `hsl(${hue} 100% 45%)`,
+    accent: `hsl(${hue} 100% 38.2%)`,
     accentMuted: `hsl(${hue} 80% 61.8%)`,
-    accentAlt: `hsl(${hue} 80% 38.2%)`,
+    accentAlt: `hsl(${hue} 80% 30%)`,
 
     /*
      * White and light grays in a light theme.


### PR DESCRIPTION
## What does this do?

1. This adds the ability for us to test Clover components in a vite-spun environment without Nextra. This can be run by: `npm run dev:vite`.
2. Uses Lighthouse to assess accessibility of components, initial score be **82**.

![image](https://github.com/samvera-labs/clover-iiif/assets/7376450/8ebc09f5-bcf4-42a1-a74b-e72783cbd9df)

3. Address issues:
- Name issue on information toggle (resolved with combination of arial-label and name attributes)
- Contrast issue on Slider header elements (resolved by combination of allowing inheriting header text color, and making our default accent color a bit darker)
- The remaining `dl` issue(s) are not actually a modern problem. It looks like Lighthouse uses an outdated spec in its analysis and does not account for [this ~2016 change](https://html.spec.whatwg.org/multipage/grouping-content.html#the-dl-element) that allows `div` groups of `dt` and `dd` values within a `dl`.  
- Given this, I think the 96 is actually a 💯 

![image](https://github.com/samvera-labs/clover-iiif/assets/7376450/c107a041-f5ec-4b1d-b75b-5e189da72dda)


 