### PR TITLE
Update CORS setting on Thumbnail component

### DIFF
--- a/src/components/Primitives/ContentResource/ContentResource.tsx
+++ b/src/components/Primitives/ContentResource/ContentResource.tsx
@@ -116,6 +116,7 @@ const ContentResource: React.FC<PrimitivesContentResource> = (props) => {
         <StyledResource
           as="img"
           alt={alt}
+          crossOrigin="anonymous"
           css={{ width: width, height: height }}
           key={id}
           src={imgSrc}
@@ -127,6 +128,7 @@ const ContentResource: React.FC<PrimitivesContentResource> = (props) => {
       return (
         <StyledResource
           as="video"
+          crossOrigin="anonymous"
           css={{ width: width, height: height }}
           disablePictureInPicture
           key={id}


### PR DESCRIPTION
## What does this do?
Add `crossorigin` attribute to underlying `img` tag in Thumbnail, to help with CORS display errors.  The problem is that Canopy doesn't load `img` resources in StackBlitz sandbox environments.

See this issue for more context:
https://github.com/nulib/dc-api-v2/issues/178

## How to test?
See this StackBlitz instance (open in Firefox and Safari browsers to see the potential fix):
https://stackblitz.com/edit/cors-corp-image-example-pzxncq
