### PR TITLE
Extend `canvasHeight` option for automatic height.

### DIFF
--- a/pages/docs/viewer.mdx
+++ b/pages/docs/viewer.mdx
@@ -164,6 +164,31 @@ const MyCustomViewer = () => {
 - Option `withCredentials` being set as `true` will inform IIIF resource requests to be made [using credentials](https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest/withCredentials) such as cookies, authorization headers or TLS client certificates.
 - Option `options.openSeadragon` will grant you ability to override the [OpenSeadragon default options](https://openseadragon.github.io/docs/OpenSeadragon.html#.Options) set within the Clover IIIF Viewer to adjust touch and mouse gesture settings and various other configurations.
 
+### Canvas Height
+
+The height of the canvas can be set using the `options.canvasHeight` prop. This prop accepts a string value that is a valid CSS height value. The default value is `500px`.
+
+#### Automatic Height
+
+If the height is set to `auto` or `100%`, the **Viewer** will expand to the height of its wrapping container element. The wrapping element must have a position `relative`, along with a defined `height` for this to display as expected. Be aware to set a `z-index` value of `0` or an applicable value within your consuming application to ensure the viewer does not conflict with other page elements.
+
+```jsx
+export default function App() {
+  const iiifContent =
+    "https://api.dc.library.northwestern.edu/api/v2/works/8a833741-74a8-40dc-bd1d-c416a3b1bb38?as=iiif";
+
+  const options = {
+    canvasHeight: "auto", // or "100%"
+  };
+
+  return (
+    <div style={{ position: "relative", height: "80vh", zIndex: "0" }}>
+      <Viewer iiifContent={iiifContent} options={options} />
+    </div>
+  );
+}
+```
+
 ### Information Panel
 
 The information panel is a collapsible panel that displays information about the current Manifest and renders supplementing resources for the active canvas. It is rendered by default, but can be configured to be hidden or to render only certain tabs.

--- a/pages/docs/viewer/demo.mdx
+++ b/pages/docs/viewer/demo.mdx
@@ -16,7 +16,7 @@ A UI component that renders a multicanvas IIIF item viewer with pan-zoom support
 
 <Viewer
   options={{
-    canvasHeight: "640px",
+    canvasHeight: "500px",
     openSeadragon: {
       gestureSettingsMouse: {
         scrollToZoom: false,

--- a/src/components/Viewer/Painting/Painting.styled.tsx
+++ b/src/components/Viewer/Painting/Painting.styled.tsx
@@ -4,10 +4,13 @@ import { styled } from "src/styles/stitches.config";
 
 const PaintingStyled = styled("div", {
   position: "relative",
-  zIndex: "0",
   display: "flex",
   flexDirection: "column",
+  flexGrow: "1",
+  flexShrink: "1",
   gap: "1rem",
+  zIndex: "0",
+  overflow: "hidden",
 
   "&:hover": {
     [`${ToggleStyled}`]: {
@@ -16,14 +19,13 @@ const PaintingStyled = styled("div", {
 
     [`${PlaceholderStyled}`]: {
       backgroundColor: "#6662",
-
-      img: {
-        filter: "brightness(0.85)",
-      },
     },
   },
 });
 
-const PaintingCanvas = styled("div", {});
+const PaintingCanvas = styled("div", {
+  width: "100%",
+  height: "100%",
+});
 
 export { PaintingCanvas, PaintingStyled, ToggleStyled };

--- a/src/components/Viewer/Painting/Painting.tsx
+++ b/src/components/Viewer/Painting/Painting.tsx
@@ -116,7 +116,10 @@ const Painting: React.FC<PaintingProps> = ({
       <PaintingCanvas
         style={{
           backgroundColor: configOptions.canvasBackgroundColor,
-          height: configOptions.canvasHeight,
+          height:
+            configOptions.canvasHeight === "auto"
+              ? "100%"
+              : configOptions.canvasHeight,
         }}
       >
         {placeholderCanvas && !isMedia && (

--- a/src/components/Viewer/Painting/Placeholder.styled.tsx
+++ b/src/components/Viewer/Painting/Placeholder.styled.tsx
@@ -1,13 +1,14 @@
 import { styled } from "src/styles/stitches.config";
 
 const PlaceholderStyled = styled("button", {
+  position: "absolute",
   background: "none",
   border: "none",
   cursor: "zoom-in",
-  width: "100%",
-  height: "100%",
   margin: "0",
   padding: "0",
+  width: "100%",
+  height: "100%",
   transition: "$all",
 
   "& img": {

--- a/src/components/Viewer/Player/Player.styled.tsx
+++ b/src/components/Viewer/Player/Player.styled.tsx
@@ -6,7 +6,7 @@ export const PlayerWrapper = styled("div", {
   display: "flex",
   flexGrow: "0",
   flexShrink: "1",
-  maxHeight: "500px",
+  height: "100%",
   zIndex: "1",
 
   video: {

--- a/src/components/Viewer/Viewer/Viewer.styled.tsx
+++ b/src/components/Viewer/Viewer/Viewer.styled.tsx
@@ -10,6 +10,7 @@ const MediaWrapper = styled("div", {
 const Content = styled("div", {
   display: "flex",
   flexDirection: "row",
+  flexGrow: "1",
   overflow: "hidden",
 
   "@sm": {
@@ -81,11 +82,20 @@ const Wrapper = styled("div", {
   fontSmooth: "auto",
   webkitFontSmoothing: "antialiased",
 
+  '&[data-absolute-position="true"]': {
+    position: "absolute",
+    width: "100%",
+    height: "100%",
+    zIndex: "0",
+  },
+
   "> div": {
     display: "flex",
     flexDirection: "column",
     flexGrow: "1",
     justifyContent: "flex-start",
+    height: "100%",
+    maxHeight: "100%",
 
     "@sm": {
       [`& ${Content}`]: {

--- a/src/components/Viewer/Viewer/Viewer.tsx
+++ b/src/components/Viewer/Viewer/Viewer.tsx
@@ -40,6 +40,11 @@ const Viewer: React.FC<ViewerProps> = ({ manifest, theme }) => {
   const viewerDispatch: any = useViewerDispatch();
   const { activeCanvas, isInformationOpen, vault, configOptions } = viewerState;
 
+  const absoluteCanvasHeights = ["100%", "auto"];
+  const isAbsolutePosition =
+    configOptions?.canvasHeight &&
+    absoluteCanvasHeights.includes(configOptions?.canvasHeight);
+
   /**
    * Local state
    */
@@ -112,6 +117,7 @@ const Viewer: React.FC<ViewerProps> = ({ manifest, theme }) => {
         className={`${theme} clover-viewer`}
         css={{ background: configOptions?.background }}
         data-body-locked={isBodyLocked}
+        data-absolute-position={isAbsolutePosition}
         data-information-panel={isInformationPanel}
         data-information-panel-open={isInformationOpen}
       >

--- a/src/context/viewer-context.tsx
+++ b/src/context/viewer-context.tsx
@@ -65,7 +65,7 @@ const defaultConfigOptions = {
   },
   background: "transparent",
   canvasBackgroundColor: "#6662",
-  canvasHeight: "61.8vh",
+  canvasHeight: "500px",
   ignoreCaptionLabels: [],
   informationPanel: {
     vtt: {


### PR DESCRIPTION
## What does this do?

This work of mostly styling changes helps the Viewer component support automatic height within a wrapping container element. If an implementer uses either `100%` or `auto` as values for `options.canvasHeight` configuration, the viewer with be absolutely positioned, and extend to the bounds of the relative element. Internally in the Clover Viewer, a combination of flexbox `flex-grow` and `height` CSS attributes expand the canvas "painting" to fit these bounds. This will be applied to Image, Video, and Sound canvases.

This can be implemented as follows:

```jsx
<div style={{ position: "relative", height: "900px", zIndex: "0" }}>
  <CloverViewer
    iiifContent="https://example.org/iiif/manifest.json"
    options={{ canvasHeight: "auto" }} // or "100%"
  />
</div>
```

Further documentation can be found at `/docs/viewer#canvas-height`.

## Notes

This follows work suggested by @tpendragon in the now closed #185. 



