### PR TITLE
Add custom View All property for overriding slider homepage.

### DIFF
--- a/pages/docs/slider.mdx
+++ b/pages/docs/slider.mdx
@@ -98,6 +98,7 @@ Render the slider with IIIF Collection URI. The only required prop is the `iiifC
 | `onItemInteraction`           | `function`                       | No       |         |
 | `options.breakpoints`         | `SwiperProps["breakpoints"]`     | No       |         |
 | `options.credentials`         | `omit`, `same-origin`, `include` | No       | `omit`  |
+| `options.customViewAll`       | `string`                         | No       |         |
 
 ### Custom Breakpoints
 

--- a/src/components/Slider/index.tsx
+++ b/src/components/Slider/index.tsx
@@ -1,3 +1,4 @@
+import "src/i18n/config";
 import {
   CollectionItems,
   CollectionNormalized,
@@ -18,6 +19,7 @@ import Header from "src/components/Slider/Header/Header";
 import Items from "src/components/Slider/Items/Items";
 import hash from "src/lib/hash";
 import { upgrade } from "@iiif/parser/upgrader";
+import { format } from "path";
 
 export interface CloverSliderProps {
   collectionId?: string;
@@ -69,6 +71,16 @@ const RenderSlider: React.FC<CloverSliderProps> = ({
     return <></>;
   }
 
+  const homepage: ContentResource[] = options.customViewAll
+    ? [
+        {
+          id: options.customViewAll,
+          type: "Text",
+          format: "text/html",
+        },
+      ]
+    : (collection?.homepage as any as ContentResource[]);
+
   const instance = hash(iiifResource);
 
   if (!collection) return <></>;
@@ -83,7 +95,7 @@ const RenderSlider: React.FC<CloverSliderProps> = ({
               ? collection.summary
               : { none: [""] }
           }
-          homepage={collection.homepage as any as ContentResource[]}
+          homepage={homepage}
           instance={instance}
         />
         <Items

--- a/src/types/slider.ts
+++ b/src/types/slider.ts
@@ -5,6 +5,7 @@ import { SwiperProps } from "swiper/react";
 export interface ConfigOptions {
   breakpoints?: SwiperBreakpoints;
   credentials?: FetchCredentials;
+  customViewAll?: string;
 }
 
 export type CustomHomepage = Array<


### PR DESCRIPTION
## What does this do?

This adds a `options.customViewAll` property for overriding or setting custom `homepage` id.