### PR TITLE
Refine information panel toggle, address responsive issues.

### DIFF
--- a/pages/docs/viewer.mdx
+++ b/pages/docs/viewer.mdx
@@ -19,15 +19,15 @@ A UI component that renders a multicanvas IIIF item viewer with pan-zoom support
 
 ---
 
-<Viewer
-  iiifContent="https://api.dc.library.northwestern.edu/api/v2/works/8a833741-74a8-40dc-bd1d-c416a3b1bb38?as=iiif"
-  options={{
-    showIIIFBadge: false,
-    informationPanel: {
-      open: false,
-    },
-  }}
-/>
+<div style={{ position: "relative", height: "500px", zIndex: "0" }}>
+  <Viewer
+    iiifContent="https://api.dc.library.northwestern.edu/api/v2/works/8a833741-74a8-40dc-bd1d-c416a3b1bb38?as=iiif"
+    options={{
+      showIIIFBadge: false,
+      canvasHeight: "100%",
+    }}
+  />
+</div>
 
 ## Features
 

--- a/pages/docs/viewer/demo.mdx
+++ b/pages/docs/viewer/demo.mdx
@@ -16,11 +16,12 @@ A UI component that renders a multicanvas IIIF item viewer with pan-zoom support
 
 <Viewer
   options={{
-    canvasHeight: "500px",
+    canvasHeight: "640px",
     openSeadragon: {
       gestureSettingsMouse: {
         scrollToZoom: false,
       },
     },
+    showIIIFBadge: false,
   }}
 />

--- a/src/components/Viewer/InformationPanel/About/About.styled.ts
+++ b/src/components/Viewer/InformationPanel/About/About.styled.ts
@@ -1,6 +1,7 @@
 import { styled } from "src/styles/stitches.config";
 
 const AboutContent = styled("div", {
+  width: "100%",
   padding: " 0 1.618rem 2rem",
   display: "flex",
   flexDirection: "column",

--- a/src/components/Viewer/InformationPanel/InformationPanel.styled.tsx
+++ b/src/components/Viewer/InformationPanel/InformationPanel.styled.tsx
@@ -1,5 +1,6 @@
-import React, { ReactNode } from "react";
 import * as Tabs from "@radix-ui/react-tabs";
+
+import React, { ReactNode } from "react";
 
 import { styled } from "src/styles/stitches.config";
 
@@ -47,6 +48,14 @@ const Trigger = styled(Tabs.Trigger, {
   cursor: "pointer",
   fontWeight: 400,
   transition: "$all",
+
+  "&[data-value='manifest-back']": {
+    display: "none;",
+
+    "@sm": {
+      display: "block",
+    },
+  },
 
   "&::after": {
     width: "0",

--- a/src/components/Viewer/InformationPanel/InformationPanel.tsx
+++ b/src/components/Viewer/InformationPanel/InformationPanel.tsx
@@ -65,6 +65,7 @@ export const InformationPanel: React.FC<NavigatorProps> = ({
   }) as CanvasNormalized;
 
   const renderContentSearch = informationPanel?.renderContentSearch;
+  const renderToggle = informationPanel?.renderToggle;
 
   /**
    * List of tabs to render in the information panel
@@ -102,6 +103,16 @@ export const InformationPanel: React.FC<NavigatorProps> = ({
       </Content>
     );
   }
+
+  /**
+   * Close the information panel
+   */
+  const handleInformationPanelClose = () => {
+    dispatch({
+      type: "updateInformationOpen",
+      isInformationOpen: false,
+    });
+  };
 
   useEffect(() => {
     /**
@@ -162,8 +173,19 @@ export const InformationPanel: React.FC<NavigatorProps> = ({
         aria-label={t("informationPanelTabs")}
         data-testid="information-panel-list"
       >
+        {renderToggle && (
+          <Trigger
+            value="manifest-back"
+            data-value="manifest-back"
+            onClick={handleInformationPanelClose}
+            as={"button"}
+          >
+            {t("informationPanelTabsClose")}
+          </Trigger>
+        )}
         {renderAbout && (
           <Trigger value="manifest-about">
+            <></>
             {t("informationPanelTabsAbout")}
           </Trigger>
         )}

--- a/src/components/Viewer/Viewer/Content.tsx
+++ b/src/components/Viewer/Viewer/Content.tsx
@@ -6,8 +6,6 @@ import {
 import { AnnotationResource, AnnotationResources } from "src/types/annotations";
 import {
   Aside,
-  CollapsibleContent,
-  CollapsibleTrigger,
   Content,
   Main,
   MediaWrapper,
@@ -17,7 +15,6 @@ import InformationPanel from "src/components/Viewer/InformationPanel/Information
 import Media from "src/components/Viewer/Media/Media";
 import Painting from "../Painting/Painting";
 import React from "react";
-import { useTranslation } from "react-i18next";
 import { useViewerState } from "src/context/viewer-context";
 
 export interface ViewerContentProps {
@@ -43,7 +40,6 @@ const ViewerContent: React.FC<ViewerContentProps> = ({
   items,
   painting,
 }) => {
-  const { t } = useTranslation();
   const { isInformationOpen, configOptions } = useViewerState();
   const { informationPanel } = configOptions;
 
@@ -52,19 +48,22 @@ const ViewerContent: React.FC<ViewerContentProps> = ({
    * there is content (About or Supplementing Resources) to display.
    */
 
-  const isAside = informationPanel?.renderAbout && isInformationOpen;
-
   const isForcedAside =
     informationPanel?.renderAnnotation &&
     annotationResources.length > 0 &&
     !informationPanel.open;
+
+  const isAside =
+    (informationPanel?.renderAbout && isInformationOpen) || isForcedAside;
+
+  const renderToggle = informationPanel?.renderToggle;
 
   return (
     <Content
       className="clover-viewer-content"
       data-testid="clover-viewer-content"
     >
-      <Main>
+      <Main data-aside-active={isAside} data-aside-toggle={renderToggle}>
         <Painting
           activeCanvas={activeCanvas}
           annotationResources={annotationResources}
@@ -72,29 +71,21 @@ const ViewerContent: React.FC<ViewerContentProps> = ({
           painting={painting}
         />
 
-        {isAside && (
-          <CollapsibleTrigger>
-            <span>{t("informationPanelToggle")}</span>
-          </CollapsibleTrigger>
-        )}
-
         {items.length > 1 && (
           <MediaWrapper className="clover-viewer-media-wrapper">
             <Media items={items} activeItem={0} />
           </MediaWrapper>
         )}
       </Main>
-      {(isAside || isForcedAside) && (
-        <Aside>
-          <CollapsibleContent>
-            <InformationPanel
-              activeCanvas={activeCanvas}
-              annotationResources={annotationResources}
-              searchServiceUrl={searchServiceUrl}
-              setContentSearchResource={setContentSearchResource}
-              contentSearchResource={contentSearchResource}
-            />
-          </CollapsibleContent>
+      {isAside && (
+        <Aside data-aside-active={isAside} data-aside-toggle={renderToggle}>
+          <InformationPanel
+            activeCanvas={activeCanvas}
+            annotationResources={annotationResources}
+            searchServiceUrl={searchServiceUrl}
+            setContentSearchResource={setContentSearchResource}
+            contentSearchResource={contentSearchResource}
+          />
         </Aside>
       )}
     </Content>

--- a/src/components/Viewer/Viewer/Header.tsx
+++ b/src/components/Viewer/Viewer/Header.tsx
@@ -16,8 +16,6 @@ import { Popover } from "src/components/UI";
 import React from "react";
 import Toggle from "./Toggle";
 import ViewerDownload from "./Download";
-import { media } from "src/styles/stitches.config";
-import { useMediaQuery } from "src/hooks/useMediaQuery";
 import { useTranslation } from "react-i18next";
 
 interface Props {
@@ -37,7 +35,6 @@ const ViewerHeader: React.FC<Props> = ({ manifestId, manifestLabel }) => {
    */
   const hasOptions =
     showDownload || showIIIFBadge || informationPanel?.renderToggle;
-  const isSmallViewport = useMediaQuery(media.sm);
 
   const { t } = useTranslation();
 
@@ -90,7 +87,7 @@ const ViewerHeader: React.FC<Props> = ({ manifestId, manifestLabel }) => {
               </PopoverContent>
             </Popover>
           )}
-          {informationPanel?.renderToggle && !isSmallViewport && <Toggle />}
+          {informationPanel?.renderToggle && <Toggle />}
         </HeaderOptions>
       )}
     </Header>

--- a/src/components/Viewer/Viewer/Toggle.styled.ts
+++ b/src/components/Viewer/Viewer/Toggle.styled.ts
@@ -33,8 +33,28 @@ const StyledThumb = styled(Switch.Thumb, {
   transform: "translateX(6px)",
   willChange: "transform",
 
+  span: {
+    fontFamily: "monospace",
+    fontSize: "0.8333rem",
+    fontWeight: "700",
+    display: "flex",
+    height: "100%",
+    width: "100%",
+    alignItems: "center",
+    justifyContent: "center",
+    color: "$primary",
+    opacity: "0.382",
+    userSelect: "none",
+    pointerEvents: "none",
+  },
+
   '&[data-state="checked"]': {
     transform: "translateX(calc(1.236rem + 6px))",
+
+    span: {
+      opacity: "1",
+      color: "$accent",
+    },
   },
 });
 

--- a/src/components/Viewer/Viewer/Toggle.tsx
+++ b/src/components/Viewer/Viewer/Toggle.tsx
@@ -1,45 +1,41 @@
 import {
-  Label,
   StyledSwitch,
   StyledThumb,
   StyledToggle,
 } from "src/components/Viewer/Viewer/Toggle.styled";
-import React, { useEffect, useState } from "react";
 import { useViewerDispatch, useViewerState } from "src/context/viewer-context";
 
+import React from "react";
 import { useTranslation } from "react-i18next";
 
 const Toggle = () => {
-  const { configOptions } = useViewerState();
+  const { isInformationOpen } = useViewerState();
   const dispatch: any = useViewerDispatch();
 
   const { t } = useTranslation();
 
-  const [checked, setChecked] = useState(configOptions?.informationPanel?.open);
-
-  useEffect(() => {
+  const handleOnCheckedChange = (checked) => {
     dispatch({
       type: "updateInformationOpen",
       isInformationOpen: checked,
     });
-  }, [checked, dispatch]);
+  };
 
   return (
     <StyledToggle>
-      <Label htmlFor="information-toggle" css={checked ? { opacity: "1" } : {}}>
-        {t("informationPanelToggle")}
-      </Label>
       <StyledSwitch
-        checked={checked}
-        onCheckedChange={() => setChecked(!checked)}
+        checked={isInformationOpen}
+        onCheckedChange={handleOnCheckedChange}
         id="information-toggle"
         aria-label={t("informationPanelToggle")}
         name="toggled?"
       >
-        <StyledThumb />
+        <StyledThumb>
+          <span>i</span>
+        </StyledThumb>
       </StyledSwitch>
     </StyledToggle>
   );
 };
 
-export default Toggle;
+export default React.memo(Toggle);

--- a/src/components/Viewer/Viewer/Viewer.styled.tsx
+++ b/src/components/Viewer/Viewer/Viewer.styled.tsx
@@ -1,5 +1,3 @@
-import * as Collapsible from "@radix-ui/react-collapsible";
-
 import { styled } from "src/styles/stitches.config";
 
 const MediaWrapper = styled("div", {
@@ -12,10 +10,6 @@ const Content = styled("div", {
   flexDirection: "row",
   flexGrow: "1",
   overflow: "hidden",
-
-  "@sm": {
-    flexDirection: "column",
-  },
 });
 
 const Main = styled("div", {
@@ -23,57 +17,45 @@ const Main = styled("div", {
   flexDirection: "column",
   flexGrow: "1",
   flexShrink: "1",
-  width: "61.8%",
+  width: "100%",
+  height: "100%",
 
-  "@sm": {
-    width: "100%",
-    height: "100%"
-  },
-});
+  "&[data-aside-active='true']": {
+    width: "61.8%",
 
-const CollapsibleTrigger = styled(Collapsible.Trigger, {
-  display: "none",
-  border: "none",
-  padding: "0",
-  transition: "$all",
-  opacity: "1",
-  background: "#6663",
-  margin: "1rem 0",
-  borderRadius: "6px",
-
-  "&[data-information-panel='false']": {
-    opacity: "0",
-    marginTop: "-59px",
-  },
-
-  "@sm": {
-    display: "flex",
-
-    "> span": {
-      display: "flex",
-      flexGrow: "1",
-      fontSize: "0.8333em",
-      justifyContent: "center",
-      padding: "0.5rem",
-      fontFamily: "inherit",
+    "@sm": {
+      width: "0",
+      opacity: "0",
     },
   },
-});
 
-const CollapsibleContent = styled(Collapsible.Content, {
-  width: "100%",
-  display: "flex",
+  "&[data-aside-toggle='false']": {
+    "@sm": {
+      width: "100% !important",
+      opacity: "1 !important",
+    },
+  },
 });
 
 const Aside = styled("aside", {
   display: "flex",
   flexGrow: "1",
   flexShrink: "0",
-  width: "38.2%",
+  width: "0",
   maxHeight: "100%",
 
-  "@sm": {
-    width: "100%",
+  "&[data-aside-active='true']": {
+    width: "38.2%",
+
+    "@sm": {
+      width: "100%",
+    },
+  },
+
+  "&[data-aside-toggle='false']": {
+    "@sm": {
+      width: "0 !important",
+    },
   },
 });
 
@@ -114,35 +96,8 @@ const Wrapper = styled("div", {
   },
 
   "&[data-information-panel-open='true']": {
-    "@sm": {
-      position: "fixed",
-      height: "100%",
-      width: "100%",
-      top: "0",
-      left: "0",
-      zIndex: "2500000000",
-
-      [`& ${MediaWrapper}`]: {
-        display: "none",
-      },
-
-      [`& ${CollapsibleTrigger}`]: {
-        margin: "1rem",
-      },
-
-      [`& ${CollapsibleContent}`]: {
-        height: "100%",
-      },
-    },
+    "@sm": {},
   },
 });
 
-export {
-  Wrapper,
-  Content,
-  Main,
-  MediaWrapper,
-  CollapsibleContent,
-  CollapsibleTrigger,
-  Aside,
-};
+export { Wrapper, Content, Main, MediaWrapper, Aside };

--- a/src/components/Viewer/Viewer/Viewer.tsx
+++ b/src/components/Viewer/Viewer/Viewer.tsx
@@ -31,7 +31,6 @@ import ViewerContent from "src/components/Viewer/Viewer/Content";
 import ViewerHeader from "src/components/Viewer/Viewer/Header";
 import { Wrapper } from "src/components/Viewer/Viewer/Viewer.styled";
 import { media } from "src/styles/stitches.config";
-import { useBodyLocked } from "src/hooks/useBodyLocked";
 import { useMediaQuery } from "src/hooks/useMediaQuery";
 
 interface ViewerProps {
@@ -75,7 +74,6 @@ const Viewer: React.FC<ViewerProps> = ({
   const [contentSearchResource, setContentSearchResource] =
     useState<AnnotationResource>();
 
-  const [isBodyLocked, setIsBodyLocked] = useBodyLocked(false);
   const isSmallViewport = useMediaQuery(media.sm);
   const [searchServiceUrl, setSearchServiceUrl] = useState();
 
@@ -93,19 +91,9 @@ const Viewer: React.FC<ViewerProps> = ({
     if (configOptions?.informationPanel?.open) {
       setInformationOpen(!isSmallViewport);
     }
-  }, [
-    isSmallViewport,
-    configOptions?.informationPanel?.open,
-    setInformationOpen,
-  ]);
+  }, [isSmallViewport, configOptions?.informationPanel?.open]);
 
-  useEffect(() => {
-    if (!isSmallViewport) {
-      setIsBodyLocked(false);
-      return;
-    }
-    setIsBodyLocked(isInformationOpen);
-  }, [isInformationOpen, isSmallViewport, setIsBodyLocked]);
+  useEffect(() => {}, [isSmallViewport]);
 
   useEffect(() => {
     const painting = getPaintingResource(vault, activeCanvas);
@@ -120,7 +108,7 @@ const Viewer: React.FC<ViewerProps> = ({
       setPainting(painting);
     }
     getAnnotationResources(vault, activeCanvas).then((resources) => {
-      if (resources.length > 0) {
+      if (resources.length > 0 && !isSmallViewport) {
         viewerDispatch({
           type: "updateInformationOpen",
           isInformationOpen: true,
@@ -129,7 +117,13 @@ const Viewer: React.FC<ViewerProps> = ({
       setAnnotationResources(resources);
       setIsInformationPanel(resources.length !== 0);
     });
-  }, [activeCanvas, annotationResources.length, vault, viewerDispatch]);
+  }, [
+    activeCanvas,
+    annotationResources.length,
+    isSmallViewport,
+    vault,
+    viewerDispatch,
+  ]);
 
   const hasSearchService = manifest.service.some(
     (service: any) => service.type === "SearchService2",
@@ -160,7 +154,6 @@ const Viewer: React.FC<ViewerProps> = ({
     ).then((contentSearch) => {
       setContentSearchResource(contentSearch);
     });
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [searchServiceUrl]);
 
   // add overlays for content search
@@ -181,7 +174,6 @@ const Viewer: React.FC<ViewerProps> = ({
       canvas,
       configOptions,
     );
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [openSeadragonViewer, contentSearchResource]);
 
   return (
@@ -189,7 +181,6 @@ const Viewer: React.FC<ViewerProps> = ({
       <Wrapper
         className={`${theme} clover-viewer`}
         css={{ background: configOptions?.background }}
-        data-body-locked={isBodyLocked}
         data-absolute-position={isAbsolutePosition}
         data-information-panel={isInformationPanel}
         data-information-panel-open={isInformationOpen}

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -9,6 +9,7 @@
   "copyFailure": "Failed",
   "copySuccess": "Copied",
   "informationPanelTabs": "Select",
+  "informationPanelTabsClose": "Viewer",
   "informationPanelTabsAbout": "About",
   "informationPanelTabsAnnotations": "Annotations",
   "informationPanelTabsSearch": "Search",


### PR DESCRIPTION
## Description

This gem addresses a responsive issues relating to legacy ideas for the Information Panel component. Previously, the information panel was treated very differently in smaller view ports, forcing the viewer to go to `position: fixed`. This is no longer desired as it grants Clover too much control over the screen within a consuming application. With the @tpendragon and Princeton's need of Clover to reside within a relative container wrapping it if `options.canvasHeight: "100%"` is set, this convention presents additional complications.

## What does this do?

- This work advances Clover by treating the Toggle the same regardless of viewport size. 
- In `@sm` viewports, the expanded Information Panel `aside` now slides completely over the viewer, overtaking width and height of the the content space provided.
- In cases where the `informationPanel.open` `informationPanel.renderToggle` are both false, the Information Panel should not rendered by default, or be able to be toggled as rendered.
- The exception to the above cases is if Annotations are present, and the informationPanel.defaultTab has been set to a custom value of `manifest-annotations`, as is the case: https://github.com/nulib/dc-nextjs/blob/deploy/staging/components/Clover/ViewerWrapper.tsx#L59-L64
- I have also added a **Viewer** tab that is only visible on smaller viewports, making it more obvious to users that may want to toggle back to the relative Image, Video, or Sound resources.

**Larger viewport, open**

![image](https://github.com/user-attachments/assets/132516b9-baf0-4dab-8882-b328af35e25f)

**Larger viewport, closed**

![image](https://github.com/user-attachments/assets/fd484cf0-12c7-4abb-8078-63cfa8e5ca83)

**Small viewport, open**

![image](https://github.com/user-attachments/assets/9a45c8ff-e154-4ec8-9f75-e8d966d75eae)

**Small viewport, closed**

![image](https://github.com/user-attachments/assets/7b591253-7719-4c83-a8d7-1ae88ace1da0)

