### PR TITLE
Added LazyLoad component to the ScrollItems in Scroll component

### DIFF
--- a/src/components/Scroll/Items/Items.tsx
+++ b/src/components/Scroll/Items/Items.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { Reference } from "@iiif/presentation-3";
 import ScrollItem from "src/components/Scroll/Items/Item";
 import { StyledScrollItems } from "src/components/Scroll/Items/Items.styled";
+import LazyLoad from "src/components/UI/LazyLoad/LazyLoad";
 
 const ScrollItems = ({ items }: { items: Reference<"Canvas">[] }) => {
   return (
@@ -11,14 +12,16 @@ const ScrollItems = ({ items }: { items: Reference<"Canvas">[] }) => {
         const isLastItem = itemNumber === items.length;
 
         return (
-          <ScrollItem
-            item={item}
-            hasItemBreak={itemNumber < items.length}
-            isLastItem={isLastItem}
-            key={item.id}
-            itemCount={items.length}
-            itemNumber={itemNumber}
-          />
+          <LazyLoad key={index}>
+            <ScrollItem
+              item={item}
+              hasItemBreak={itemNumber < items.length}
+              isLastItem={isLastItem}
+              key={item.id}
+              itemCount={items.length}
+              itemNumber={itemNumber}
+            />
+          </LazyLoad>
         );
       })}
     </StyledScrollItems>


### PR DESCRIPTION
This seems to do the job on a manifest with 188 pages. The only issue seems to be that when the user loads the page kind of mid-way the LazyLoad component is not aware of the position of the user and gets a little behind loading what is on the screen. We may need to add something there to check what will be on the screen as the page itself is loading.