### PR TITLE
Fix blank page aside rendering bug

### DIFF
--- a/pages/docs/viewer.mdx
+++ b/pages/docs/viewer.mdx
@@ -172,6 +172,7 @@ The information panel is a collapsible panel that displays information about the
 | ---------------------------------------------- | --------- | -------- | ------- |
 | `options.informationPanel.open`                | `boolean` | No       | true    |
 | `options.informationPanel.renderAbout`         | `boolean` | No       | true    |
+| `options.informationPanel.renderAnnotation`    | `boolean` | No       | true    |
 | `options.informationPanel.renderSupplementing` | `boolean` | No       | true    |
 | `options.informationPanel.renderToggle`        | `boolean` | No       | true    |
 

--- a/src/components/Viewer/Viewer/Content.test.tsx
+++ b/src/components/Viewer/Viewer/Content.test.tsx
@@ -4,6 +4,7 @@ import ViewerContent, {
 import { ViewerProvider, defaultState } from "src/context/viewer-context";
 import { render, screen } from "@testing-library/react";
 
+import { AnnotationResources } from "src/types/annotations";
 import InformationPanel from "../InformationPanel/InformationPanel";
 import Painting from "src/components/Viewer/Painting/Painting";
 import React from "react";
@@ -20,37 +21,39 @@ vi.mocked(InformationPanel).mockReturnValue(
   <div data-testid="mock-information-panel">Information Panel</div>,
 );
 
+const annotationResources: AnnotationResources = [
+  {
+    id: "http://localhost:3000/manifest/newspaper/newspaper_issue_1-anno_p2.json",
+    type: "AnnotationPage",
+    behavior: [],
+    motivation: null,
+    label: {
+      none: ["Annotations"],
+    },
+    thumbnail: [],
+    summary: null,
+    requiredStatement: null,
+    metadata: [],
+    rights: null,
+    provider: [],
+    items: [
+      {
+        id: "http://localhost:3000/manifest/newspaper/newspaper_issue_1-anno_p2.json-1",
+        type: "Annotation",
+      },
+    ],
+    seeAlso: [],
+    homepage: [],
+    logo: [],
+    rendering: [],
+    service: [],
+  },
+];
+
 const props: ViewerContentProps = {
   activeCanvas: "http://example.com/iiif/foobar/canvas/1",
   painting: [],
-  annotationResources: [
-    {
-      id: "http://localhost:3000/manifest/newspaper/newspaper_issue_1-anno_p2.json",
-      type: "AnnotationPage",
-      behavior: [],
-      motivation: null,
-      label: {
-        none: ["Annotations"],
-      },
-      thumbnail: [],
-      summary: null,
-      requiredStatement: null,
-      metadata: [],
-      rights: null,
-      provider: [],
-      items: [
-        {
-          id: "http://localhost:3000/manifest/newspaper/newspaper_issue_1-anno_p2.json-1",
-          type: "Annotation",
-        },
-      ],
-      seeAlso: [],
-      homepage: [],
-      logo: [],
-      rendering: [],
-      service: [],
-    },
-  ],
+  annotationResources: [],
   items: [],
   isAudioVideo: false,
 };
@@ -65,45 +68,25 @@ describe("ViewerContent", () => {
 });
 
 describe("ViewerContent with no Annotation Resources", () => {
-  const newProps = {
-    ...props,
-    annotationResources: [],
-  };
-
   test("renders InformationPanel by default", () => {
-    render(<ViewerContent {...newProps} />);
+    render(
+      <ViewerProvider
+        initialState={{
+          ...defaultState,
+        }}
+      >
+        <ViewerContent {...props} />
+      </ViewerProvider>,
+    );
     expect(screen.getByTestId("mock-information-panel"));
   });
 
-  test("does not render InformationPanel if configured not to display it", () => {
+  test("does not render InformationPanel or Toggle when configured not to display it", () => {
     render(
       <ViewerProvider
         initialState={{
           ...defaultState,
-          informationOpen: false,
-          configOptions: {
-            informationPanel: {
-              open: false,
-              renderAbout: false,
-              renderToggle: false,
-            },
-          },
-        }}
-      >
-        <ViewerContent {...newProps} />
-      </ViewerProvider>,
-    );
-    expect(screen.queryByTestId("mock-information-panel")).toBeNull();
-  });
-});
-
-describe("ViewerContent with Annotation Resources", () => {
-  test("renders Annotations in InformationPanel even if initial default configuration turns off InformationPanel", () => {
-    render(
-      <ViewerProvider
-        initialState={{
-          ...defaultState,
-          informationOpen: true,
+          informationOpen: false, // This is set as false in a parent component when informationPanel.open is false
           configOptions: {
             informationPanel: {
               open: false,
@@ -116,6 +99,95 @@ describe("ViewerContent with Annotation Resources", () => {
         <ViewerContent {...props} />
       </ViewerProvider>,
     );
-    expect(screen.getByTestId("mock-information-panel")).toBeInTheDocument();
+    expect(screen.queryByTestId("mock-information-panel")).toBeNull();
+  });
+
+  test("renders the InformationPanel as closed when configured to do so", () => {
+    render(
+      <ViewerProvider
+        initialState={{
+          ...defaultState,
+          informationOpen: false,
+          configOptions: {
+            informationPanel: {
+              open: false,
+              renderAbout: true,
+              renderToggle: true,
+            },
+          },
+        }}
+      >
+        <ViewerContent {...props} />
+      </ViewerProvider>,
+    );
+    expect(screen.queryByTestId("mock-information-panel")).toBeNull();
+  });
+});
+
+describe("ViewerContent with Annotation Resources", () => {
+  const propsWithAnnotationResources = {
+    ...props,
+    annotationResources,
+  };
+
+  test("renders InformationPanel even if initial default configuration turns off InformationPanel", async () => {
+    render(
+      <ViewerProvider
+        initialState={{
+          ...defaultState,
+          informationOpen: true,
+          configOptions: {
+            informationPanel: {
+              ...defaultState.configOptions.informationPanel,
+              open: false,
+              renderAbout: false,
+              renderToggle: false,
+            },
+          },
+        }}
+      >
+        <ViewerContent {...propsWithAnnotationResources} />
+      </ViewerProvider>,
+    );
+    expect(
+      await screen.findByTestId("mock-information-panel"),
+    ).toBeInTheDocument();
+  });
+
+  test("does not render the Information Panel when toggle state is off", () => {
+    render(
+      <ViewerProvider
+        initialState={{
+          ...defaultState,
+          informationOpen: false,
+        }}
+      >
+        <ViewerContent {...propsWithAnnotationResources} />
+      </ViewerProvider>,
+    );
+    expect(screen.queryByTestId("mock-information-panel")).toBeNull();
+  });
+
+  test("does not render the Information Panel if configured to hide Information Pane and hide annotations", () => {
+    render(
+      <ViewerProvider
+        initialState={{
+          ...defaultState,
+          informationOpen: true,
+          configOptions: {
+            informationPanel: {
+              ...defaultState.configOptions.informationPanel,
+              renderAnnotation: false,
+              open: false,
+              renderAbout: false,
+              renderToggle: false,
+            },
+          },
+        }}
+      >
+        <ViewerContent {...propsWithAnnotationResources} />
+      </ViewerProvider>,
+    );
+    expect(screen.queryByTestId("mock-information-panel")).toBeNull();
   });
 });

--- a/src/components/Viewer/Viewer/Content.tsx
+++ b/src/components/Viewer/Viewer/Content.tsx
@@ -38,9 +38,12 @@ const ViewerContent: React.FC<ViewerContentProps> = ({
    * there is content (About or Supplementing Resources) to display.
    */
 
-  const isAside =
-    informationPanel?.renderAbout ||
-    (informationPanel?.renderAnnotation && annotationResources.length > 0);
+  const isAside = informationPanel?.renderAbout && informationOpen;
+
+  const isForcedAside =
+    informationPanel?.renderAnnotation &&
+    annotationResources.length > 0 &&
+    !informationPanel.open;
 
   return (
     <Content
@@ -67,7 +70,7 @@ const ViewerContent: React.FC<ViewerContentProps> = ({
           </MediaWrapper>
         )}
       </Main>
-      {(informationOpen || isAside) && (
+      {(isAside || isForcedAside) && (
         <Aside>
           <CollapsibleContent>
             <InformationPanel

--- a/src/components/Viewer/Viewer/Viewer.tsx
+++ b/src/components/Viewer/Viewer/Viewer.tsx
@@ -103,8 +103,8 @@ const Viewer: React.FC<ViewerProps> = ({ manifest, theme }) => {
     }
 
     setAnnotationResources(resources);
-    setIsInformationPanel(annotationResources.length !== 0);
-  }, [activeCanvas, annotationResources.length, vault, viewerDispatch]);
+    setIsInformationPanel(resources.length !== 0);
+  }, [activeCanvas, vault, viewerDispatch]);
 
   return (
     <ErrorBoundary FallbackComponent={ErrorFallback}>


### PR DESCRIPTION
## What does this do?
Quick patch to account for a state where:
- `InformationPanel` open context value is `false`
- "About" in `InformationPanel` configured to be `true`
- No annotation resources exist

It results in the Viewer rendering an empty space where the `InformationPanel` displays (not good)

![image](https://github.com/samvera-labs/clover-iiif/assets/3020266/0651ea08-5b49-413c-b388-90b70ee020d6)

## How to test
With default configuration, run in your dev environment and the initial render should not display empty space to the right of the Viewer Content:

![image](https://github.com/samvera-labs/clover-iiif/assets/3020266/357d3bda-5a4c-49a9-a940-fb414009c1f1)
