### PR TITLE
Add CSS helper classes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # dev
 .build
 .next
+.vscode/
 dist
 node_modules
 out

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,0 @@
-{
-  "editor.codeActionsOnSave": {
-    "source.fixAll.eslint": true
-  },
-  "editor.formatOnSave": true,
-  "editor.defaultFormatter": "esbenp.prettier-vscode"
-}

--- a/pages/docs/viewer.mdx
+++ b/pages/docs/viewer.mdx
@@ -296,6 +296,19 @@ const customTheme = {
 return <Viewer iiifContent={iiifContent} customTheme={customTheme} />;
 ```
 
+#### CSS Classes
+
+Additional CSS classes are made available on structural HTML elements in the Viewer, which may be referenced in a client's own CSS files/style definitions to further customize the Viewer's appearance. You may inspect the DOM to see classes applied to each element, but in general it follows a pattern similar to:
+
+```html
+<div class="clover-viewer">
+  <header class="clover-viewer-header" />
+  <div class="clover-viewer-content">
+    <div class="clover-viewer-painting">...</div>
+  </div>
+</div>
+```
+
 ---
 
 ### Request Headers

--- a/src/components/Viewer/ImageViewer/OSD.test.tsx
+++ b/src/components/Viewer/ImageViewer/OSD.test.tsx
@@ -1,0 +1,27 @@
+import OSD, { osdImageTypes } from "./OSD";
+import { render, screen } from "@testing-library/react";
+
+import React from "react";
+
+const props = {
+  uri: "foobar",
+  hasPlaceholder: false,
+  imageType: "simpleImage" as osdImageTypes,
+};
+
+vi.mock("openseadragon", () => ({
+  default: () => {
+    return {
+      addSimpleImage: () => {},
+    };
+  },
+}));
+
+describe("OSD", () => {
+  test("renders an element with the 'clover-viewer-osd' class name", () => {
+    render(<OSD {...props} />);
+    expect(screen.getByTestId("clover-viewer-osd-wrapper")).toHaveClass(
+      "clover-viewer-osd-wrapper",
+    );
+  });
+});

--- a/src/components/Viewer/ImageViewer/OSD.tsx
+++ b/src/components/Viewer/ImageViewer/OSD.tsx
@@ -90,6 +90,8 @@ const OSD: React.FC<OSDProps> = ({ uri, hasPlaceholder, imageType }) => {
         backgroundColor: configOptions.canvasBackgroundColor,
         height: configOptions.canvasHeight,
       }}
+      className="clover-viewer-osd-wrapper"
+      data-testid="clover-viewer-osd-wrapper"
     >
       <Controls hasPlaceholder={hasPlaceholder} options={config} />
       <Navigator id={`openseadragon-navigator-${osdInstance}`} />

--- a/src/components/Viewer/InformationPanel/InformationPanel.test.tsx
+++ b/src/components/Viewer/InformationPanel/InformationPanel.test.tsx
@@ -1,0 +1,31 @@
+// Write a unit test for whether the InformationPanel component renders correctly and also renders an element with the 'clover-viewer-information-panel' class name.
+
+import { render, screen } from "@testing-library/react";
+
+import InformationPanel from "./InformationPanel";
+import React from "react";
+
+const props = {
+  activeCanvas: "foobar",
+  resources: [],
+};
+
+vi.mock("src/components/Viewer/InformationPanel/Resource", () => ({
+  default: () => {
+    return <div data-testid="mock-resource">Resource</div>;
+  },
+}));
+vi.mock("src/components/Viewer/InformationPanel/About/About", () => ({
+  default: () => {
+    return <div data-testid="mock-information">Information</div>;
+  },
+}));
+
+describe("InformationPanel", () => {
+  test("renders an element with the 'clover-viewer-information-panel' class name", () => {
+    render(<InformationPanel {...props} />);
+    expect(screen.getByTestId("information-panel")).toHaveClass(
+      "clover-viewer-information-panel",
+    );
+  });
+});

--- a/src/components/Viewer/InformationPanel/InformationPanel.tsx
+++ b/src/components/Viewer/InformationPanel/InformationPanel.tsx
@@ -54,6 +54,7 @@ export const InformationPanel: React.FC<NavigatorProps> = ({
       onValueChange={handleValueChange}
       orientation="horizontal"
       value={activeResource}
+      className="clover-viewer-information-panel"
     >
       <List aria-label="select chapter" data-testid="information-panel-list">
         {renderAbout && <Trigger value="manifest-about">About</Trigger>}

--- a/src/components/Viewer/Painting/Painting.tsx
+++ b/src/components/Viewer/Painting/Painting.tsx
@@ -42,7 +42,7 @@ const Painting: React.FC<PaintingProps> = ({
   };
 
   return (
-    <PaintingStyled>
+    <PaintingStyled className="clover-viewer-painting">
       <PaintingCanvas
         style={{
           backgroundColor: configOptions.canvasBackgroundColor,

--- a/src/components/Viewer/Painting/Placeholder.test.tsx
+++ b/src/components/Viewer/Painting/Placeholder.test.tsx
@@ -1,0 +1,18 @@
+import { render, screen } from "@testing-library/react";
+
+import PaintingPlaceholder from "./Placeholder";
+import React from "react";
+
+const props = {
+  isMedia: false,
+  label: { en: ["label"] },
+  placeholderCanvas: "foobar",
+  setIsInteractive: vi.fn(),
+};
+
+describe("PaintingPlaceholder", () => {
+  test("renders an element with the 'clover-viewer-placeholder' class name", () => {
+    render(<PaintingPlaceholder {...props} />);
+    expect(screen.getByRole("button")).toHaveClass("clover-viewer-placeholder");
+  });
+});

--- a/src/components/Viewer/Painting/Placeholder.tsx
+++ b/src/components/Viewer/Painting/Placeholder.tsx
@@ -28,7 +28,11 @@ const PaintingPlaceholder: React.FC<Props> = ({
     : ["placeholder image"];
 
   return (
-    <PlaceholderStyled onClick={() => setIsInteractive(true)} isMedia={isMedia}>
+    <PlaceholderStyled
+      onClick={() => setIsInteractive(true)}
+      isMedia={isMedia}
+      className="clover-viewer-placeholder"
+    >
       <img
         src={placeholder?.id || ""}
         alt={labelAsArray.join()}

--- a/src/components/Viewer/Player/Player.tsx
+++ b/src/components/Viewer/Player/Player.tsx
@@ -141,6 +141,7 @@ const Player: React.FC<PlayerProps> = ({ allSources, resources, painting }) => {
         position: "relative",
       }}
       data-testid="player-wrapper"
+      className="clover-viewer-player-wrapper"
     >
       <video
         id="clover-iiif-video"

--- a/src/components/Viewer/Viewer/Content.test.tsx
+++ b/src/components/Viewer/Viewer/Content.test.tsx
@@ -1,0 +1,44 @@
+import { render, screen } from "@testing-library/react";
+
+import React from "react";
+import ViewerContent from "./Content";
+
+vi.mock("../Painting/Painting", () => ({
+  default: () => {
+    return <div data-testid="mock-painting">Painting</div>;
+  },
+}));
+vi.mock("src/components/Viewer/InformationPanel/InformationPanel", () => ({
+  default: () => {
+    return <div data-testid="mock-information-panel">Information Panel</div>;
+  },
+}));
+vi.mock("@radix-ui/react-collapsible", () => ({
+  Content: () => {
+    return (
+      <div data-testid="mock-collapsible-content">Collapsible Content</div>
+    );
+  },
+  Trigger: () => {
+    return (
+      <div data-testid="mock-collapsible-trigger">Collapsible Trigger</div>
+    );
+  },
+}));
+
+const props = {
+  activeCanvas: "foobar",
+  painting: [],
+  resources: [],
+  items: [],
+  isAudioVideo: false,
+};
+
+describe("ViewerContent", () => {
+  test("renders an element with the 'clover-viewer-content' class name", () => {
+    render(<ViewerContent {...props} />);
+    expect(screen.getByTestId("clover-viewer-content")).toHaveClass(
+      "clover-viewer-content",
+    );
+  });
+});

--- a/src/components/Viewer/Viewer/Content.tsx
+++ b/src/components/Viewer/Viewer/Content.tsx
@@ -43,7 +43,10 @@ const ViewerContent: React.FC<Props> = ({
     (informationPanel?.renderSupplementing && resources.length > 0);
 
   return (
-    <Content className="clover-content">
+    <Content
+      className="clover-viewer-content"
+      data-testid="clover-viewer-content"
+    >
       <Main>
         <Painting
           activeCanvas={activeCanvas}
@@ -59,7 +62,7 @@ const ViewerContent: React.FC<Props> = ({
         )}
 
         {items.length > 1 && (
-          <MediaWrapper className="clover-canvases">
+          <MediaWrapper className="clover-viewer-media-wrapper">
             <Media items={items} activeItem={0} />
           </MediaWrapper>
         )}

--- a/src/components/Viewer/Viewer/Header.tsx
+++ b/src/components/Viewer/Viewer/Header.tsx
@@ -36,12 +36,12 @@ const ViewerHeader: React.FC<Props> = ({ manifestId, manifestLabel }) => {
   const isSmallViewport = useMediaQuery(media.sm);
 
   return (
-    <Header className="clover-header">
+    <Header className="clover-viewer-header">
       {collection?.items ? (
         <Collection />
       ) : (
         <ManifestLabel className={!showTitle ? "visually-hidden" : ""}>
-          {showTitle && <Label label={manifestLabel} />}
+          {showTitle && <Label label={manifestLabel} className="label" />}
         </ManifestLabel>
       )}
       {hasOptions && (

--- a/src/components/Viewer/Viewer/Viewer.tsx
+++ b/src/components/Viewer/Viewer/Viewer.tsx
@@ -103,7 +103,7 @@ const Viewer: React.FC<ViewerProps> = ({ manifest, theme }) => {
   return (
     <ErrorBoundary FallbackComponent={ErrorFallback}>
       <Wrapper
-        className={`${theme} clover-iiif`}
+        className={`${theme} clover-viewer`}
         css={{ background: configOptions?.background }}
         data-body-locked={isBodyLocked}
         data-information-panel={isInformationPanel}


### PR DESCRIPTION
## What does this do?
Adds CSS helper classes which consuming applications can target to further customize the Clover Viewer.

## How to test
- General opinion on the class naming convention
- Run the test suite (tests added to verify class names exist and don't get knocked out of place)

## General notes
@mathewjordan This might seem like a small change, but Clover commits to providing this vehicle for customization, its pretty important to clearly announce/document any changes to class names so as not to break client app styling.

