### PR TITLE
Add support for a custom loading component

### DIFF
--- a/pages/docs/viewer.mdx
+++ b/pages/docs/viewer.mdx
@@ -494,7 +494,7 @@ return (
 
 ### Custom Loading Component
 
-You may choose to override the default loading component that displays while the manifest is fetched and loaded into state.
+Clients may choose to override the default _loading_ component that displays while the IIIF resource is fetched and loaded into state.
 
 ```jsx
 <Viewer

--- a/pages/docs/viewer.mdx
+++ b/pages/docs/viewer.mdx
@@ -492,6 +492,21 @@ return (
 
 ---
 
+### Custom Loading Component
+
+You may choose to override the default loading component that displays while the manifest is fetched and loaded into state.
+
+```jsx
+<Viewer
+  iiifContent="https://example.com/manifest/1"
+  options={{
+    customLoadingComponent: () => <>My custom loading component</>,
+  }}
+/>
+```
+
+---
+
 ### Custom canvas displays
 
 Clients may wish to use their own display components instead of Clover Viewer's default displays ([OpenSeadragon](https://openseadragon.github.io/) for images and [HTML Video Player](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/video) for audio/video). The `Viewer` component allows a client to target individual `canvas` items in a IIIF Manifest by either direct reference to a canvas `id` or `format` (ie. `video/ogg`). See the Type Definition below for `CustomDisplay`, and an example implementation.

--- a/pages/docs/viewer.mdx
+++ b/pages/docs/viewer.mdx
@@ -142,27 +142,28 @@ const MyCustomViewer = () => {
 
 `Viewer` can configured through an `options` prop, which will serve as a object for common options.
 
-| Prop                            | Type                                                                        | Required | Default                                  |
-| ------------------------------- | --------------------------------------------------------------------------- | -------- | ---------------------------------------- |
-| `iiifContent`                   | `string`                                                                    | Yes      |                                          |
-| `iiifContentSearchQuery`        | [See Content Search](#content-search)                                       | No       |                                          |
-| `canvasIdCallback`              | `function`                                                                  | No       |                                          |
-| `customDisplays`                | [See Custom Displays](#custom-displays)                                     | No       |                                          |
-| `customTheme`                   | `object`                                                                    | No       |                                          |
-| `plugins`                       | [See Plugins](#plugins)                                                     | No       |                                          |
-| `options`                       | `object`                                                                    | No       |                                          |
-| `options.background`            | `string` [CSS](https://developer.mozilla.org/en-US/docs/Web/CSS/background) | No       | `transparent`                            |
-| `options.canvasBackgroundColor` | `string` [CSS](https://developer.mozilla.org/en-US/docs/Web/CSS/background) | No       | `#1a1d1e`                                |
-| `options.canvasHeight`          | `string` [CSS](https://developer.mozilla.org/en-US/docs/Web/CSS/height)     | No       | `500px`                                  |
-| `options.ignoreCaptionLabels`   | `string[]`                                                                  | No       | []                                       |
-| `options.openSeadragon`         | `OpenSeadragon.Options`                                                     | No       |                                          |
-| `options.informationPanel`      | [See Information Panel](#information-panel)                                 | No       |                                          |
-| `options.requestHeaders`        | `IncomingHttpHeaders`                                                       | No       | `{ "Content-Type": "application/json" }` |
-| `options.showDownload`          | `boolean`                                                                   | No       | true                                     |
-| `options.showIIIFBadge`         | `boolean`                                                                   | No       | true                                     |
-| `options.showTitle`             | `boolean`                                                                   | No       | true                                     |
-| `options.withCredentials`       | `boolean`                                                                   | No       | false                                    |
-| `options.contentSearch`         | [See Content Search](#content-search)                                       | No       |                                          |
+| Prop                             | Type                                                                        | Required | Default                                  |
+| -------------------------------- | --------------------------------------------------------------------------- | -------- | ---------------------------------------- |
+| `iiifContent`                    | `string`                                                                    | Yes      |                                          |
+| `iiifContentSearchQuery`         | [See Content Search](#content-search)                                       | No       |                                          |
+| `canvasIdCallback`               | `function`                                                                  | No       |                                          |
+| `customDisplays`                 | [See Custom Displays](#custom-displays)                                     | No       |                                          |
+| `customTheme`                    | `object`                                                                    | No       |                                          |
+| `plugins`                        | [See Plugins](#plugins)                                                     | No       |                                          |
+| `options`                        | `object`                                                                    | No       |                                          |
+| `options.background`             | `string` [CSS](https://developer.mozilla.org/en-US/docs/Web/CSS/background) | No       | `transparent`                            |
+| `options.canvasBackgroundColor`  | `string` [CSS](https://developer.mozilla.org/en-US/docs/Web/CSS/background) | No       | `#1a1d1e`                                |
+| `options.canvasHeight`           | `string` [CSS](https://developer.mozilla.org/en-US/docs/Web/CSS/height)     | No       | `500px`                                  |
+| `options.ignoreCaptionLabels`    | `string[]`                                                                  | No       | []                                       |
+| `options.openSeadragon`          | `OpenSeadragon.Options`                                                     | No       |                                          |
+| `options.informationPanel`       | [See Information Panel](#information-panel)                                 | No       |                                          |
+| `options.requestHeaders`         | `IncomingHttpHeaders`                                                       | No       | `{ "Content-Type": "application/json" }` |
+| `options.showDownload`           | `boolean`                                                                   | No       | true                                     |
+| `options.showIIIFBadge`          | `boolean`                                                                   | No       | true                                     |
+| `options.showTitle`              | `boolean`                                                                   | No       | true                                     |
+| `options.customLoadingComponent` | `React.ComponentType`                                                       | No       |                                          |
+| `options.withCredentials`        | `boolean`                                                                   | No       | false                                    |
+| `options.contentSearch`          | [See Content Search](#content-search)                                       | No       |                                          |
 
 - Options `canvasBackgroundColor` and `canvasHeight` will apply to both `<video>` elements and the OpenseaDragon canvas.
 - Option `withCredentials` being set as `true` will inform IIIF resource requests to be made [using credentials](https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest/withCredentials) such as cookies, authorization headers or TLS client certificates.

--- a/src/components/Viewer/index.tsx
+++ b/src/components/Viewer/index.tsx
@@ -192,7 +192,14 @@ const RenderViewer: React.FC<CloverViewerProps> = ({
    * loaded into React.Context as `vault`. Upon completion
    * (error or not) isLoaded will be set to true.
    */
-  if (!isLoaded) return <>Loading</>;
+  if (!isLoaded) {
+    if (options?.customLoadingComponent) {
+      const CustomLoadingComponent = options.customLoadingComponent;
+      return <CustomLoadingComponent />;
+    } else {
+      return <>Loading</>;
+    }
+  }
 
   /**
    * If an error occurs during manifest fetch process used by

--- a/src/context/viewer-context.tsx
+++ b/src/context/viewer-context.tsx
@@ -47,6 +47,7 @@ export type ViewerConfigOptions = {
   showDownload?: boolean;
   showIIIFBadge?: boolean;
   showTitle?: boolean;
+  customLoadingComponent?: React.ComponentType;
   withCredentials?: boolean;
   localeText?: {
     contentSearch?: {


### PR DESCRIPTION
Hey there!

This is a pull request to add support for replacing the default loading UI ("Loading") with a React component. The idea is from this issue: https://github.com/samvera-labs/clover-iiif/issues/245

I had to use React.ComponentType as opposed to the more flexible ReactNode because ReactNode caused an infinite loop in the `deepMerge` function.

In the [issue thread](https://github.com/samvera-labs/clover-iiif/issues/245), it was mentioned that a new default loading state would be nice. I'm open to implementing that! For example, we could do [some sort of skeleton](https://ui.shadcn.com/docs/components/skeleton). If we do implement a skeleton, let me know how detailed it should be (big rectangle vs lots of smaller shapes).