### PR TITLE
Hotfix: show interior scrollbars only when necessary

### DIFF
--- a/src/components/Viewer/InformationPanel/About/About.styled.ts
+++ b/src/components/Viewer/InformationPanel/About/About.styled.ts
@@ -53,6 +53,10 @@ const AboutContent = styled("div", {
     margin: "1rem 0 0.25rem",
   },
 
+  div: {
+    overflow: "auto",
+  },
+
   "ul, ol": {
     padding: "0",
     margin: "0",

--- a/src/components/Viewer/InformationPanel/About/About.styled.ts
+++ b/src/components/Viewer/InformationPanel/About/About.styled.ts
@@ -5,7 +5,7 @@ const AboutContent = styled("div", {
   padding: " 0 1.618rem 2rem",
   display: "flex",
   flexDirection: "column",
-  overflow: "scroll",
+  overflow: "auto",
   position: "absolute",
   fontWeight: "400",
   fontSize: "1rem",
@@ -51,10 +51,6 @@ const AboutContent = styled("div", {
   ".manifest-property-title": {
     fontWeight: "700",
     margin: "1rem 0 0.25rem",
-  },
-
-  div: {
-    overflow: "auto",
   },
 
   "ul, ol": {


### PR DESCRIPTION
## What does this do?

Adjusts overflow behavior to show scrollbar only when content is clipped.