### PR TITLE
Update crossOrigin pattern for videos.

### DIFF
--- a/pages/docs/viewer.mdx
+++ b/pages/docs/viewer.mdx
@@ -142,28 +142,29 @@ const MyCustomViewer = () => {
 
 `Viewer` can configured through an `options` prop, which will serve as a object for common options.
 
-| Prop                             | Type                                                                        | Required | Default                                  |
-| -------------------------------- | --------------------------------------------------------------------------- | -------- | ---------------------------------------- |
-| `iiifContent`                    | `string`                                                                    | Yes      |                                          |
-| `iiifContentSearchQuery`         | [See Content Search](#content-search)                                       | No       |                                          |
-| `canvasIdCallback`               | `function`                                                                  | No       |                                          |
-| `customDisplays`                 | [See Custom Displays](#custom-displays)                                     | No       |                                          |
-| `customTheme`                    | `object`                                                                    | No       |                                          |
-| `plugins`                        | [See Plugins](#plugins)                                                     | No       |                                          |
-| `options`                        | `object`                                                                    | No       |                                          |
-| `options.background`             | `string` [CSS](https://developer.mozilla.org/en-US/docs/Web/CSS/background) | No       | `transparent`                            |
-| `options.canvasBackgroundColor`  | `string` [CSS](https://developer.mozilla.org/en-US/docs/Web/CSS/background) | No       | `#1a1d1e`                                |
-| `options.canvasHeight`           | `string` [CSS](https://developer.mozilla.org/en-US/docs/Web/CSS/height)     | No       | `500px`                                  |
-| `options.ignoreCaptionLabels`    | `string[]`                                                                  | No       | []                                       |
-| `options.openSeadragon`          | `OpenSeadragon.Options`                                                     | No       |                                          |
-| `options.informationPanel`       | [See Information Panel](#information-panel)                                 | No       |                                          |
-| `options.requestHeaders`         | `IncomingHttpHeaders`                                                       | No       | `{ "Content-Type": "application/json" }` |
-| `options.showDownload`           | `boolean`                                                                   | No       | true                                     |
-| `options.showIIIFBadge`          | `boolean`                                                                   | No       | true                                     |
-| `options.showTitle`              | `boolean`                                                                   | No       | true                                     |
-| `options.customLoadingComponent` | `React.ComponentType`                                                       | No       |                                          |
-| `options.withCredentials`        | `boolean`                                                                   | No       | false                                    |
-| `options.contentSearch`          | [See Content Search](#content-search)                                       | No       |                                          |
+| Prop                             | Type                                                                                                                                             | Required | Default                                  |
+| -------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ | -------- | ---------------------------------------- |
+| `iiifContent`                    | `string`                                                                                                                                         | Yes      |                                          |
+| `iiifContentSearchQuery`         | [See Content Search](#content-search)                                                                                                            | No       |                                          |
+| `canvasIdCallback`               | `function`                                                                                                                                       | No       |                                          |
+| `customDisplays`                 | [See Custom Displays](#custom-displays)                                                                                                          | No       |                                          |
+| `customTheme`                    | `object`                                                                                                                                         | No       |                                          |
+| `plugins`                        | [See Plugins](#plugins)                                                                                                                          | No       |                                          |
+| `options`                        | `object`                                                                                                                                         | No       |                                          |
+| `options.background`             | `string` [CSS](https://developer.mozilla.org/en-US/docs/Web/CSS/background)                                                                      | No       | `transparent`                            |
+| `options.canvasBackgroundColor`  | `string` [CSS](https://developer.mozilla.org/en-US/docs/Web/CSS/background)                                                                      | No       | `#1a1d1e`                                |
+| `options.canvasHeight`           | `string` [CSS](https://developer.mozilla.org/en-US/docs/Web/CSS/height)                                                                          | No       | `500px`                                  |
+| `options.crossOrigin`            | `anonymous`, `use-credentials`, or `undefined` [crossorigin](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Attributes/crossorigin) | No       | `undefined`                              |
+| `options.ignoreCaptionLabels`    | `string[]`                                                                                                                                       | No       | []                                       |
+| `options.openSeadragon`          | `OpenSeadragon.Options`                                                                                                                          | No       |                                          |
+| `options.informationPanel`       | [See Information Panel](#information-panel)                                                                                                      | No       |                                          |
+| `options.requestHeaders`         | `IncomingHttpHeaders`                                                                                                                            | No       | `{ "Content-Type": "application/json" }` |
+| `options.showDownload`           | `boolean`                                                                                                                                        | No       | true                                     |
+| `options.showIIIFBadge`          | `boolean`                                                                                                                                        | No       | true                                     |
+| `options.showTitle`              | `boolean`                                                                                                                                        | No       | true                                     |
+| `options.customLoadingComponent` | `React.ComponentType`                                                                                                                            | No       |                                          |
+| `options.withCredentials`        | `boolean`                                                                                                                                        | No       | false                                    |
+| `options.contentSearch`          | [See Content Search](#content-search)                                                                                                            | No       |                                          |
 
 - Options `canvasBackgroundColor` and `canvasHeight` will apply to both `<video>` elements and the OpenseaDragon canvas.
 - Option `withCredentials` being set as `true` will inform IIIF resource requests to be made [using credentials](https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest/withCredentials) such as cookies, authorization headers or TLS client certificates.

--- a/src/components/Viewer/Player/Player.tsx
+++ b/src/components/Viewer/Player/Player.tsx
@@ -161,7 +161,7 @@ const Player: React.FC<PlayerProps> = ({
         controls
         height={painting.height}
         width={painting.width}
-        crossOrigin="anonymous"
+        crossOrigin={configOptions.crossOrigin}
         poster={poster}
         style={{
           maxHeight: configOptions.canvasHeight,

--- a/src/context/viewer-context.tsx
+++ b/src/context/viewer-context.tsx
@@ -4,7 +4,7 @@ import {
   Reference,
 } from "@iiif/presentation-3";
 import OpenSeadragon, { Options as OpenSeadragonOptions } from "openseadragon";
-import React, { useReducer } from "react";
+import React, { MediaHTMLAttributes, useReducer } from "react";
 
 import { IncomingHttpHeaders } from "http";
 import { Vault } from "@iiif/helpers/vault";
@@ -30,6 +30,7 @@ export type ViewerConfigOptions = {
     searchResultsLimit?: number;
     overlays?: OverlayOptions;
   };
+  crossOrigin?: MediaHTMLAttributes<HTMLVideoElement>["crossOrigin"];
   ignoreCaptionLabels?: string[];
   informationPanel?: {
     open?: boolean;
@@ -101,6 +102,7 @@ const defaultConfigOptions = {
       zoomLevel: 4,
     },
   },
+  crossOrigin: undefined,
   ignoreCaptionLabels: [],
   informationPanel: {
     vtt: {


### PR DESCRIPTION
This updates the `crossorigin` attribute assigned to videos. Previously all AV material was assumed to be `crossigin: "anonymous"`. This was restrictive and assumed proper CORS arrangements were made on all providers. This hampered material served through the Internet Archive, related: https://github.com/internetarchive/iiif/issues/109.

The default is now `undefined` and can be modified as required at `configOptions.crossOrigin` which corresponds to enums described at https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Attributes/crossorigin.