### PR TITLE
Add class to media search/close button so it's easier to target with CSS

### DIFF
--- a/src/components/Viewer/Media/Controls.tsx
+++ b/src/components/Viewer/Media/Controls.tsx
@@ -143,7 +143,11 @@ const Controls: React.FC<Props> = ({
             </Button>
           </Direction>
         )}
-        <Button onClick={handleFilterToggle} type="button">
+        <Button
+          onClick={handleFilterToggle}
+          type="button"
+          className="clover-viewer-media-search"
+        >
           {toggleFilter ? (
             <CloseIcon title={t("commonClose")} />
           ) : (


### PR DESCRIPTION
Hey!

On a previous project, a client wanted us to hide the media search button. While possible, the css wasn't pretty.
I thought it would be valuable to add a class to this search button so that it's easier to target.

Let me know what you think!

![image](https://github.com/user-attachments/assets/b9ee27b2-642f-4f84-888a-125fa1d03ba1)