### PR TITLE
Update flexsearch dependency.

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "@radix-ui/react-switch": "^1.0.3",
     "@radix-ui/react-tabs": "^1.0.4",
     "@stitches/react": "^1.2.8",
-    "flexsearch": "^0.7.11",
+    "flexsearch": "^0.7.43",
     "hls.js": "^1.5.3",
     "node-webvtt": "^1.9.4",
     "openseadragon": "^2.4.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -42,8 +42,8 @@ dependencies:
     specifier: ^1.2.8
     version: 1.2.8(react@18.2.0)
   flexsearch:
-    specifier: ^0.7.11
-    version: 0.7.11
+    specifier: ^0.7.43
+    version: 0.7.43
   hls.js:
     specifier: ^1.5.3
     version: 1.5.3
@@ -4222,13 +4222,8 @@ packages:
     resolution: {integrity: sha512-36yxDn5H7OFZQla0/jFJmbIKTdZAQHngCedGxiMmpNfEZM0sdEeT+WczLQrjK6D7o2aiyLYDnkw0R3JK0Qv1RQ==}
     dev: true
 
-  /flexsearch@0.7.11:
-    resolution: {integrity: sha512-7li2Kv9as1le1QuxK8lflA8D+qsI97wBAu8SPiDFZLtQ1wlakPOo6ytpRvd885tlEJez0qII1DnMpInhee4Y0Q==}
-    dev: false
-
   /flexsearch@0.7.43:
     resolution: {integrity: sha512-c5o/+Um8aqCSOXGcZoqZOm+NqtVwNsvVpWv6lfmSclU954O3wvQKxxK8zj74fPaSJbXpSLTs4PRhh+wnoCXnKg==}
-    dev: true
 
   /focus-visible@5.2.0:
     resolution: {integrity: sha512-Rwix9pBtC1Nuy5wysTmKy+UjbDJpIfg8eHjw0rjZ1mX4GNLz1Bmd16uDpI3Gk1i70Fgcs8Csg2lPm8HULFg9DQ==}

--- a/src/components/Scroll/Panel/Search/Results.tsx
+++ b/src/components/Scroll/Panel/Search/Results.tsx
@@ -1,7 +1,4 @@
-import {
-  Document as FlexSearchDocumentIndex,
-  IndexOptionsForDocumentSearch,
-} from "flexsearch";
+import FlexSearch, { IndexOptionsForDocumentSearch } from "flexsearch";
 import React, { useContext } from "react";
 import {
   StyledSearch,
@@ -34,7 +31,7 @@ const ScrollSearch: React.FC<ScrollSearchProps> = ({ isPanelExpanded }) => {
   const { state } = useContext(ScrollContext);
   const { annotations, searchString = "" } = state;
 
-  const index = new FlexSearchDocumentIndex(config);
+  const index = new FlexSearch.Document(config);
   const indexIds: string[] = [];
   annotations?.forEach((annotation) => {
     annotation?.body?.forEach((body) => {


### PR DESCRIPTION
This updates the Flexsearch dependency to latest and resolves an import issue noted by @ @tarjelavik in #193.