### PR TITLE
Force redraw to destroy previous tiled image.

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "flexsearch": "^0.7.43",
     "hls.js": "^1.5.3",
     "node-webvtt": "^1.9.4",
-    "openseadragon": "^2.4.2",
+    "openseadragon": "^4.1.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-error-boundary": "^4.0.12",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -54,8 +54,8 @@ dependencies:
     specifier: ^1.9.4
     version: 1.9.4
   openseadragon:
-    specifier: ^2.4.2
-    version: 2.4.2
+    specifier: ^4.1.1
+    version: 4.1.1
   react:
     specifier: ^18.2.0
     version: 18.2.0
@@ -6798,8 +6798,8 @@ packages:
       mimic-fn: 4.0.0
     dev: true
 
-  /openseadragon@2.4.2:
-    resolution: {integrity: sha512-398KbZwRtOYA6OmeWRY4Q0737NTacQ9Q6whmr9Lp1MNQO3p0eBz5LIASRne+4gwequcSM1vcHcjfy3dIndQziw==}
+  /openseadragon@4.1.1:
+    resolution: {integrity: sha512-owU9gsasAcobLN+LM8lN58Xc2VDSDotY9mkrwS/NB6g9KX/PcusV4RZvhHng2RF/Q0pMziwldf62glwXoGnuzg==}
     dev: false
 
   /optionator@0.9.3:

--- a/src/components/Image/OSD/OSD.tsx
+++ b/src/components/Image/OSD/OSD.tsx
@@ -42,8 +42,11 @@ const OSD: React.FC<OSDProps> = ({
   }, [openSeadragon, openSeadragonCallback]);
 
   useEffect(() => {
-    if (uri !== osdUri) setOsdUri(uri);
-  }, [osdUri, uri]);
+    if (openSeadragon && uri !== osdUri) {
+      openSeadragon.forceRedraw();
+      setOsdUri(uri);
+    }
+  }, [openSeadragon, osdUri, uri]);
 
   useEffect(() => {
     if (osdUri && openSeadragon) {


### PR DESCRIPTION
This addresses issue #203 raised by @wykhuh. In some instances when navigating canvases of a manfiest, the expected IIIF tiled images is not drawn to the canvas and the previous item is retained. The actual occurance is a collision on the index of the canvas where the IIIF tiled image is strangely drawn under the previous tiled image that was somehow retained. In addition to the redraw, we now also update a timing issue where the `osdUri` is not reset unless the `openSeadragon` instance exists.

To resolve, we are now forcing a redraw prior to the drawing of the new image.

This also updates the `openseadragon` dependency as previous IIIF tile size issues have now been resolved in the recent release 4.1.1.