### PR TITLE
Bug fix to play audio files

### DIFF
--- a/src/components/Viewer/Player/Player.tsx
+++ b/src/components/Viewer/Player/Player.tsx
@@ -153,7 +153,7 @@ const Player: React.FC<PlayerProps> = ({ allSources, resources, painting }) => {
         style={{
           maxHeight: configOptions.canvasHeight,
           position: "relative",
-          zIndex: "0",
+          zIndex: "1",
         }}
       >
         {allSources.map((painting) => (


### PR DESCRIPTION
## What does this do?

- Fixes a bug which was overlaying the "audio visualizer" element on top of the `video` element when playing audio files, thereby not allowing a user to play audio files in the UI.
- Fix an audio visualizer component bug when a user clicks around to different time values in the `video` element

![image](https://github.com/samvera-labs/clover-iiif/assets/3020266/597b4d15-1ad1-40af-a869-6543e262f918)

## How to test
- Spin up the app in local dev environment
- Test this link and verify you can play the audio file in the UI, and the visualizer appears:

http://localhost:3000/docs/viewer/demo?iiif-content=https://iiif.io/api/cookbook/recipe/0002-mvm-audio/manifest.json



