### PR TITLE
Add content state callback.

### DIFF
--- a/docs/components/DynamicImports/Viewer.tsx
+++ b/docs/components/DynamicImports/Viewer.tsx
@@ -22,12 +22,14 @@ const CloverViewer = ({
   customDisplays,
   iiifContentSearchQuery,
   plugins,
+  contentStateCallback,
 }: {
   iiifContent: string;
   options?: ViewerConfigOptions;
   customDisplays?: Array<CustomDisplay>;
   iiifContentSearchQuery?: ContentSearchQuery;
   plugins?: Array<PluginConfig>;
+  contentStateCallback?: (json: any) => void;
 }) => {
   const router = useRouter();
   const iiifResource = router.query["iiif-content"]
@@ -36,13 +38,9 @@ const CloverViewer = ({
 
   const background = isDark() ? "rgb(17, 17, 17)" : "#fff";
 
-  const handleContentStateCallback = (json) => {
-    console.log("Content state callback", json);
-  };
-
   return (
     <Viewer
-      contentStateCallback={handleContentStateCallback}
+      contentStateCallback={contentStateCallback}
       iiifContent={iiifResource}
       iiifContentSearchQuery={iiifContentSearchQuery}
       options={{ ...options, background }}

--- a/docs/components/DynamicImports/Viewer.tsx
+++ b/docs/components/DynamicImports/Viewer.tsx
@@ -36,8 +36,13 @@ const CloverViewer = ({
 
   const background = isDark() ? "rgb(17, 17, 17)" : "#fff";
 
+  const handleContentStateCallback = (json) => {
+    console.log("Content state callback", json);
+  };
+
   return (
     <Viewer
+      contentStateCallback={handleContentStateCallback}
       iiifContent={iiifResource}
       iiifContentSearchQuery={iiifContentSearchQuery}
       options={{ ...options, background }}

--- a/pages/docs/viewer/_meta.json
+++ b/pages/docs/viewer/_meta.json
@@ -13,5 +13,12 @@
       "sidebar": false,
       "layout": "full"
     }
+  },
+  "content-state": {
+    "theme": {
+      "layout": "full",
+      "sidebar": false
+    },
+    "title": "Content State"
   }
 }

--- a/pages/docs/viewer/_meta.json
+++ b/pages/docs/viewer/_meta.json
@@ -15,6 +15,7 @@
     }
   },
   "content-state": {
+    "display": "hidden",
     "theme": {
       "layout": "full",
       "sidebar": false

--- a/pages/docs/viewer/content-state.mdx
+++ b/pages/docs/viewer/content-state.mdx
@@ -1,0 +1,58 @@
+import Viewer from "docs/components/DynamicImports/Viewer";
+import CustomManifest from "docs/components/CustomManifest/CustomManifest";
+import CallToAction from "docs/components/CallToAction";
+
+export const handleContentStateCallback = (contentState) => {
+  const textAreaEncoded = document.getElementById("content-state-encoded");
+  const textAreaJson = document.getElementById("content-state-json");
+  if (textAreaEncoded && contentState) {
+    textAreaEncoded.value = contentState.encoded;
+  }
+  if (textAreaJson && contentState) {
+    textAreaJson.value = JSON.stringify(contentState.json);
+  }
+};
+
+## Viewer (Content State)
+
+<textarea
+  id="content-state-encoded"
+  style={{
+    background: "#0001",
+    borderRadius: "0.5rem",
+    width: "100%",
+    height: "200px",
+    padding: "1rem",
+    fontSize: "0.833rem",
+    resize: "none",
+  }}
+></textarea>
+
+<textarea
+  id="content-state-json"
+  style={{
+    background: "#0001",
+    borderRadius: "0.5rem",
+    width: "100%",
+    height: "200px",
+    padding: "1rem",
+    fontSize: "0.833rem",
+    resize: "none",
+  }}
+></textarea>
+
+<CustomManifest placeholder="IIIF Manifest or Collection" />
+
+<Viewer
+  contentStateCallback={handleContentStateCallback}
+  options={{
+    canvasHeight: "640px",
+    openSeadragon: {
+      gestureSettingsMouse: {
+        scrollToZoom: false,
+      },
+    },
+    showIIIFBadge: false,
+
+}}
+/>

--- a/public/manifest/content-state/fragment-selector-video.json
+++ b/public/manifest/content-state/fragment-selector-video.json
@@ -1,0 +1,24 @@
+{
+  "@context": "http://iiif.io/api/presentation/3/context.json",
+  "id": "http://localhost:3000/manifest/content-state/fragment-selector-video.json",
+  "type": "Annotation",
+  "motivation": ["contentState"],
+  "target": {
+    "type": "SpecificResource",
+    "source": {
+      "id": "https://iiif.io/api/cookbook/recipe/0065-opera-multiple-canvases/canvas/1",
+      "type": "Canvas",
+      "partOf": [
+        {
+          "id": "https://iiif.io/api/cookbook/recipe/0065-opera-multiple-canvases/manifest.json",
+          "type": "Manifest"
+        }
+      ]
+    },
+    "selector": {
+      "type": "FragmentSelector",
+      "value": "t=350,470"
+    }
+  },
+  "body": []
+}

--- a/public/manifest/content-state/point-selector.json
+++ b/public/manifest/content-state/point-selector.json
@@ -1,0 +1,24 @@
+{
+  "@context": "http://iiif.io/api/presentation/3/context.json",
+  "id": "http://localhost:3000/manifest/content-state/point-selector.json",
+  "type": "Annotation",
+  "motivation": ["contentState"],
+  "target": {
+    "type": "SpecificResource",
+    "source": {
+      "id": "https://iiif.io/api/cookbook/recipe/0065-opera-multiple-canvases/canvas/2",
+      "type": "Canvas",
+      "partOf": [
+        {
+          "id": "https://iiif.io/api/cookbook/recipe/0065-opera-multiple-canvases/manifest.json",
+          "type": "Manifest"
+        }
+      ]
+    },
+    "selector": {
+      "type": "PointSelector",
+      "t": 2318
+    }
+  },
+  "body": []
+}

--- a/src/components/Viewer/InformationPanel/Annotation/VTT/Cue.tsx
+++ b/src/components/Viewer/InformationPanel/Annotation/VTT/Cue.tsx
@@ -1,13 +1,13 @@
 import React, { useEffect, useRef, useState } from "react";
-
-import { AutoScrollOptions } from "src/context/viewer-context";
-import { Item } from "src/components/Viewer/InformationPanel/Annotation/VTT/Cue.styled";
-import { convertTime } from "src/lib/utils";
 import {
   ViewerContextStore,
   useViewerDispatch,
   useViewerState,
 } from "src/context/viewer-context";
+
+import { AutoScrollOptions } from "src/context/viewer-context";
+import { Item } from "src/components/Viewer/InformationPanel/Annotation/VTT/Cue.styled";
+import { convertTime } from "src/lib/utils";
 
 const AutoScrollDisableTime = 750;
 
@@ -134,7 +134,7 @@ const Cue: React.FC<Props> = ({ label, start, end }) => {
       onClick={handleClick}
       value={label}
     >
-      {label}
+      <span>{label}</span>
       <strong>{convertTime(start)}</strong>
     </Item>
   );

--- a/src/components/Viewer/InformationPanel/Annotation/VTT/VTT.tsx
+++ b/src/components/Viewer/InformationPanel/Annotation/VTT/VTT.tsx
@@ -11,15 +11,19 @@ import { getLabel } from "src/hooks/use-iiif";
 import { parse } from "node-webvtt";
 
 type AnnotationItemVTTProps = {
+  inlineCues?: NodeWebVttCueNested[];
   label: InternationalString | undefined;
-  vttUri: string;
+  vttUri?: string;
 };
 
 const AnnotationItemVTT: React.FC<AnnotationItemVTTProps> = ({
+  inlineCues,
   label,
   vttUri,
 }) => {
-  const [cues, setCues] = React.useState<Array<NodeWebVttCueNested>>([]);
+  const [cues, setCues] = React.useState<Array<NodeWebVttCueNested>>(
+    inlineCues ? inlineCues : [],
+  );
   const { createNestedCues, orderCuesByTime } = useWebVtt();
   const [isNetworkError, setIsNetworkError] = React.useState<Error>();
 

--- a/src/components/Viewer/Player/Player.tsx
+++ b/src/components/Viewer/Player/Player.tsx
@@ -158,7 +158,7 @@ const Player: React.FC<PlayerProps> = ({
               },
             });
           }
-        }, 1000);
+        }, 500);
       }
 
       if (video && video.paused) {
@@ -176,10 +176,10 @@ const Player: React.FC<PlayerProps> = ({
     video.addEventListener("timeupdate", onTimeUpdate);
 
     return () => {
-      video.removeEventListener("timeupdate", onTimeUpdate);
+      video?.removeEventListener("timeupdate", onTimeUpdate);
       if (intervalId) clearInterval(intervalId);
     };
-  }, [playerRef]);
+  }, [painting.id, activeCanvas]);
 
   /**
    * Update to video to content state annotation selector
@@ -244,6 +244,7 @@ const Player: React.FC<PlayerProps> = ({
         id="clover-iiif-video"
         key={painting.id}
         ref={playerRef}
+        data-src={painting.id}
         controls
         height={painting.height}
         width={painting.width}

--- a/src/components/Viewer/Player/Player.tsx
+++ b/src/components/Viewer/Player/Player.tsx
@@ -14,9 +14,6 @@ import { PlayerWrapper } from "src/components/Viewer/Player/Player.styled";
 import Track from "src/components/Viewer/Player/Track";
 import { getPaintingResource } from "src/hooks/use-iiif";
 import { hlsMimeTypes } from "src/lib/hls";
-import { retry } from "src/lib/retry";
-
-// Set referrer header as a NU domain: ie. meadow.rdc-staging.library.northwestern.edu
 
 interface PlayerProps {
   allSources: LabeledIIIFExternalWebResource[];

--- a/src/components/Viewer/index.tsx
+++ b/src/components/Viewer/index.tsx
@@ -113,8 +113,14 @@ const RenderViewer: React.FC<CloverViewerProps> = ({
    * the normalized manifest available from @iiif/helpers/vault.
    */
   const store = useViewerState();
-  const { activeCanvas, activeManifest, activeSelector, isLoaded, vault } =
-    store;
+  const {
+    activeCanvas,
+    activeManifest,
+    activeSelector,
+    isLoaded,
+    vault,
+    visibleCanvases,
+  } = store;
   const [iiifResource, setIiifResource] = useState<
     CollectionNormalized | ManifestNormalized | AnnotationNormalized
   >();
@@ -141,7 +147,7 @@ const RenderViewer: React.FC<CloverViewerProps> = ({
         target: {
           type: "SpecificResource",
           source: {
-            id: activeCanvas,
+            id: visibleCanvases[0]?.id || activeCanvas,
             type: "Canvas",
             partOf: [
               {
@@ -164,6 +170,7 @@ const RenderViewer: React.FC<CloverViewerProps> = ({
     activeSelector,
     canvasIdCallback,
     contentStateCallback,
+    visibleCanvases,
   ]);
 
   useEffect(() => {

--- a/src/components/Viewer/index.tsx
+++ b/src/components/Viewer/index.tsx
@@ -113,7 +113,8 @@ const RenderViewer: React.FC<CloverViewerProps> = ({
    * the normalized manifest available from @iiif/helpers/vault.
    */
   const store = useViewerState();
-  const { activeCanvas, activeManifest, isLoaded, vault } = store;
+  const { activeCanvas, activeManifest, activeSelector, isLoaded, vault } =
+    store;
   const [iiifResource, setIiifResource] = useState<
     CollectionNormalized | ManifestNormalized | AnnotationNormalized
   >();
@@ -149,6 +150,7 @@ const RenderViewer: React.FC<CloverViewerProps> = ({
               },
             ],
           },
+          selector: activeSelector,
         },
       };
       contentStateCallback({
@@ -156,7 +158,13 @@ const RenderViewer: React.FC<CloverViewerProps> = ({
         encoded: encodeContentState(JSON.stringify(json)),
       });
     }
-  }, [activeManifest, activeCanvas, canvasIdCallback, contentStateCallback]);
+  }, [
+    activeCanvas,
+    activeManifest,
+    activeSelector,
+    canvasIdCallback,
+    contentStateCallback,
+  ]);
 
   useEffect(() => {
     if (activeManifest)

--- a/src/components/Viewer/index.tsx
+++ b/src/components/Viewer/index.tsx
@@ -133,6 +133,16 @@ const RenderViewer: React.FC<CloverViewerProps> = ({
   if (customTheme) theme = createTheme("custom", customTheme);
 
   /**
+   * Update activeSelector when the canvas or manifest changes.
+   */
+  useEffect(() => {
+    dispatch({
+      type: "updateActiveSelector",
+      selector: undefined,
+    });
+  }, [activeCanvas, activeManifest]);
+
+  /**
    * On change, pass the activeCanvas up to the wrapping `<App/>`
    * component to be handed off to a consuming application.
    */

--- a/src/components/Viewer/index.tsx
+++ b/src/components/Viewer/index.tsx
@@ -16,7 +16,7 @@ import {
   PluginConfig,
 } from "src/context/viewer-context";
 
-import { getManifestSequence } from "@iiif/helpers";
+import { encodeContentState, getManifestSequence } from "@iiif/helpers";
 import { Vault } from "@iiif/helpers/vault";
 import Viewer from "src/components/Viewer/Viewer/Viewer";
 import { createTheme } from "@stitches/react";
@@ -32,6 +32,7 @@ import { contentStateSpecificResource } from "src/lib/content-state";
 
 export interface CloverViewerProps {
   canvasIdCallback?: (arg0: string) => void;
+  contentStateCallback?: (iiifContentState: object) => void;
   customDisplays?: Array<CustomDisplay>;
   plugins?: Array<PluginConfig>;
   customTheme?: any;
@@ -43,7 +44,8 @@ export interface CloverViewerProps {
 }
 
 const CloverViewer: React.FC<CloverViewerProps> = ({
-  canvasIdCallback = () => {},
+  canvasIdCallback,
+  contentStateCallback,
   customDisplays = [],
   plugins = [],
   customTheme,
@@ -87,6 +89,7 @@ const CloverViewer: React.FC<CloverViewerProps> = ({
       <RenderViewer
         iiifContent={iiifResource}
         canvasIdCallback={canvasIdCallback}
+        contentStateCallback={contentStateCallback}
         customTheme={customTheme}
         options={options}
         iiifContentSearchQuery={iiifContentSearchQuery}
@@ -97,6 +100,7 @@ const CloverViewer: React.FC<CloverViewerProps> = ({
 
 const RenderViewer: React.FC<CloverViewerProps> = ({
   canvasIdCallback,
+  contentStateCallback,
   customTheme,
   iiifContent,
   options,
@@ -126,8 +130,33 @@ const RenderViewer: React.FC<CloverViewerProps> = ({
    * component to be handed off to a consuming application.
    */
   useEffect(() => {
-    if (canvasIdCallback) canvasIdCallback(activeCanvas);
-  }, [activeCanvas, canvasIdCallback]);
+    if (canvasIdCallback) {
+      canvasIdCallback(activeCanvas);
+    }
+
+    if (contentStateCallback) {
+      const json = {
+        ...contentStateSpecificResource,
+        target: {
+          type: "SpecificResource",
+          source: {
+            id: activeCanvas,
+            type: "Canvas",
+            partOf: [
+              {
+                id: activeManifest,
+                type: "Manifest",
+              },
+            ],
+          },
+        },
+      };
+      contentStateCallback({
+        json,
+        encoded: encodeContentState(JSON.stringify(json)),
+      });
+    }
+  }, [activeManifest, activeCanvas, canvasIdCallback, contentStateCallback]);
 
   useEffect(() => {
     if (activeManifest)

--- a/src/context/viewer-context.tsx
+++ b/src/context/viewer-context.tsx
@@ -9,7 +9,6 @@ import React, { MediaHTMLAttributes, useEffect, useReducer } from "react";
 
 import { IncomingHttpHeaders } from "http";
 import { Vault } from "@iiif/helpers/vault";
-import { W } from "node_modules/@iiif/helpers/dist/vault-actions-FZxiP2q-";
 import { deepMerge } from "src/lib/utils";
 import { v4 as uuidv4 } from "uuid";
 
@@ -407,6 +406,10 @@ const ViewerProvider: React.FC<ViewerProviderProps> = ({
           },
         });
       });
+
+      return () => {
+        openSeadragonViewer.removeAllHandlers("update-viewport");
+      };
     }
   }, [openSeadragonViewer]);
 

--- a/src/lib/iiif.ts
+++ b/src/lib/iiif.ts
@@ -118,6 +118,8 @@ export const parseIiifContent = (iiifContent: string) => {
   if (isURL(iiifContent)) {
     return { resourceId: iiifContent };
   } else {
+    const decodedContent = decodeContentState(iiifContent);
+    console.log("Decoded content", decodedContent);
     const json = JSON.parse(decodeContentState(iiifContent));
     const { active } = parseContentStateJson(json);
 

--- a/src/lib/iiif.ts
+++ b/src/lib/iiif.ts
@@ -118,8 +118,6 @@ export const parseIiifContent = (iiifContent: string) => {
   if (isURL(iiifContent)) {
     return { resourceId: iiifContent };
   } else {
-    const decodedContent = decodeContentState(iiifContent);
-    console.log("Decoded content", decodedContent);
     const json = JSON.parse(decodeContentState(iiifContent));
     const { active } = parseContentStateJson(json);
 


### PR DESCRIPTION
## Description
This work adds in the ability for the Viewer component to return its current _Content State_ through the `contentStateCallback` prop. If enabled the an object is returned to the consuming application containing both an encoded Content State as well as the raw JSON. The consuming application can then handle this however is required for its use case(s). This can be valuable for sharing the current content state with other human users or for communicating with other IIIF-fluent components in their application.

### Usage

Implementation:

```jsx
const MyViewerComponent = () => {
  const handleContentStateCallback = (contentState) => {
    console.log(contentState);
  };
  return (
    <Viewer
      contentStateCallback={handleContentStateCallback}
      iiifContent="https://api.dc.library.northwestern.edu/api/v2/works/71153379-4283-43be-8b0f-4e7e3bfda275?as=iiif"
    />
  );
};
```

Example output of above `console.log()`

```json
{
  "json": {
    "@context": "http://iiif.io/api/presentation/3/context.json",
    "id": "http://example.org/iiif/content-state/specific-resource",
    "type": "Annotation",
    "motivation": [
      "contentState"
    ],
    "target": {
      "type": "SpecificResource",
      "source": {
        "id": "https://api.dc.library.northwestern.edu/api/v2/works/71153379-4283-43be-8b0f-4e7e3bfda275?as=iiif/canvas/1",
        "type": "Canvas",
        "partOf": [
          {
            "id": "https://api.dc.library.northwestern.edu/api/v2/works/71153379-4283-43be-8b0f-4e7e3bfda275?as=iiif",
            "type": "Manifest"
          }
        ]
      },
      "selector": {
        "type": "FragmentSelector",
        "value": "xywh=3071,1092,4344,3722"
      }
    },
    "body": []
  },
  "encoded": "JTdCJTIyJTQwY29udGV4dCUyMiUzQSUyMmh0dHAlM0ElMkYlMkZpaWlmLmlvJTJGYXBpJTJGcHJlc2VudGF0aW9uJTJGMyUyRmNvbnRleHQuanNvbiUyMiUyQyUyMmlkJTIyJTNBJTIyaHR0cCUzQSUyRiUyRmV4YW1wbGUub3JnJTJGaWlpZiUyRmNvbnRlbnQtc3RhdGUlMkZzcGVjaWZpYy1yZXNvdXJjZSUyMiUyQyUyMnR5cGUlMjIlM0ElMjJBbm5vdGF0aW9uJTIyJTJDJTIybW90aXZhdGlvbiUyMiUzQSU1QiUyMmNvbnRlbnRTdGF0ZSUyMiU1RCUyQyUyMnRhcmdldCUyMiUzQSU3QiUyMnR5cGUlMjIlM0ElMjJTcGVjaWZpY1Jlc291cmNlJTIyJTJDJTIyc291cmNlJTIyJTNBJTdCJTIyaWQlMjIlM0ElMjJodHRwcyUzQSUyRiUyRmFwaS5kYy5saWJyYXJ5Lm5vcnRod2VzdGVybi5lZHUlMkZhcGklMkZ2MiUyRndvcmtzJTJGNzExNTMzNzktNDI4My00M2JlLThiMGYtNGU3ZTNiZmRhMjc1JTNGYXMlM0RpaWlmJTJGY2FudmFzJTJGMSUyMiUyQyUyMnR5cGUlMjIlM0ElMjJDYW52YXMlMjIlMkMlMjJwYXJ0T2YlMjIlM0ElNUIlN0IlMjJpZCUyMiUzQSUyMmh0dHBzJTNBJTJGJTJGYXBpLmRjLmxpYnJhcnkubm9ydGh3ZXN0ZXJuLmVkdSUyRmFwaSUyRnYyJTJGd29ya3MlMkY3MTE1MzM3OS00MjgzLTQzYmUtOGIwZi00ZTdlM2JmZGEyNzUlM0ZhcyUzRGlpaWYlMjIlMkMlMjJ0eXBlJTIyJTNBJTIyTWFuaWZlc3QlMjIlN0QlNUQlN0QlMkMlMjJzZWxlY3RvciUyMiUzQSU3QiUyMnR5cGUlMjIlM0ElMjJGcmFnbWVudFNlbGVjdG9yJTIyJTJDJTIydmFsdWUlMjIlM0ElMjJ4eXdoJTNEMzA3MSUyQzEwOTIlMkM0MzQ0JTJDMzcyMiUyMiU3RCU3RCUyQyUyMmJvZHklMjIlM0ElNUIlNUQlN0Q"
}
```

## How do we review?

- Spin up Clover using `npm run dev`
- Go to the test page http://localhost:3000/docs/viewer/content-state
- Input any manifest or use the default **Zagna "lunga"**
- Note the two text areas where the encoded content state and the JSON are out put respectively.
- Note the console in inspector tools where the page is output the content state through a a `console.log()` like the example noted in the Usage section.
- Update the canvas and note the change in each text area (may be harder to see in encoded)
- Activate the OpenSeadragon canvas and begin to pan-zoom. Note the changing selector values.
- Note, you can round trip this by taking the encoded string value and submitting this into the text input on the text page. [Example](http://localhost:3000/docs/viewer/content-state?iiif-content=JTdCJTIyJTQwY29udGV4dCUyMiUzQSUyMmh0dHAlM0ElMkYlMkZpaWlmLmlvJTJGYXBpJTJGcHJlc2VudGF0aW9uJTJGMyUyRmNvbnRleHQuanNvbiUyMiUyQyUyMmlkJTIyJTNBJTIyaHR0cCUzQSUyRiUyRmV4YW1wbGUub3JnJTJGaWlpZiUyRmNvbnRlbnQtc3RhdGUlMkZzcGVjaWZpYy1yZXNvdXJjZSUyMiUyQyUyMnR5cGUlMjIlM0ElMjJBbm5vdGF0aW9uJTIyJTJDJTIybW90aXZhdGlvbiUyMiUzQSU1QiUyMmNvbnRlbnRTdGF0ZSUyMiU1RCUyQyUyMnRhcmdldCUyMiUzQSU3QiUyMnR5cGUlMjIlM0ElMjJTcGVjaWZpY1Jlc291cmNlJTIyJTJDJTIyc291cmNlJTIyJTNBJTdCJTIyaWQlMjIlM0ElMjJodHRwcyUzQSUyRiUyRmFwaS5kYy5saWJyYXJ5Lm5vcnRod2VzdGVybi5lZHUlMkZhcGklMkZ2MiUyRndvcmtzJTJGNzExNTMzNzktNDI4My00M2JlLThiMGYtNGU3ZTNiZmRhMjc1JTNGYXMlM0RpaWlmJTJGY2FudmFzJTJGMSUyMiUyQyUyMnR5cGUlMjIlM0ElMjJDYW52YXMlMjIlMkMlMjJwYXJ0T2YlMjIlM0ElNUIlN0IlMjJpZCUyMiUzQSUyMmh0dHBzJTNBJTJGJTJGYXBpLmRjLmxpYnJhcnkubm9ydGh3ZXN0ZXJuLmVkdSUyRmFwaSUyRnYyJTJGd29ya3MlMkY3MTE1MzM3OS00MjgzLTQzYmUtOGIwZi00ZTdlM2JmZGEyNzUlM0ZhcyUzRGlpaWYlMjIlMkMlMjJ0eXBlJTIyJTNBJTIyTWFuaWZlc3QlMjIlN0QlNUQlN0QlMkMlMjJzZWxlY3RvciUyMiUzQSU3QiUyMnR5cGUlMjIlM0ElMjJGcmFnbWVudFNlbGVjdG9yJTIyJTJDJTIydmFsdWUlMjIlM0ElMjJ4eXdoJTNEMzA3MSUyQzEwOTIlMkM0MzQ0JTJDMzcyMiUyMiU3RCU3RCUyQyUyMmJvZHklMjIlM0ElNUIlNUQlN0Q)