### PR TITLE
Make sure the manifest has a service property, and then check manifes…

### DIFF
--- a/src/components/Viewer/Viewer/Viewer.tsx
+++ b/src/components/Viewer/Viewer/Viewer.tsx
@@ -165,9 +165,9 @@ const Viewer: React.FC<ViewerProps> = ({
     configOptions,
   ]);
 
-  const hasSearchService = manifest.service.some(
-    (service: any) => service.type === "SearchService2",
-  );
+  const hasSearchService = manifest.service
+    ? manifest.service.some((service: any) => service.type === "SearchService2")
+    : false;
 
   // check if search service exists in the manifest
   useEffect(() => {


### PR DESCRIPTION
This checks to see if a `service` property is defined before assuming it to be an array.