### PR TITLE
Fix mobile display stretching past bounding box in mobile.

### DIFF
--- a/src/components/Viewer/Viewer/Viewer.styled.tsx
+++ b/src/components/Viewer/Viewer/Viewer.styled.tsx
@@ -27,6 +27,7 @@ const Main = styled("div", {
 
   "@sm": {
     width: "100%",
+    height: "100%"
   },
 });
 


### PR DESCRIPTION
We noticed this in https://github.com/pulibrary/figgy/issues/6351. My
initial tests show this should fix it, but I honestly don't know how to
get a test release into my app to see for sure.

This might fix #214 
