### PR TITLE
Set default labels as index + 1 for canvas figures.

### DIFF
--- a/src/components/Viewer/Media/Media.test.tsx
+++ b/src/components/Viewer/Media/Media.test.tsx
@@ -1,12 +1,53 @@
+import { render, screen } from "@testing-library/react";
+
+import { Canvas } from "@iiif/presentation-3";
 import Media from "src/components/Viewer/Media/Media";
 import React from "react";
-import { render, screen } from "@testing-library/react";
+
+const items = [
+  {
+    id: "https://example.org/manifest/1/canvas/1",
+    type: "Canvas",
+    height: 600,
+    width: 800,
+    label: { none: ["Canvas 1"] },
+    thumbnail: [
+      {
+        id: "https://example.org/item/1/default.jpg",
+        type: "Image",
+        height: 75,
+        width: 100,
+        format: "image/jpeg",
+      },
+    ],
+  },
+  {
+    id: "https://example.org/manifest/1/canvas/2",
+    type: "Canvas",
+    height: 600,
+    width: 800,
+    label: { none: ["Canvas 2"] },
+    thumbnail: [
+      {
+        id: "https://example.org/item/2/default.jpg",
+        type: "Image",
+        height: 75,
+        width: 100,
+        format: "image/jpeg",
+      },
+    ],
+  },
+] as unknown as Canvas[];
 
 describe("Media component", () => {
   it("renders", () => {
-    render(<Media items={[]} activeItem={0} />);
+    render(<Media items={items} activeItem={0} />);
     const media = screen.getByTestId("media");
     expect(media);
     expect(media.hasAttribute("aria-label")).toBe(true);
+    expect(media.getAttribute("data-active-canvas")).toBe(
+      "https://example.org/manifest/1/canvas/1",
+    );
+    expect(media.getAttribute("data-canvas-length")).toBe("2");
   });
 });

--- a/src/components/Viewer/Media/Media.tsx
+++ b/src/components/Viewer/Media/Media.tsx
@@ -95,19 +95,27 @@ const Media: React.FC<MediaProps> = ({ items }) => {
         handleFilter={handleFilter}
         handleCanvasToggle={handleCanvasToggle}
         activeIndex={activeIndex}
-        canvasLength={mediaItems.length}
+        canvasLength={items.length}
       />
       <Group
         aria-label={t("media.selectItem")}
         data-testid="media"
+        data-active-canvas={items[activeIndex].id}
+        data-canvas-length={items.length}
+        data-filter={filter}
         ref={scrollRef}
       >
         {mediaItems
-          .filter((item) => {
+          .filter((item, key) => {
+            if (!filter) return true;
+
             if (item.canvas?.label) {
               const label = getLabel(item.canvas.label);
               if (Array.isArray(label))
                 return label[0].toLowerCase().includes(filter.toLowerCase());
+            } else {
+              const label = (key + 1).toString();
+              return label.includes(filter);
             }
           })
           .map((item, index) => (

--- a/src/components/Viewer/Media/Media.tsx
+++ b/src/components/Viewer/Media/Media.tsx
@@ -121,7 +121,7 @@ const Media: React.FC<MediaProps> = ({ items }) => {
           .map((item, index) => (
             <Thumbnail
               canvas={item.canvas as CanvasNormalized}
-              canvasIndex={index}
+              canvasIndex={mediaItems.findIndex((el) => el === item)}
               handleChange={handleChange}
               isActive={activeCanvas === item?.canvas?.id ? true : false}
               key={item?.canvas?.id}

--- a/src/components/Viewer/Media/Thumbnail.test.tsx
+++ b/src/components/Viewer/Media/Thumbnail.test.tsx
@@ -92,6 +92,20 @@ describe("Thumbnail component", () => {
     });
   });
 
+  describe("figure missing a label", () => {
+    const newProps = { ...props, canvas: { ...props.canvas, label: null } };
+
+    it("renders a fallback label for item index + 1", () => {
+      render(
+        <Group>
+          <Thumbnail {...newProps} />
+        </Group>,
+      );
+      expect(screen.getByTestId("fig-caption")).toHaveTextContent("2");
+      expect(screen.getByAltText("2"));
+    });
+  });
+
   describe("audio and video thumbnail types", () => {
     it("renders a duration value in the tag for audio type", () => {
       const newProps = { ...props, type: "Sound" };

--- a/src/components/Viewer/Media/Thumbnail.tsx
+++ b/src/components/Viewer/Media/Thumbnail.tsx
@@ -55,6 +55,10 @@ const Thumbnail: React.FC<ThumbnailProps> = ({
   type,
   handleChange,
 }) => {
+  const label = canvas?.label
+    ? getLabel(canvas.label)
+    : (canvasIndex + 1).toString();
+
   return (
     <Item
       aria-checked={isActive}
@@ -65,12 +69,7 @@ const Thumbnail: React.FC<ThumbnailProps> = ({
     >
       <figure>
         <div>
-          {thumbnail?.id && (
-            <img
-              src={thumbnail.id}
-              alt={canvas?.label ? (getLabel(canvas.label) as string) : ""}
-            />
-          )}
+          {thumbnail?.id && <img src={thumbnail.id} alt={label as string} />}
 
           <Type>
             <Tag isIcon data-testid="thumbnail-tag">
@@ -84,11 +83,13 @@ const Thumbnail: React.FC<ThumbnailProps> = ({
             </Tag>
           </Type>
         </div>
-        {canvas?.label && (
-          <figcaption data-testid="fig-caption">
+        <figcaption data-testid="fig-caption">
+          {canvas.label ? (
             <Label label={canvas.label} />
-          </figcaption>
-        )}
+          ) : (
+            (canvasIndex + 1).toString()
+          )}
+        </figcaption>
       </figure>
     </Item>
   );


### PR DESCRIPTION
## What does this do?

This sets the default label for canvas figures (thumbnails) in the media component in cases where the Canvas does not have a label. The label will be the `(index + 1).toString()` to accommodate all languages. This same label will be the `alt` of the rendered thumbnail as well. Filtering will also work in this cases, ex: "2" as the input value will be show the "2", "12", "21", "22", etc... thumbnails.

## How to review?

Review with this fixture
https://samvera-labs.github.io/clover-iiif/docs/viewer/demo?iiif-content=https%3A%2F%2Fmarkpbaggett.github.io%2Fstatic_iiif%2Fmanifests%2Ftests%2Fservice_maps_0103.json

 - Canvas thumbnails will render as "1" and "2'.
 - Canvases are filterable