### PR TITLE
Hotfix: Add lazy loading to slider component entries.

### DIFF
--- a/src/components/Slider/Items/Items.tsx
+++ b/src/components/Slider/Items/Items.tsx
@@ -6,6 +6,7 @@ import { Swiper, SwiperSlide } from "swiper/react";
 import { CollectionItems } from "@iiif/presentation-3";
 import Item from "./Item";
 import { ItemsStyled } from "src/components/Slider/Items/Items.styled";
+import LazyLoad from "src/components/UI/LazyLoad/LazyLoad";
 
 interface ItemsProps {
   breakpoints?: SwiperBreakpoints;
@@ -74,11 +75,13 @@ const Items: React.FC<ItemsProps> = ({
             data-index={index}
             data-type={item?.type.toLowerCase()}
           >
-            <Item
-              handleItemInteraction={handleItemInteraction}
-              index={index}
-              item={item as SliderItem}
-            />
+            <LazyLoad>
+              <Item
+                handleItemInteraction={handleItemInteraction}
+                index={index}
+                item={item as SliderItem}
+              />
+            </LazyLoad>
           </SwiperSlide>
         ))}
       </Swiper>

--- a/src/components/UI/LazyLoad/LazyLoad.test.tsx
+++ b/src/components/UI/LazyLoad/LazyLoad.test.tsx
@@ -1,0 +1,47 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+import LazyLoad from "./LazyLoad"; // adjust path as needed
+import React from "react";
+
+describe("LazyLoad", () => {
+  let observeMock: ReturnType<typeof vi.fn>;
+  let disconnectMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    observeMock = vi.fn();
+    disconnectMock = vi.fn();
+
+    // Mock IntersectionObserver globally
+    vi.stubGlobal(
+      "IntersectionObserver",
+      vi.fn(function (this: any, callback) {
+        this.observe = observeMock;
+        this.disconnect = disconnectMock;
+        // Simulate element entering viewport immediately
+        setTimeout(() => {
+          callback([{ isIntersecting: true }]);
+        }, 0);
+      }),
+    );
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("renders children once visible", async () => {
+    render(
+      <LazyLoad>
+        <div>Lazy Content</div>
+      </LazyLoad>,
+    );
+
+    // Wait for the next tick so the setTimeout and callback can run
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    expect(screen.getByText("Lazy Content")).toBeInTheDocument();
+    expect(observeMock).toHaveBeenCalled();
+    expect(disconnectMock).toHaveBeenCalled();
+  });
+});

--- a/src/components/UI/LazyLoad/LazyLoad.tsx
+++ b/src/components/UI/LazyLoad/LazyLoad.tsx
@@ -1,0 +1,36 @@
+import React, { useEffect, useRef, useState } from "react";
+
+interface LazyLoadProps {
+  children: React.ReactNode;
+  rootMargin?: string;
+}
+
+const LazyLoad: React.FC<LazyLoadProps> = ({
+  children,
+  rootMargin = "100px",
+}) => {
+  const ref = useRef<HTMLDivElement>(null);
+  const [isVisible, setIsVisible] = useState(false);
+
+  useEffect(() => {
+    const node = ref.current;
+    if (!node) return;
+
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry.isIntersecting) {
+          setIsVisible(true);
+          observer.disconnect();
+        }
+      },
+      { rootMargin },
+    );
+
+    observer.observe(node);
+    return () => observer.disconnect();
+  }, [ref]);
+
+  return <div ref={ref}>{isVisible ? children : null}</div>;
+};
+
+export default LazyLoad;


### PR DESCRIPTION
## What does this do?

This work adds a LazyLoad wrapper component using InteractionObserver  around the Slider entries to prevent large collections from overpopulating the DOM on intial load.