### PR TITLE
Allow Annotations tab value configuration

### DIFF
--- a/pages/docs/viewer.mdx
+++ b/pages/docs/viewer.mdx
@@ -168,12 +168,13 @@ const MyCustomViewer = () => {
 
 The information panel is a collapsible panel that displays information about the current Manifest and renders supplementing resources for the active canvas. It is rendered by default, but can be configured to be hidden or to render only certain tabs.
 
-| Prop                                           | Type      | Required | Default |
-| ---------------------------------------------- | --------- | -------- | ------- |
-| `options.informationPanel.open`                | `boolean` | No       | true    |
-| `options.informationPanel.renderAbout`         | `boolean` | No       | true    |
-| `options.informationPanel.renderSupplementing` | `boolean` | No       | true    |
-| `options.informationPanel.renderToggle`        | `boolean` | No       | true    |
+| Prop                                                 | Type      | Required | Default       |
+| ---------------------------------------------------- | --------- | -------- | ------------- |
+| `options.informationPanel.open`                      | `boolean` | No       | true          |
+| `options.informationPanel.renderAbout`               | `boolean` | No       | true          |
+| `options.informationPanel.renderSupplementing`       | `boolean` | No       | true          |
+| `options.informationPanel.renderToggle`              | `boolean` | No       | true          |
+| `options.informationPanel.defaultAnnotationTabLabel` | `boolean` | No       | "Annotations" |
 
 ### Custom Displays
 

--- a/public/manifest/annotations/supplementing-vtt.json
+++ b/public/manifest/annotations/supplementing-vtt.json
@@ -1,0 +1,163 @@
+{
+  "@context": "http://iiif.io/api/presentation/3/context.json",
+  "homepage": [
+    {
+      "format": "text/html",
+      "id": "https://dc.rdc-staging.library.northwestern.edu/items/f9878d91-be39-4fdf-a4db-ea31b7a41754",
+      "label": {
+        "none": [
+          "Homepage at Northwestern University Libraries Digital Collections"
+        ]
+      },
+      "type": "Text"
+    }
+  ],
+  "id": "https://dcapi.rdc-staging.library.northwestern.edu/api/v2/works/f9878d91-be39-4fdf-a4db-ea31b7a41754?as=iiif",
+  "items": [
+    {
+      "annotations": [
+        {
+          "id": "https://dcapi.rdc-staging.library.northwestern.edu/api/v2/works/f9878d91-be39-4fdf-a4db-ea31b7a41754?as=iiif/canvas/access/0/annotations/page/0",
+          "items": [
+            {
+              "body": {
+                "format": "text/vtt",
+                "id": "https://iiif.stack.rdc-staging.library.northwestern.edu/public/vtt/5e/34/91/1f/-8/4c/5-/4d/ba/-b/9a/1-/5d/d3/1b/81/2a/e5/5e34911f-84c5-4dba-b9a1-5dd31b812ae5.vtt",
+                "label": {
+                  "en": ["Chapters"]
+                },
+                "language": "none",
+                "type": "Text"
+              },
+              "id": "https://dcapi.rdc-staging.library.northwestern.edu/api/v2/works/f9878d91-be39-4fdf-a4db-ea31b7a41754?as=iiif/canvas/access/0/annotations/page/0/a0",
+              "motivation": "supplementing",
+              "target": "https://dcapi.rdc-staging.library.northwestern.edu/api/v2/works/f9878d91-be39-4fdf-a4db-ea31b7a41754?as=iiif/canvas/access/0",
+              "type": "Annotation"
+            }
+          ],
+          "type": "AnnotationPage"
+        }
+      ],
+      "duration": 10,
+      "height": 720,
+      "id": "https://dcapi.rdc-staging.library.northwestern.edu/api/v2/works/f9878d91-be39-4fdf-a4db-ea31b7a41754?as=iiif/canvas/access/0",
+      "items": [
+        {
+          "id": "https://dcapi.rdc-staging.library.northwestern.edu/api/v2/works/f9878d91-be39-4fdf-a4db-ea31b7a41754?as=iiif/canvas/access/0/annotation-page",
+          "items": [
+            {
+              "body": {
+                "duration": 10,
+                "format": "application/x-mpegurl",
+                "height": 720,
+                "id": "https://meadow-streaming.rdc-staging.library.northwestern.edu/5e/34/91/1f/-8/4c/5-/4d/ba/-b/9a/1-/5d/d3/1b/81/2a/e5/5e34911f-84c5-4dba-b9a1-5dd31b812ae5.m3u8",
+                "type": "Video",
+                "width": 1280
+              },
+              "id": "https://dcapi.rdc-staging.library.northwestern.edu/api/v2/works/f9878d91-be39-4fdf-a4db-ea31b7a41754?as=iiif/canvas/access/0/annotation/0",
+              "motivation": "painting",
+              "target": "https://dcapi.rdc-staging.library.northwestern.edu/api/v2/works/f9878d91-be39-4fdf-a4db-ea31b7a41754?as=iiif/canvas/access/0",
+              "type": "Annotation"
+            }
+          ],
+          "type": "AnnotationPage"
+        }
+      ],
+      "label": {
+        "none": ["Big Buck"]
+      },
+      "type": "Canvas",
+      "width": 1280
+    }
+  ],
+  "label": {
+    "none": ["Adam Test Video"]
+  },
+  "logo": [
+    {
+      "format": "image/webp",
+      "height": 139,
+      "id": "https://iiif.dc.library.northwestern.edu/iiif/2/00000000-0000-0000-0000-000000000003/full/pct:50/0/default.webp",
+      "type": "Image",
+      "width": 1190
+    }
+  ],
+  "metadata": [
+    {
+      "label": {
+        "none": ["Last Modified"]
+      },
+      "value": {
+        "none": ["2024-02-19T15:16:09.236327Z"]
+      }
+    }
+  ],
+  "partOf": [
+    {
+      "id": "https://dcapi.rdc-staging.library.northwestern.edu/api/v2/collections/f76a8cc3-7395-4e05-83d2-590c0c5c71c6?as=iiif",
+      "label": {
+        "none": ["Adam Test Collection"]
+      },
+      "type": "Collection"
+    }
+  ],
+  "provider": [
+    {
+      "homepage": [
+        {
+          "format": "text/html",
+          "id": "https://dc.library.northwestern.edu/",
+          "label": {
+            "none": [
+              "Northwestern University Libraries Digital Collections Homepage"
+            ]
+          },
+          "language": ["en"],
+          "type": "Text"
+        }
+      ],
+      "id": "https://www.library.northwestern.edu/",
+      "label": {
+        "none": ["Northwestern University Libraries"]
+      },
+      "logo": [
+        {
+          "format": "image/webp",
+          "height": 139,
+          "id": "https://iiif.dc.library.northwestern.edu/iiif/2/00000000-0000-0000-0000-000000000003/full/pct:50/0/default.webp",
+          "type": "Image",
+          "width": 1190
+        }
+      ],
+      "type": "Agent"
+    }
+  ],
+  "requiredStatement": {
+    "label": {
+      "none": ["Attribution"]
+    },
+    "value": {
+      "none": ["Courtesy of Northwestern University Libraries"]
+    }
+  },
+  "seeAlso": [
+    {
+      "format": "application/json",
+      "id": "https://dcapi.rdc-staging.library.northwestern.edu/api/v2/works/f9878d91-be39-4fdf-a4db-ea31b7a41754",
+      "label": {
+        "none": ["Northwestern University Libraries Digital Collections API"]
+      },
+      "type": "Dataset"
+    }
+  ],
+  "thumbnail": [
+    {
+      "format": "image/jpeg",
+      "height": 300,
+      "id": "https://dcapi.rdc-staging.library.northwestern.edu/api/v2/works/f9878d91-be39-4fdf-a4db-ea31b7a41754/thumbnail",
+      "type": "Image",
+      "width": 300
+    }
+  ],
+  "type": "Manifest"
+}

--- a/src/components/Viewer/Viewer/Viewer.tsx
+++ b/src/components/Viewer/Viewer/Viewer.tsx
@@ -94,7 +94,13 @@ const Viewer: React.FC<ViewerProps> = ({ manifest, theme }) => {
       setPainting(painting);
     }
 
-    setAnnotationResources(getAnnotationResources(vault, activeCanvas));
+    setAnnotationResources(
+      getAnnotationResources(
+        vault,
+        activeCanvas,
+        configOptions?.informationPanel?.defaultAnnotationTabLabel,
+      ),
+    );
 
     setIsInformationPanel(annotationResources.length !== 0);
   }, [activeCanvas, annotationResources.length, vault]);

--- a/src/context/viewer-context.test.tsx
+++ b/src/context/viewer-context.test.tsx
@@ -88,6 +88,9 @@ describe("Viewer Context", () => {
     );
     expect(elObj.configOptions.canvasIndex).toEqual(0);
     expect(elObj.configOptions.canvasNavigationId).toEqual("canvas-nav");
+    expect(
+      elObj.configOptions.informationPanel.defaultAnnotationTabLabel,
+    ).toEqual("Annotations");
     expect(elObj.informationOpen).toEqual(true);
     expect(elObj.isLoaded).toEqual(false);
   });

--- a/src/context/viewer-context.tsx
+++ b/src/context/viewer-context.tsx
@@ -1,8 +1,8 @@
+import OpenSeadragon, { Options as OpenSeadragonOptions } from "openseadragon";
 import React, { useReducer } from "react";
 
 import { CollectionNormalized } from "@iiif/presentation-3";
 import { IncomingHttpHeaders } from "http";
-import OpenSeadragon, { Options as OpenSeadragonOptions } from "openseadragon";
 import { Vault } from "@iiif/vault";
 import { deepMerge } from "src/lib/utils";
 
@@ -21,6 +21,7 @@ export type ViewerConfigOptions = {
   canvasHeight?: string;
   ignoreCaptionLabels?: string[];
   informationPanel?: {
+    defaultAnnotationTabLabel?: string;
     open?: boolean;
     renderAbout?: boolean;
     renderSupplementing?: boolean;
@@ -49,6 +50,7 @@ const defaultConfigOptions = {
   canvasHeight: "61.8vh",
   ignoreCaptionLabels: [],
   informationPanel: {
+    defaultAnnotationTabLabel: "Annotations",
     open: true,
     renderAbout: true,
     renderSupplementing: true,

--- a/src/hooks/use-iiif/getAnnotationResources.test.ts
+++ b/src/hooks/use-iiif/getAnnotationResources.test.ts
@@ -11,6 +11,10 @@ import { Vault } from "@iiif/vault";
 import { getAnnotationResources } from "./getAnnotationResources";
 import { manifestNoAnnotations } from "src/fixtures/use-iiif/get-supplementing-resources";
 
+// This value is part of the default config options in the ViewerContext
+// and defaults to "Annotations" if not configured
+const DEFAULT_ANNOTATION_TAB_LABEL = "Annotations";
+
 describe("getAnnotationResources method", () => {
   it("processes manifest with simple annotations", async () => {
     const vault = new Vault();
@@ -19,6 +23,7 @@ describe("getAnnotationResources method", () => {
     const result = getAnnotationResources(
       vault,
       "https://iiif.io/api/cookbook/recipe/0266-full-canvas-annotation/canvas-1",
+      DEFAULT_ANNOTATION_TAB_LABEL,
     );
 
     const expected = [
@@ -60,6 +65,7 @@ describe("getAnnotationResources method", () => {
     const result = getAnnotationResources(
       vault,
       "https://iiif.io/api/cookbook/recipe/0021-tagging/canvas/p1",
+      "Chapters",
     );
 
     const expected = [
@@ -69,7 +75,7 @@ describe("getAnnotationResources method", () => {
         behavior: [],
         motivation: null,
         label: {
-          none: ["Annotations"],
+          none: ["Chapters"],
         },
         thumbnail: [],
         summary: null,
@@ -100,6 +106,7 @@ describe("getAnnotationResources method", () => {
     const result = getAnnotationResources(
       vault,
       "https://iiif.io/api/cookbook/recipe/0261-non-rectangular-commenting/canvas/p1",
+      DEFAULT_ANNOTATION_TAB_LABEL,
     );
 
     const expected = [
@@ -140,6 +147,7 @@ describe("getAnnotationResources method", () => {
     const result = getAnnotationResources(
       vault,
       "http://localhost:3000/manifest/newspaper/canvas/i1p1",
+      DEFAULT_ANNOTATION_TAB_LABEL,
     );
 
     const expected = [
@@ -192,6 +200,7 @@ describe("getAnnotationResources method", () => {
     const result = getAnnotationResources(
       vault,
       "https://iiif.io/api/cookbook/recipe/0377-image-in-annotation/canvas-1",
+      DEFAULT_ANNOTATION_TAB_LABEL,
     );
 
     const expected = [
@@ -232,6 +241,7 @@ describe("getAnnotationResources method", () => {
     const result = getAnnotationResources(
       vault,
       "https://api.dc.library.northwestern.edu/api/v2/works/57446da0-dc8b-4be6-998d-efb67c71f654?as=iiif/canvas/access/0",
+      DEFAULT_ANNOTATION_TAB_LABEL,
     );
 
     expect(result).toHaveLength(0);
@@ -273,6 +283,7 @@ describe("getAnnotationResources method", () => {
     const result = getAnnotationResources(
       vault,
       "https://iiif.io/api/cookbook/recipe/0219-using-caption-file/canvas",
+      DEFAULT_ANNOTATION_TAB_LABEL,
     );
 
     expect(result).toStrictEqual(expected);

--- a/src/hooks/use-iiif/getAnnotationResources.ts
+++ b/src/hooks/use-iiif/getAnnotationResources.ts
@@ -8,6 +8,7 @@ export type FormattedAnnotationItem = {
 export const getAnnotationResources = (
   vault: any,
   activeCanvas: string,
+  defaultAnnotationTabLabel: string = "",
 ): AnnotationResources => {
   const canvas: CanvasNormalized = vault.get({
     id: activeCanvas,
@@ -29,9 +30,10 @@ export const getAnnotationResources = (
     .map((annotationPage) => {
       /**
        * If the annotation page doesn't have a label, add a default label.
-       * Set this value in a CONFIG and not here.
        */
-      const label = annotationPage.label || { none: ["Annotations"] };
+      const label = annotationPage.label || {
+        none: [defaultAnnotationTabLabel],
+      };
       return { ...annotationPage, label };
     });
 };


### PR DESCRIPTION
## What does this do?

Allows a user to configure a default Annotation tab label value as part of `Viewer` configuration options.  

![image](https://github.com/samvera-labs/clover-iiif/assets/3020266/d2ba3d76-f7ea-4970-8c67-edb9dfd189a1)


```jsx
<Viewer
  options={{
    canvasHeight: "640px",
    informationPanel: {
      defaultAnnotationTabLabel: "I am a tab next to About",
    },
  }}
/>
```

### Notes:
- This will only affect IIIF `canvas`s which contain `annotations`.
- Clover `Viewer` will first look to an `AnnotationPage` `label` value.
- If `label` is not set on `AnnotationPage`, then "Annotations" as a value is set as a default value in the `Viewer`'s context.  The PR elevates where the code establishes the default value.

## How to Test
1. Run Clover locally, and go to the Viewer demo page.
2. Load the local manifest `http://localhost:3000/manifest/annotations/supplementing-vtt.json`
3. Try adding a `label` to the `AnnotationPage` item in `supplementing-vtt.json`
4. Experiment with setting `informationPanel.defaultAnnotationTabLabel` value when loading the `Viewer`.

