### PR TITLE
Always render annotation resources in Viewer

### DIFF
--- a/src/components/Viewer/Viewer/Content.test.tsx
+++ b/src/components/Viewer/Viewer/Content.test.tsx
@@ -1,9 +1,12 @@
+import ViewerContent, {
+  ViewerContentProps,
+} from "src/components/Viewer/Viewer/Content";
+import { ViewerProvider, defaultState } from "src/context/viewer-context";
 import { render, screen } from "@testing-library/react";
 
 import InformationPanel from "../InformationPanel/InformationPanel";
 import Painting from "src/components/Viewer/Painting/Painting";
 import React from "react";
-import ViewerContent from "src/components/Viewer/Viewer/Content";
 
 vi.mock("@radix-ui/react-collapsible");
 
@@ -17,11 +20,37 @@ vi.mocked(InformationPanel).mockReturnValue(
   <div data-testid="mock-information-panel">Information Panel</div>,
 );
 
-const props = {
-  activeCanvas: "foobar",
+const props: ViewerContentProps = {
+  activeCanvas: "http://example.com/iiif/foobar/canvas/1",
   painting: [],
-  resources: [],
-  annotationResources: [],
+  annotationResources: [
+    {
+      id: "http://localhost:3000/manifest/newspaper/newspaper_issue_1-anno_p2.json",
+      type: "AnnotationPage",
+      behavior: [],
+      motivation: null,
+      label: {
+        none: ["Annotations"],
+      },
+      thumbnail: [],
+      summary: null,
+      requiredStatement: null,
+      metadata: [],
+      rights: null,
+      provider: [],
+      items: [
+        {
+          id: "http://localhost:3000/manifest/newspaper/newspaper_issue_1-anno_p2.json-1",
+          type: "Annotation",
+        },
+      ],
+      seeAlso: [],
+      homepage: [],
+      logo: [],
+      rendering: [],
+      service: [],
+    },
+  ],
   items: [],
   isAudioVideo: false,
 };
@@ -32,5 +61,61 @@ describe("ViewerContent", () => {
     expect(screen.getByTestId("clover-viewer-content")).toHaveClass(
       "clover-viewer-content",
     );
+  });
+});
+
+describe("ViewerContent with no Annotation Resources", () => {
+  const newProps = {
+    ...props,
+    annotationResources: [],
+  };
+
+  test("renders InformationPanel by default", () => {
+    render(<ViewerContent {...newProps} />);
+    expect(screen.getByTestId("mock-information-panel"));
+  });
+
+  test("does not render InformationPanel if configured not to display it", () => {
+    render(
+      <ViewerProvider
+        initialState={{
+          ...defaultState,
+          informationOpen: false,
+          configOptions: {
+            informationPanel: {
+              open: false,
+              renderAbout: false,
+              renderToggle: false,
+            },
+          },
+        }}
+      >
+        <ViewerContent {...newProps} />
+      </ViewerProvider>,
+    );
+    expect(screen.queryByTestId("mock-information-panel")).toBeNull();
+  });
+});
+
+describe("ViewerContent with Annotation Resources", () => {
+  test("renders Annotations in InformationPanel even if initial default configuration turns off InformationPanel", () => {
+    render(
+      <ViewerProvider
+        initialState={{
+          ...defaultState,
+          informationOpen: true,
+          configOptions: {
+            informationPanel: {
+              open: false,
+              renderAbout: false,
+              renderToggle: false,
+            },
+          },
+        }}
+      >
+        <ViewerContent {...props} />
+      </ViewerProvider>,
+    );
+    expect(screen.getByTestId("mock-information-panel")).toBeInTheDocument();
   });
 });

--- a/src/components/Viewer/Viewer/Content.tsx
+++ b/src/components/Viewer/Viewer/Content.tsx
@@ -15,7 +15,7 @@ import Painting from "../Painting/Painting";
 import React from "react";
 import { useViewerState } from "src/context/viewer-context";
 
-interface ViewerContentProps {
+export interface ViewerContentProps {
   activeCanvas: string;
   annotationResources: AnnotationResources;
   isAudioVideo: boolean;
@@ -67,7 +67,7 @@ const ViewerContent: React.FC<ViewerContentProps> = ({
           </MediaWrapper>
         )}
       </Main>
-      {informationOpen && isAside && (
+      {(informationOpen || isAside) && (
         <Aside>
           <CollapsibleContent>
             <InformationPanel

--- a/src/components/Viewer/Viewer/Toggle.tsx
+++ b/src/components/Viewer/Viewer/Toggle.tsx
@@ -18,7 +18,7 @@ const Toggle = () => {
       type: "updateInformationOpen",
       informationOpen: checked,
     });
-  }, [checked]);
+  }, [checked, dispatch]);
 
   return (
     <StyledToggle>

--- a/src/components/Viewer/Viewer/Viewer.tsx
+++ b/src/components/Viewer/Viewer/Viewer.tsx
@@ -43,7 +43,6 @@ const Viewer: React.FC<ViewerProps> = ({ manifest, theme }) => {
   /**
    * Local state
    */
-
   const [isInformationPanel, setIsInformationPanel] = useState<boolean>(false);
   const [isAudioVideo, setIsAudioVideo] = useState(false);
   const [painting, setPainting] = useState<IIIFExternalWebResource[]>([]);
@@ -94,10 +93,18 @@ const Viewer: React.FC<ViewerProps> = ({ manifest, theme }) => {
       setPainting(painting);
     }
 
-    setAnnotationResources(getAnnotationResources(vault, activeCanvas));
+    const resources = getAnnotationResources(vault, activeCanvas);
 
+    if (resources.length > 0) {
+      viewerDispatch({
+        type: "updateInformationOpen",
+        informationOpen: true,
+      });
+    }
+
+    setAnnotationResources(resources);
     setIsInformationPanel(annotationResources.length !== 0);
-  }, [activeCanvas, annotationResources.length, vault]);
+  }, [activeCanvas, annotationResources.length, vault, viewerDispatch]);
 
   return (
     <ErrorBoundary FallbackComponent={ErrorFallback}>

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,19 +18,19 @@
     "outDir": "dist",
     "paths": {
       "docs/*": ["docs/*"],
-      "src/*": ["src/*"]
+      "src/*": ["src/*"],
     },
     "plugins": [
       {
-        "name": "next"
-      }
+        "name": "next",
+      },
     ],
     "resolveJsonModule": true,
     "skipLibCheck": true,
     "strict": false,
     "strictNullChecks": true,
     "target": "esnext",
-    "types": ["vitest/globals"]
+    "types": ["vitest/globals"],
   },
   "exclude": ["dist", "node_modules", "theme.config.tsx", "vite.*"],
   "include": [
@@ -39,6 +39,6 @@
     "**/*.tsx",
     "../index.ts",
     ".next/types/**/*.ts",
-    "src/setupTests.ts"
-  ]
+    "src/setupTests.ts",
+  ],
 }


### PR DESCRIPTION
## What does this do?

Fixes a bug where Annotation Resources were being hidden when a user configures their `Viewer` to hide the `InformationPanel`.  For example, say there are VTT files associated with a Video in a `canvas`, these should always render alongside the content.

![image](https://github.com/samvera-labs/clover-iiif/assets/3020266/2da24a25-6296-4ee6-94a4-ceab5624dc27)

## How to test:
Configure the viewer to hide the `InformationPanel`, i.e.
```jsx
<Viewer
  options={{
    canvasHeight: "640px",
    informationPanel: {
      open: false,
      renderAbout: false,
      renderToggle: false,
    },
  }}
/>
```

If running Clover in a dev environment, use this manifest:

https://api.dc.library.northwestern.edu/api/v2/works/44f70212-029f-44cd-a3b3-03c18b208103?as=iiif

...or any manifest which contains Annotation Resources (doesn't have to be `VTT` annotations).