### PR TITLE
Patch fix for the rendering download button

### DIFF
--- a/src/components/Viewer/Viewer/Download.test.tsx
+++ b/src/components/Viewer/Viewer/Download.test.tsx
@@ -4,6 +4,7 @@ import { render, screen } from "@testing-library/react";
 import Download from "./Download";
 import React from "react";
 import { Vault } from "@iiif/vault";
+import noRenderingManifest from "src/fixtures/viewer/rendering/manifest-without-renderings.json";
 import renderingManifest from "src/fixtures/iiif-cookbook/0046-rendering.json";
 import renderingMultipleManifest from "src/fixtures/viewer/rendering/manifest-with-renderings.json";
 import userEvent from "@testing-library/user-event";
@@ -80,5 +81,27 @@ describe("Viewer Download popover component", () => {
     expect(
       screen.getByText("Download the original file (image/tiff)"),
     ).toBeInTheDocument();
+  });
+
+  it("should not render the download button when no rendering items are present", async () => {
+    await vault.loadManifest("", noRenderingManifest);
+
+    render(
+      <ViewerProvider
+        initialState={{
+          ...defaultState,
+          activeManifest:
+            "https://iiif.io/api/cookbook/recipe/0046-rendering/manifest.json",
+          activeCanvas:
+            "https://iiif.io/api/cookbook/recipe/0046-rendering/canvas/p1",
+          vault,
+        }}
+      >
+        <Download />
+      </ViewerProvider>,
+    );
+
+    expect(screen.queryByTestId("download-button")).toBeNull();
+    expect(screen.queryByTestId("download-content")).toBeNull();
   });
 });

--- a/src/components/Viewer/Viewer/Download.tsx
+++ b/src/components/Viewer/Viewer/Download.tsx
@@ -11,10 +11,15 @@ import useViewerDownload from "src/hooks/useViewerDownload";
 
 const ViewerDownload = () => {
   const { allPages, individualPages } = useViewerDownload();
+  const showDownloadButton = allPages.length > 0 || individualPages.length > 0;
 
   const handleDownloadClick = (id: RenderingItem["id"]) => {
     window.open(id, "_blank");
   };
+
+  if (!showDownloadButton) {
+    return null;
+  }
 
   return (
     <Popover>

--- a/src/fixtures/viewer/rendering/manifest-without-renderings.json
+++ b/src/fixtures/viewer/rendering/manifest-without-renderings.json
@@ -1,0 +1,51 @@
+{
+  "@context": "http://iiif.io/api/presentation/3/context.json",
+  "id": "https://iiif.io/api/cookbook/recipe/0046-rendering/manifest.json",
+  "type": "Manifest",
+  "label": {
+    "en": ["No Rendering properties"]
+  },
+  "summary": {
+    "en": ["Test"]
+  },
+  "viewingDirection": "right-to-left",
+  "items": [
+    {
+      "id": "https://iiif.io/api/cookbook/recipe/0046-rendering/canvas/p1",
+      "type": "Canvas",
+      "label": {
+        "en": ["front cover"]
+      },
+      "width": 3497,
+      "height": 4823,
+      "items": [
+        {
+          "id": "https://iiif.io/api/cookbook/recipe/0046-rendering/page/p1/1",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://iiif.io/api/cookbook/recipe/0046-rendering/annotation/p0001-image",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": {
+                "id": "https://iiif.io/api/image/3.0/example/reference/4f92cceb12dd53b52433425ce44308c7-ucla_bib1987273_no001_rs_001/full/max/0/default.jpg",
+                "type": "Image",
+                "format": "image/jpeg",
+                "width": 3497,
+                "height": 4823,
+                "service": [
+                  {
+                    "id": "https://iiif.io/api/image/3.0/example/reference/4f92cceb12dd53b52433425ce44308c7-ucla_bib1987273_no001_rs_001",
+                    "type": "ImageService3",
+                    "profile": "level1"
+                  }
+                ]
+              },
+              "target": "https://iiif.io/api/cookbook/recipe/0046-rendering/canvas/p1"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## What does this do?

Patch fix for the rendering download button display to only show if rendering items exist on a manifest.  For example, this manifest has no `rendering` properties.

![image](https://github.com/samvera-labs/clover-iiif/assets/3020266/320a25f9-613e-404d-aa3a-3eccb6a0f11e)

## How to test
- Run the app locally and in the Viewer Demo page, load any manifest which does not contain `rendering` properties.
- Verify the download button does not display