### PR TITLE
Support download of manifest and canvas rendering property items

### DIFF
--- a/pages/docs/viewer.mdx
+++ b/pages/docs/viewer.mdx
@@ -156,6 +156,7 @@ const MyCustomViewer = () => {
 | `options.openSeadragon`         | `OpenSeadragon.Options`                                                     | No       |                                          |
 | `options.informationPanel`      | [See Information Panel](#information-panel)                                 | No       |                                          |
 | `options.requestHeaders`        | `IncomingHttpHeaders`                                                       | No       | `{ "Content-Type": "application/json" }` |
+| `options.showDownload`          | `boolean`                                                                   | No       | true                                     |
 | `options.showIIIFBadge`         | `boolean`                                                                   | No       | true                                     |
 | `options.showTitle`             | `boolean`                                                                   | No       | true                                     |
 | `options.withCredentials`       | `boolean`                                                                   | No       | false                                    |

--- a/src/components/UI/Icon/Icon.tsx
+++ b/src/components/UI/Icon/Icon.tsx
@@ -1,11 +1,18 @@
-import { Add, Audio, Close, Image, Video } from "src/components/UI/Icons";
+import {
+  Add,
+  Audio,
+  Close,
+  Download,
+  Image,
+  Video,
+} from "src/components/UI/Icons";
 import { type CSS, type VariantProps } from "src/styles/stitches.config";
 
 import React from "react";
 import { StyledIcon } from "./Icon.styled";
 
 /**
- * Define SVG subelement <title>
+ * Define SVG sub element <title>
  */
 type TitleShape = {
   children: React.ReactNode;
@@ -26,6 +33,7 @@ interface IconComposition {
   Add: React.FC;
   Audio: React.FC;
   Close: React.FC;
+  Download: React.FC;
   Image: React.FC;
   Title: React.FC<TitleShape>;
   Video: React.FC;
@@ -61,6 +69,7 @@ Icon.Title = Title;
 Icon.Add = Add;
 Icon.Audio = Audio;
 Icon.Close = Close;
+Icon.Download = Download;
 Icon.Image = Image;
 Icon.Video = Video;
 

--- a/src/components/UI/Icons/Download.tsx
+++ b/src/components/UI/Icons/Download.tsx
@@ -1,0 +1,24 @@
+import React from "react";
+
+const Download: React.FC = () => (
+  <>
+    <path
+      d="M336 176h40a40 40 0 0140 40v208a40 40 0 01-40 40H136a40 40 0 01-40-40V216a40 40 0 0140-40h40"
+      fill="none"
+      stroke="currentColor"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      strokeWidth="32"
+    />
+    <path
+      fill="none"
+      stroke="currentColor"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      strokeWidth="32"
+      d="M176 272l80 80 80-80M256 48v288"
+    />
+  </>
+);
+
+export default Download;

--- a/src/components/UI/Icons/index.tsx
+++ b/src/components/UI/Icons/index.tsx
@@ -1,7 +1,8 @@
 import Add from "./Add";
 import Audio from "./Audio";
 import Close from "./Close";
+import Download from "./Download";
 import Image from "./Image";
 import Video from "./Video";
 
-export { Add, Audio, Close, Image, Video };
+export { Add, Audio, Close, Download, Image, Video };

--- a/src/components/Viewer/InformationPanel/InformationPanel.tsx
+++ b/src/components/Viewer/InformationPanel/InformationPanel.tsx
@@ -55,7 +55,6 @@ export const InformationPanel: React.FC<NavigatorProps> = ({
   }, [activeCanvas, renderAbout, annotationResources]);
 
   function handleScroll() {
-    // console.log("Type of scroll: ", isAutoScrolling ? 'auto' : 'user');
     if (!isAutoScrolling) {
       clearTimeout(isUserScrolling);
       const timeout = setTimeout(() => {

--- a/src/components/Viewer/Viewer/Content.tsx
+++ b/src/components/Viewer/Viewer/Content.tsx
@@ -45,8 +45,6 @@ const ViewerContent: React.FC<ViewerContentProps> = ({
     annotationResources.length > 0 &&
     !informationPanel.open;
 
-  console.log(isAside, isForcedAside);
-
   return (
     <Content
       className="clover-viewer-content"

--- a/src/components/Viewer/Viewer/Download.styled.ts
+++ b/src/components/Viewer/Viewer/Download.styled.ts
@@ -1,0 +1,25 @@
+import { Popover } from "src/components/UI";
+import { PopoverContent } from "./Header.styled";
+import { styled } from "src/styles/stitches.config";
+
+const DownloadButton = styled(Popover.Trigger, {
+  width: "30px",
+  padding: "5px",
+});
+
+const DownloadContent = styled(PopoverContent, {
+  h3: {
+    color: "$primaryAlt",
+    fontSize: "$2",
+    fontWeight: "700",
+    margin: "$2 0",
+  },
+
+  button: {},
+
+  "& ul li": {
+    marginBottom: "$1",
+  },
+});
+
+export { DownloadButton, DownloadContent };

--- a/src/components/Viewer/Viewer/Download.test.tsx
+++ b/src/components/Viewer/Viewer/Download.test.tsx
@@ -1,0 +1,84 @@
+import { ViewerProvider, defaultState } from "src/context/viewer-context";
+import { render, screen } from "@testing-library/react";
+
+import Download from "./Download";
+import React from "react";
+import { Vault } from "@iiif/vault";
+import renderingManifest from "src/fixtures/iiif-cookbook/0046-rendering.json";
+import renderingMultipleManifest from "src/fixtures/viewer/rendering/manifest-with-renderings.json";
+import userEvent from "@testing-library/user-event";
+
+describe("Viewer Download popover component", () => {
+  let vault: Vault;
+
+  beforeEach(() => {
+    vault = new Vault();
+  });
+
+  it("should render the download button and popover content", async () => {
+    const user = userEvent.setup();
+    await vault.loadManifest("", renderingManifest);
+
+    render(
+      <ViewerProvider
+        initialState={{
+          ...defaultState,
+          activeManifest:
+            "https://iiif.io/api/cookbook/recipe/0046-rendering/manifest.json",
+          activeCanvas:
+            "https://iiif.io/api/cookbook/recipe/0046-rendering/canvas/p1",
+          vault,
+        }}
+      >
+        <Download />
+      </ViewerProvider>,
+    );
+
+    const popoverButton = screen.getByTestId("download-button");
+
+    expect(popoverButton).toBeInTheDocument();
+    expect(screen.queryByTestId("download-content")).toBeNull();
+
+    await user.click(popoverButton);
+
+    expect(screen.getByTestId("download-content")).toBeInTheDocument();
+
+    await user.click(popoverButton);
+
+    expect(screen.queryByTestId("download-content")).toBeNull();
+  });
+
+  it("should render root level and canvas level rendering items in the download content section", async () => {
+    const user = userEvent.setup();
+    await vault.loadManifest("", renderingMultipleManifest);
+
+    render(
+      <ViewerProvider
+        initialState={{
+          ...defaultState,
+          activeManifest:
+            "https://figgy.princeton.edu/concern/scanned_resources/f93c3171-43a6-4db3-9692-ba394d669320/manifest",
+          activeCanvas:
+            "https://figgy.princeton.edu/concern/scanned_resources/f93c3171-43a6-4db3-9692-ba394d669320/manifest/canvas/f2b05d1c-e02f-43cc-bcfd-2650136288ed",
+          vault,
+        }}
+      >
+        <Download />
+      </ViewerProvider>,
+    );
+
+    await user.click(screen.getByTestId("download-button"));
+
+    expect(screen.getByText("Individual Pages")).toBeInTheDocument();
+    expect(screen.getByText("All Pages")).toBeInTheDocument();
+    expect(
+      screen.getByText("Root Rendering Label (text/html)"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("Download page text (text/plain)"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("Download the original file (image/tiff)"),
+    ).toBeInTheDocument();
+  });
+});

--- a/src/components/Viewer/Viewer/Download.tsx
+++ b/src/components/Viewer/Viewer/Download.tsx
@@ -1,0 +1,61 @@
+import {
+  DownloadButton,
+  DownloadContent,
+} from "src/components/Viewer/Viewer/Download.styled";
+
+import { Icon } from "src/components/UI/Icon/Icon";
+import { Popover } from "src/components/UI";
+import React from "react";
+import { RenderingItem } from "src/types/presentation-3";
+import useViewerDownload from "src/hooks/useViewerDownload";
+
+const ViewerDownload = () => {
+  const { allPages, individualPages } = useViewerDownload();
+
+  const handleDownloadClick = (id: RenderingItem["id"]) => {
+    window.open(id, "_blank");
+  };
+
+  return (
+    <Popover>
+      <DownloadButton data-testid="download-button">
+        <Icon>
+          <Icon.Download />
+        </Icon>
+      </DownloadButton>
+      <DownloadContent data-testid="download-content">
+        {individualPages.length > 0 && (
+          <>
+            <h3>Individual Pages</h3>
+            <ul>
+              {individualPages.map(({ format, id, label }) => (
+                <li key={label}>
+                  <button onClick={() => handleDownloadClick(id)}>
+                    {label} ({format})
+                  </button>
+                </li>
+              ))}
+            </ul>
+          </>
+        )}
+
+        {allPages.length > 0 && (
+          <>
+            <h3>All Pages</h3>
+            <ul>
+              {allPages.map(({ format, id, label }) => (
+                <li key={label}>
+                  <button onClick={() => handleDownloadClick(id)}>
+                    {label} ({format})
+                  </button>
+                </li>
+              ))}
+            </ul>
+          </>
+        )}
+      </DownloadContent>
+    </Popover>
+  );
+};
+
+export default ViewerDownload;

--- a/src/components/Viewer/Viewer/Header.styled.ts
+++ b/src/components/Viewer/Viewer/Header.styled.ts
@@ -7,7 +7,7 @@ const IIIFBadgeButton = styled(Popover.Trigger, {
   padding: "5px",
 });
 
-const IIIFBadgeContent = styled(Popover.Content, {
+const PopoverContent = styled(Popover.Content, {
   display: "flex",
   flexDirection: "column",
   fontSize: "0.8333rem",
@@ -85,6 +85,6 @@ export {
   Header,
   HeaderOptions,
   IIIFBadgeButton,
-  IIIFBadgeContent,
+  PopoverContent,
   ManifestLabel,
 };

--- a/src/components/Viewer/Viewer/Header.tsx
+++ b/src/components/Viewer/Viewer/Header.tsx
@@ -2,8 +2,8 @@ import {
   Header,
   HeaderOptions,
   IIIFBadgeButton,
-  IIIFBadgeContent,
   ManifestLabel,
+  PopoverContent,
 } from "./Header.styled";
 import { ViewerContextStore, useViewerState } from "src/context/viewer-context";
 
@@ -15,6 +15,7 @@ import { Label } from "src/components/Primitives";
 import { Popover } from "src/components/UI";
 import React from "react";
 import Toggle from "./Toggle";
+import ViewerDownload from "./Download";
 import { media } from "src/styles/stitches.config";
 import { useMediaQuery } from "src/hooks/useMediaQuery";
 
@@ -27,12 +28,14 @@ const ViewerHeader: React.FC<Props> = ({ manifestId, manifestLabel }) => {
   const viewerState: ViewerContextStore = useViewerState();
   const { collection, configOptions } = viewerState;
 
-  const { showTitle, showIIIFBadge, informationPanel } = configOptions;
+  const { informationPanel, showDownload, showIIIFBadge, showTitle } =
+    configOptions;
 
   /**
    * Determine if header options should be rendered.
    */
-  const hasOptions = showIIIFBadge || informationPanel?.renderToggle;
+  const hasOptions =
+    showDownload || showIIIFBadge || informationPanel?.renderToggle;
   const isSmallViewport = useMediaQuery(media.sm);
 
   return (
@@ -46,12 +49,13 @@ const ViewerHeader: React.FC<Props> = ({ manifestId, manifestLabel }) => {
       )}
       {hasOptions && (
         <HeaderOptions>
+          {showDownload && <ViewerDownload />}
           {showIIIFBadge && (
             <Popover>
               <IIIFBadgeButton>
                 <IIIFBadge />
               </IIIFBadgeButton>
-              <IIIFBadgeContent>
+              <PopoverContent>
                 {collection?.items && (
                   <button
                     onClick={(e) => {
@@ -80,7 +84,7 @@ const ViewerHeader: React.FC<Props> = ({ manifestId, manifestLabel }) => {
                   textPrompt="Copy Manifest URL"
                   textToCopy={manifestId}
                 />
-              </IIIFBadgeContent>
+              </PopoverContent>
             </Popover>
           )}
           {informationPanel?.renderToggle && !isSmallViewport && <Toggle />}

--- a/src/context/viewer-context.tsx
+++ b/src/context/viewer-context.tsx
@@ -43,6 +43,7 @@ export type ViewerConfigOptions = {
   };
   openSeadragon?: OpenSeadragonOptions;
   requestHeaders?: IncomingHttpHeaders;
+  showDownload?: boolean;
   showIIIFBadge?: boolean;
   showTitle?: boolean;
   withCredentials?: boolean;
@@ -82,6 +83,7 @@ const defaultConfigOptions = {
   },
   openSeadragon: {},
   requestHeaders: { "Content-Type": "application/json" },
+  showDownload: true,
   showIIIFBadge: true,
   showTitle: true,
   withCredentials: false,

--- a/src/fixtures/iiif-cookbook/0046-rendering.json
+++ b/src/fixtures/iiif-cookbook/0046-rendering.json
@@ -1,0 +1,211 @@
+{
+  "@context": "http://iiif.io/api/presentation/3/context.json",
+  "id": "https://iiif.io/api/cookbook/recipe/0046-rendering/manifest.json",
+  "type": "Manifest",
+  "label": {
+    "en": ["Alternative Representations Through Rendering"]
+  },
+  "summary": {
+    "en": [
+      "Playbill for \"Akiba gongen kaisen-banashi,\" \"Futatsu chōchō kuruwa nikki\" and \"Godairiki koi no fūjime\" performed at the Chikugo Theater in Osaka from the fifth month of Kaei 2 (May, 1849); main actors: Gadō Kataoka II, Ebizō Ichikawa VI, Kitō Sawamura II, Daigorō Mimasu IV and Karoku Nakamura I; on front cover: producer Mominosuke Ichikawa's crest."
+    ]
+  },
+  "viewingDirection": "right-to-left",
+  "rendering": [
+    {
+      "id": "https://fixtures.iiif.io/other/UCLA/kabuki_ezukushi_rtl.pdf",
+      "type": "Text",
+      "label": {
+        "en": ["PDF version"]
+      },
+      "format": "application/pdf"
+    }
+  ],
+  "items": [
+    {
+      "id": "https://iiif.io/api/cookbook/recipe/0046-rendering/canvas/p1",
+      "type": "Canvas",
+      "label": {
+        "en": ["front cover"]
+      },
+      "width": 3497,
+      "height": 4823,
+      "items": [
+        {
+          "id": "https://iiif.io/api/cookbook/recipe/0046-rendering/page/p1/1",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://iiif.io/api/cookbook/recipe/0046-rendering/annotation/p0001-image",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": {
+                "id": "https://iiif.io/api/image/3.0/example/reference/4f92cceb12dd53b52433425ce44308c7-ucla_bib1987273_no001_rs_001/full/max/0/default.jpg",
+                "type": "Image",
+                "format": "image/jpeg",
+                "width": 3497,
+                "height": 4823,
+                "service": [
+                  {
+                    "id": "https://iiif.io/api/image/3.0/example/reference/4f92cceb12dd53b52433425ce44308c7-ucla_bib1987273_no001_rs_001",
+                    "type": "ImageService3",
+                    "profile": "level1"
+                  }
+                ]
+              },
+              "target": "https://iiif.io/api/cookbook/recipe/0046-rendering/canvas/p1"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://iiif.io/api/cookbook/recipe/0046-rendering/canvas/p2",
+      "type": "Canvas",
+      "label": {
+        "en": ["pages 1–2"]
+      },
+      "width": 6062,
+      "height": 4804,
+      "items": [
+        {
+          "id": "https://iiif.io/api/cookbook/recipe/0046-rendering/page/p2/1",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://iiif.io/api/cookbook/recipe/0046-rendering/annotation/p0002-image",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": {
+                "id": "https://iiif.io/api/image/3.0/example/reference/4f92cceb12dd53b52433425ce44308c7-ucla_bib1987273_no001_rs_002/full/max/0/default.jpg",
+                "type": "Image",
+                "format": "image/jpeg",
+                "width": 6062,
+                "height": 4804,
+                "service": [
+                  {
+                    "id": "https://iiif.io/api/image/3.0/example/reference/4f92cceb12dd53b52433425ce44308c7-ucla_bib1987273_no001_rs_002",
+                    "type": "ImageService3",
+                    "profile": "level1"
+                  }
+                ]
+              },
+              "target": "https://iiif.io/api/cookbook/recipe/0046-rendering/canvas/p2"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://iiif.io/api/cookbook/recipe/0046-rendering/canvas/p3",
+      "type": "Canvas",
+      "label": {
+        "en": ["pages 3–4"]
+      },
+      "width": 6127,
+      "height": 4776,
+      "items": [
+        {
+          "id": "https://iiif.io/api/cookbook/recipe/0046-rendering/page/p3/1",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://iiif.io/api/cookbook/recipe/0046-rendering/annotation/p0003-image",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": {
+                "id": "https://iiif.io/api/image/3.0/example/reference/4f92cceb12dd53b52433425ce44308c7-ucla_bib1987273_no001_rs_003/full/max/0/default.jpg",
+                "type": "Image",
+                "format": "image/jpeg",
+                "width": 6127,
+                "height": 4776,
+                "service": [
+                  {
+                    "id": "https://iiif.io/api/image/3.0/example/reference/4f92cceb12dd53b52433425ce44308c7-ucla_bib1987273_no001_rs_003",
+                    "type": "ImageService3",
+                    "profile": "level1"
+                  }
+                ]
+              },
+              "target": "https://iiif.io/api/cookbook/recipe/0046-rendering/canvas/p3"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://iiif.io/api/cookbook/recipe/0046-rendering/canvas/p4",
+      "type": "Canvas",
+      "label": {
+        "en": ["pages 5–6"]
+      },
+      "width": 6124,
+      "height": 4751,
+      "items": [
+        {
+          "id": "https://iiif.io/api/cookbook/recipe/0046-rendering/page/p4/1",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://iiif.io/api/cookbook/recipe/0046-rendering/annotation/p0004-image",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": {
+                "id": "https://iiif.io/api/image/3.0/example/reference/4f92cceb12dd53b52433425ce44308c7-ucla_bib1987273_no001_rs_004/full/max/0/default.jpg",
+                "type": "Image",
+                "format": "image/jpeg",
+                "width": 6124,
+                "height": 4751,
+                "service": [
+                  {
+                    "id": "https://iiif.io/api/image/3.0/example/reference/4f92cceb12dd53b52433425ce44308c7-ucla_bib1987273_no001_rs_004",
+                    "type": "ImageService3",
+                    "profile": "level1"
+                  }
+                ]
+              },
+              "target": "https://iiif.io/api/cookbook/recipe/0046-rendering/canvas/p4"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://iiif.io/api/cookbook/recipe/0046-rendering/canvas/p5",
+      "type": "Canvas",
+      "label": {
+        "en": ["back cover"]
+      },
+      "width": 3510,
+      "height": 4808,
+      "items": [
+        {
+          "id": "https://iiif.io/api/cookbook/recipe/0046-rendering/page/p5/1",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://iiif.io/api/cookbook/recipe/0046-rendering/annotation/p0005-image",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": {
+                "id": "https://iiif.io/api/image/3.0/example/reference/4f92cceb12dd53b52433425ce44308c7-ucla_bib1987273_no001_rs_005/full/max/0/default.jpg",
+                "type": "Image",
+                "format": "image/jpeg",
+                "width": 3510,
+                "height": 4808,
+                "service": [
+                  {
+                    "id": "https://iiif.io/api/image/3.0/example/reference/4f92cceb12dd53b52433425ce44308c7-ucla_bib1987273_no001_rs_005",
+                    "type": "ImageService3",
+                    "profile": "level1"
+                  }
+                ]
+              },
+              "target": "https://iiif.io/api/cookbook/recipe/0046-rendering/canvas/p5"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/src/fixtures/viewer/rendering/manifest-with-renderings.json
+++ b/src/fixtures/viewer/rendering/manifest-with-renderings.json
@@ -1,0 +1,161 @@
+{
+  "@context": "http://iiif.io/api/presentation/2/context.json",
+  "@type": "sc:Manifest",
+  "@id": "https://figgy.princeton.edu/concern/scanned_resources/f93c3171-43a6-4db3-9692-ba394d669320/manifest",
+  "label": [
+    "Release: Telegram Sent to the Minister of Foreign Affairs in Honduras"
+  ],
+  "viewingHint": "individuals",
+  "metadata": [
+    { "label": "Date Created", "value": ["1956 July 19"] },
+    { "label": "Extent", "value": ["1 box"] },
+    { "label": "Identifier", "value": ["ark:/88435/1g05fh554"] },
+    {
+      "label": "Title",
+      "value": [
+        "Release: Telegram Sent to the Minister of Foreign Affairs in Honduras"
+      ]
+    },
+    { "label": "Language", "value": ["English"] },
+    { "label": "Publisher", "value": ["Dulles, John Foster (1888-1959)"] },
+    { "label": "Container", "value": ["Box 349"] },
+    {
+      "label": "Member Of Collections",
+      "value": ["John Foster Dulles Papers MC016"]
+    }
+  ],
+  "sequences": [
+    {
+      "@type": "sc:Sequence",
+      "@id": "https://figgy.princeton.edu/concern/scanned_resources/f93c3171-43a6-4db3-9692-ba394d669320/manifest/sequence/normal",
+      "rendering": [
+        {
+          "@id": "https://figgy.princeton.edu/catalog/f93c3171-43a6-4db3-9692-ba394d669320/pdf",
+          "label": "Download as PDF",
+          "format": "application/pdf"
+        }
+      ],
+      "canvases": [
+        {
+          "@type": "sc:Canvas",
+          "@id": "https://figgy.princeton.edu/concern/scanned_resources/f93c3171-43a6-4db3-9692-ba394d669320/manifest/canvas/f2b05d1c-e02f-43cc-bcfd-2650136288ed",
+          "label": "1",
+          "rendering": [
+            {
+              "@id": "https://figgy.princeton.edu/concern/file_sets/f2b05d1c-e02f-43cc-bcfd-2650136288ed/text",
+              "format": "text/plain",
+              "label": "Download page text"
+            },
+            {
+              "@id": "https://figgy.princeton.edu/downloads/f2b05d1c-e02f-43cc-bcfd-2650136288ed/file/1e878229-df13-4e3d-94bd-4bdf1b941f15",
+              "label": "Download the original file",
+              "format": "image/tiff"
+            }
+          ],
+          "width": 3490,
+          "height": 4470,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@type": "dctypes:Image",
+                "@id": "https://iiif-cloud.princeton.edu/iiif/2/d5%2F74%2F7d%2Fd5747d15fff349d6b9512b78d5db0f3a%2Fintermediate_file/full/1000,/0/default.jpg",
+                "height": 4470,
+                "width": 3490,
+                "format": "image/jpeg",
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif-cloud.princeton.edu/iiif/2/d5%2F74%2F7d%2Fd5747d15fff349d6b9512b78d5db0f3a%2Fintermediate_file",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "@id": "https://figgy.princeton.edu/concern/scanned_resources/f93c3171-43a6-4db3-9692-ba394d669320/manifest/image/f2b05d1c-e02f-43cc-bcfd-2650136288ed",
+              "on": "https://figgy.princeton.edu/concern/scanned_resources/f93c3171-43a6-4db3-9692-ba394d669320/manifest/canvas/f2b05d1c-e02f-43cc-bcfd-2650136288ed"
+            }
+          ]
+        },
+        {
+          "@type": "sc:Canvas",
+          "@id": "https://figgy.princeton.edu/concern/scanned_resources/f93c3171-43a6-4db3-9692-ba394d669320/manifest/canvas/6a7352c3-f192-4007-8679-d72885a77c14",
+          "label": "2",
+          "rendering": [
+            {
+              "@id": "https://figgy.princeton.edu/concern/file_sets/6a7352c3-f192-4007-8679-d72885a77c14/text",
+              "format": "text/plain",
+              "label": "Download page text"
+            },
+            {
+              "@id": "https://figgy.princeton.edu/downloads/6a7352c3-f192-4007-8679-d72885a77c14/file/1afc3e0e-d0cb-4ec0-b366-de8bc681426a",
+              "label": "Download the original file",
+              "format": "image/tiff"
+            }
+          ],
+          "width": 3279,
+          "height": 4277,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@type": "dctypes:Image",
+                "@id": "https://iiif-cloud.princeton.edu/iiif/2/2d%2F53%2F30%2F2d533040a9f54c80919dcf253bcfb572%2Fintermediate_file/full/1000,/0/default.jpg",
+                "height": 4277,
+                "width": 3279,
+                "format": "image/jpeg",
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif-cloud.princeton.edu/iiif/2/2d%2F53%2F30%2F2d533040a9f54c80919dcf253bcfb572%2Fintermediate_file",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "@id": "https://figgy.princeton.edu/concern/scanned_resources/f93c3171-43a6-4db3-9692-ba394d669320/manifest/image/6a7352c3-f192-4007-8679-d72885a77c14",
+              "on": "https://figgy.princeton.edu/concern/scanned_resources/f93c3171-43a6-4db3-9692-ba394d669320/manifest/canvas/6a7352c3-f192-4007-8679-d72885a77c14"
+            }
+          ]
+        }
+      ],
+      "viewingHint": "individuals"
+    }
+  ],
+  "structures": [
+    {
+      "@type": "sc:Range",
+      "@id": "https://figgy.princeton.edu/concern/scanned_resources/f93c3171-43a6-4db3-9692-ba394d669320/manifest/range/reb1552e4-fab0-4786-bd9c-ca387101e882",
+      "label": "Logical",
+      "viewingHint": "top",
+      "ranges": [],
+      "canvases": []
+    }
+  ],
+  "seeAlso": [
+    {
+      "@id": "https://figgy.princeton.edu/catalog/f93c3171-43a6-4db3-9692-ba394d669320.jsonld",
+      "format": "application/ld+json"
+    },
+    {
+      "@id": "https://findingaids.princeton.edu/catalog/MC016_c10393.xml",
+      "format": "text/xml"
+    }
+  ],
+  "license": "http://rightsstatements.org/vocab/CNE/1.0/",
+  "thumbnail": {
+    "@id": "https://iiif-cloud.princeton.edu/iiif/2/d5%2F74%2F7d%2Fd5747d15fff349d6b9512b78d5db0f3a%2Fintermediate_file/full/!200,150/0/default.jpg",
+    "service": {
+      "@context": "http://iiif.io/api/image/2/context.json",
+      "@id": "https://iiif-cloud.princeton.edu/iiif/2/d5%2F74%2F7d%2Fd5747d15fff349d6b9512b78d5db0f3a%2Fintermediate_file",
+      "profile": "http://iiif.io/api/image/2/level2.json"
+    }
+  },
+  "rendering": {
+    "@id": "http://arks.princeton.edu/ark:/88435/1g05fh554",
+    "format": "text/html"
+  },
+  "logo": "https://figgy.princeton.edu/assets/pul_logo_icon-5333765252f2b86e34cd7c096c97e79495fe4656c5f787c5510a84ee6b67afd8.png",
+  "service": {
+    "@context": "http://iiif.io/api/search/0/context.json",
+    "@id": "https://figgy.princeton.edu/catalog/f93c3171-43a6-4db3-9692-ba394d669320/iiif_search",
+    "profile": "http://iiif.io/api/search/0/search",
+    "label": "Search within this item"
+  }
+}

--- a/src/hooks/use-iiif/useRendering.ts
+++ b/src/hooks/use-iiif/useRendering.ts
@@ -1,0 +1,55 @@
+import { Canvas, Manifest } from "@iiif/presentation-3";
+import { useEffect, useState } from "react";
+
+import { RenderingItem } from "src/types/presentation-3";
+import { useViewerState } from "src/context/viewer-context";
+
+function extractRenderingContent(
+  rendering: Manifest["rendering"] | Canvas["rendering"],
+  vault: any,
+) {
+  const content: RenderingItem[] = [];
+  if (!rendering) return content;
+
+  for (const item of rendering) {
+    if (item.id) {
+      const itemContent = vault.get(item.id) as RenderingItem;
+      if (itemContent) {
+        content.push(itemContent);
+      }
+    }
+  }
+
+  return content;
+}
+
+type UseRenderingReturn = {
+  root: RenderingItem[];
+  canvas: RenderingItem[];
+};
+
+export default function useRendering() {
+  const { activeCanvas, activeManifest, vault } = useViewerState();
+  const [rendering, setRendering] = useState<UseRenderingReturn>({
+    root: [],
+    canvas: [],
+  });
+
+  useEffect(() => {
+    const manifest = vault.get(activeManifest) as Manifest;
+    const activeCanvasEntity = vault.get(activeCanvas) as Canvas;
+
+    const rootRendering = manifest?.rendering;
+    const activeCanvasRendering = activeCanvasEntity?.rendering;
+
+    const rootContent = extractRenderingContent(rootRendering, vault);
+    const canvasContent = extractRenderingContent(activeCanvasRendering, vault);
+
+    setRendering({
+      root: rootContent,
+      canvas: canvasContent,
+    });
+  }, [activeCanvas, activeManifest, vault]);
+
+  return { ...rendering };
+}

--- a/src/hooks/useViewerDownload.tsx
+++ b/src/hooks/useViewerDownload.tsx
@@ -1,0 +1,39 @@
+import { RenderingItem } from "src/types/presentation-3";
+import { getLabelAsString } from "src/lib/label-helpers";
+import useRendering from "src/hooks/use-iiif/useRendering";
+
+type DownloadItem = {
+  format?: string;
+  id?: string;
+  label: string;
+};
+
+function prepareDownloadLinks(
+  items: RenderingItem[],
+  defaultLabel: string,
+): DownloadItem[] {
+  return items.map(({ format, id, label }) => ({
+    format,
+    id,
+    label: getLabelAsString(label) || defaultLabel,
+  }));
+}
+
+export default function useViewerDownload() {
+  const rendering = useRendering();
+
+  const allPages = prepareDownloadLinks(
+    rendering?.root || [],
+    "Root Rendering Label",
+  );
+
+  const individualPages = prepareDownloadLinks(
+    rendering?.canvas || [],
+    "Canvas Rendering Label",
+  );
+
+  return {
+    allPages,
+    individualPages,
+  };
+}

--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -14,6 +14,19 @@ HTMLMediaElement.prototype.load = () => {};
 HTMLMediaElement.prototype.pause = () => {};
 //HTMLMediaElement.prototype.addTextTrack = () => { /* do nothing */ };
 
+// Mock ResizeObserver
+global.ResizeObserver = class ResizeObserver {
+  observe() {
+    // do nothing
+  }
+  unobserve() {
+    // do nothing
+  }
+  disconnect() {
+    // do nothing
+  }
+};
+
 // runs a cleanup after each test case (e.g. clearing jsdom)
 afterEach(() => {
   cleanup();

--- a/src/types/presentation-3.ts
+++ b/src/types/presentation-3.ts
@@ -7,3 +7,9 @@ export interface LabeledIIIFExternalWebResource
   extends IIIFExternalWebResource {
   label?: InternationalString;
 }
+
+export type RenderingItem = WithLabel<IIIFExternalWebResource>;
+
+export type WithLabel<T> = T & {
+  label: InternationalString;
+};


### PR DESCRIPTION
## What does this do?
Adds a UI popover feature to download items present in a Manifest and Canvas's `rendering` property:

https://iiif.io/api/cookbook/recipe/0046-rendering/

![image](https://github.com/samvera-labs/clover-iiif/assets/3020266/13723155-33ef-49d3-a797-400765df305f)

The download button will display by default, but you can configure the Viewer to not display it also:

```jsx
<Viewer
  options={{
    showDownload: false,
    canvasHeight: "500px",
    ...
  }}
/>
```

## How to test:
Start up a local Clover instance, navigate to: http://localhost:3000/docs/viewer/demo and test any manifest with `rendering` either at the root, or within a canvas.  Here are two example manifests:
- https://iiif.io/api/cookbook/recipe/0046-rendering/manifest.json
- https://figgy.princeton.edu/concern/scanned_resources/f93c3171-43a6-4db3-9692-ba394d669320/manifest
