### PR TITLE
Update for determining Sound annotation body type

### DIFF
--- a/src/components/Viewer/Player/Player.tsx
+++ b/src/components/Viewer/Player/Player.tsx
@@ -22,7 +22,7 @@ const Player: React.FC<PlayerProps> = ({ allSources, resources, painting }) => {
   const [currentTime, setCurrentTime] = React.useState<number>(0);
   const [poster, setPoster] = React.useState<string | undefined>();
   const playerRef = React.useRef<HTMLVideoElement>(null);
-  const isAudio = painting?.format?.includes("audio/");
+  const isAudio = painting?.type === "Sound";
 
   const viewerState: ViewerContextStore = useViewerState();
   const { activeCanvas, configOptions, vault } = viewerState;


### PR DESCRIPTION
## What does this do?

Updates how Clover Viewer determines what is a `Sound` type file, which will help cue when the Audio Visualizer displays for streaming and non-streaming files.

![image](https://github.com/samvera-labs/clover-iiif/assets/3020266/9d49c1f8-233d-46b5-824e-f5fbeacf58f9)

## How to test
1. Pull down this branch locally
2. Test a streaming Audio Canvas: http://localhost:3001/docs/viewer/demo?iiif-content=https://dcapi.rdc-staging.library.northwestern.edu/api/v2/works/d2a423b1-6b5e-45cb-9956-46a99cd62cfd?as=iiif
3. Test a non-streaming Audio Canvas: http://localhost:3001/docs/viewer/demo?iiif-content=https://iiif.io/api/cookbook/recipe/0002-mvm-audio/manifest.json