### PR TITLE
Add ability to accept prefetched JSON as `iiifContent`

### DIFF
--- a/pages/docs/viewer.mdx
+++ b/pages/docs/viewer.mdx
@@ -15,6 +15,45 @@ export const handleContentStateCallback = ({ encoded, json }) => {
   });
 };
 
+export const prefetchedManifestJson = {
+  "@context": "http://iiif.io/api/presentation/3/context.json",
+  id: "https://iiif.io/api/cookbook/recipe/0001-mvm-image/manifest.json",
+  type: "Manifest",
+  label: {
+    en: ["Single Image Example"],
+  },
+  items: [
+    {
+      id: "https://iiif.io/api/cookbook/recipe/0001-mvm-image/canvas/p1",
+      type: "Canvas",
+      height: 1800,
+      width: 1200,
+      items: [
+        {
+          id: "https://iiif.io/api/cookbook/recipe/0001-mvm-image/page/p1/1",
+          type: "AnnotationPage",
+          items: [
+            {
+              id: "https://iiif.io/api/cookbook/recipe/0001-mvm-image/annotation/p0001-image",
+              type: "Annotation",
+              motivation: "painting",
+              body: {
+                id: "http://iiif.io/api/presentation/2.1/example/fixtures/resources/page1-full.png",
+                type: "Image",
+                format: "image/png",
+                height: 1800,
+                width: 1200,
+              },
+              target:
+                "https://iiif.io/api/cookbook/recipe/0001-mvm-image/canvas/p1",
+            },
+          ],
+        },
+      ],
+    },
+  ],
+};
+
 # Viewer
 
 A UI component that renders a multicanvas IIIF item viewer with pan-zoom support for `Image` via [OpenSeadragon](https://openseadragon.github.io/) and `Video` and `Sound` content resources using the [HTML video element](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/video).
@@ -91,7 +130,9 @@ Render `Viewer` with a IIIF Manifest or Collection URI. The only required prop i
     ```
   </Tab>
   <Tab>
-    <Viewer iiifContent="https://api.dc.library.northwestern.edu/api/v2/works/8a833741-74a8-40dc-bd1d-c416a3b1bb38?as=iiif" />
+    <div style={{ position: "relative", height: "500px", zIndex: "0" }}>
+      <Viewer iiifContent="https://api.dc.library.northwestern.edu/api/v2/works/8a833741-74a8-40dc-bd1d-c416a3b1bb38?as=iiif" />
+    </div>
   </Tab>
 </Tabs>
 
@@ -123,6 +164,64 @@ The Viewer can also be implemented in Vanilla Javascript by use of a web compone
   </Tab>
 </Tabs>
 
+### React (prefetched Manifest)
+
+In some use cases, applications may wish to prefetch a IIIF Manifest or Collection and pass it as a JSON object to the `Viewer` component. This can be done by passing the JSON object directly to the `iiifContent` prop.
+
+```jsx
+const prefetchedManifestJson = {
+  "@context": "http://iiif.io/api/presentation/3/context.json",
+  id: "https://iiif.io/api/cookbook/recipe/0001-mvm-image/manifest.json",
+  type: "Manifest",
+  label: {
+    en: ["Single Image Example"],
+  },
+  items: [
+    {
+      id: "https://iiif.io/api/cookbook/recipe/0001-mvm-image/canvas/p1",
+      type: "Canvas",
+      height: 1800,
+      width: 1200,
+      items: [
+        {
+          id: "https://iiif.io/api/cookbook/recipe/0001-mvm-image/page/p1/1",
+          type: "AnnotationPage",
+          items: [
+            {
+              id: "https://iiif.io/api/cookbook/recipe/0001-mvm-image/annotation/p0001-image",
+              type: "Annotation",
+              motivation: "painting",
+              body: {
+                id: "http://iiif.io/api/presentation/2.1/example/fixtures/resources/page1-full.png",
+                type: "Image",
+                format: "image/png",
+                height: 1800,
+                width: 1200,
+              },
+              target:
+                "https://iiif.io/api/cookbook/recipe/0001-mvm-image/canvas/p1",
+            },
+          ],
+        },
+      ],
+    },
+  ],
+};
+```
+
+<Tabs items={["Code", "Preview"]}>
+  <Tab>
+    ```jsx
+    <Viewer iiifContent={prefetchedManifestJson} />
+    ```
+  </Tab>
+  <Tab>
+    <div style={{ position: "relative", height: "500px", zIndex: "0" }}>
+      <Viewer iiifContent={prefetchedManifestJson} />
+    </div>
+  </Tab>
+</Tabs>
+
 ### Next.js
 
 Implementation with Next.js requires a [dynamic import](https://nextjs.org/docs/advanced-features/dynamic-import) utilizing `next/dynamic`. This is due to Next's node compilation method creating issue with an `OpenSeadragon` (a dependency of Clover IIIF) assumption of a browser `document` object.
@@ -151,7 +250,7 @@ const MyCustomViewer = () => {
 
 | Prop                             | Type                                                                                                                                             | Required | Default                                  |
 | -------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ | -------- | ---------------------------------------- |
-| `iiifContent`                    | `string`                                                                                                                                         | Yes      |                                          |
+| `iiifContent`                    | `string` as URI, or JSON `object` as `Manifest` or `Collection`                                                                                  | Yes      |                                          |
 | `iiifContentSearchQuery`         | [See Content Search](#content-search)                                                                                                            | No       |                                          |
 | `canvasIdCallback`               | `function`                                                                                                                                       | No       |                                          |
 | `contentStateCallback`           | [See IIIF Content State](#iiif-content-state)                                                                                                    | No       |                                          |

--- a/pages/docs/viewer/_meta.json
+++ b/pages/docs/viewer/_meta.json
@@ -20,5 +20,13 @@
       "sidebar": false
     },
     "title": "Content State"
+  },
+  "prefetched": {
+    "display": "hidden",
+    "theme": {
+      "layout": "full",
+      "sidebar": false
+    },
+    "title": "Prefetched Content"
   }
 }

--- a/pages/docs/viewer/prefetched.mdx
+++ b/pages/docs/viewer/prefetched.mdx
@@ -1,0 +1,153 @@
+import Viewer from "docs/components/DynamicImports/Viewer";
+import CustomManifest from "docs/components/CustomManifest/CustomManifest";
+import CallToAction from "docs/components/CallToAction";
+
+export const prefetchedManifestPres2 = {
+  "@context": "http://iiif.io/api/presentation/2/context.json",
+  "@id": "https://api.artic.edu/api/v1/artworks/89503/manifest.json",
+  "@type": "sc:Manifest",
+  label:
+    'Under the Wave off Kanagawa (Kanagawa oki nami ura), also known as The Great Wave, from the series "Thirty-Six Views of Mount Fuji (Fugaku sanjurokkei)"',
+  description: [
+    {
+      value:
+        "Katsushika Hokusai’s much celebrated series, Thirty-Six Views of Mount Fuji (Fugaku sanjûrokkei), was begun in 1830, when the artist was 70 years old. This tour-de-force series established the popularity of landscape prints, which continues to this day. Perhaps most striking about the series is Hokusai’s copious use of the newly affordable Berlin blue pigment, featured in many of the compositions in the color for the sky and water. Mount Fuji is the protagonist in each scene, viewed from afar or up close, during various weather conditions and seasons, and from all directions.\nThe most famous image from the set is the &quot;Great Wave&quot; (Kanagawa oki nami ura), in which a diminutive Mount Fuji can be seen in the distance under the crest of a giant wave. The three impressions of Hokusai’s Great Wave in the Art Institute are all later impressions than the first state of the design.\n",
+      language: "en",
+    },
+  ],
+  metadata: [
+    {
+      label: "Artist / Maker",
+      value: "Katsushika Hokusai 葛飾 北斎\nJapanese, 1760-1849",
+    },
+    {
+      label: "Medium",
+      value: "Color woodblock print; oban",
+    },
+  ],
+  sequences: [
+    {
+      "@type": "sc:Sequence",
+      canvases: [
+        {
+          "@type": "sc:Canvas",
+          "@id":
+            "https://www.artic.edu/iiif/2/2fa24f36-cc26-41b6-4b49-12bba2a6c1c8",
+          label:
+            'Under the Wave off Kanagawa (Kanagawa oki nami ura), also known as The Great Wave, from the series "Thirty-Six Views of Mount Fuji (Fugaku sanjurokkei)", 1830/33. Katsushika Hokusai 葛飾 北斎, Japanese, 1760-1849',
+          width: 843,
+          height: 583,
+          images: [
+            {
+              "@type": "oa:Annotation",
+              motivation: "sc:painting",
+              on: "https://www.artic.edu/iiif/2/2fa24f36-cc26-41b6-4b49-12bba2a6c1c8",
+              resource: {
+                "@type": "dctypes:Image",
+                "@id":
+                  "https://www.artic.edu/iiif/2/2fa24f36-cc26-41b6-4b49-12bba2a6c1c8/full/843,/0/default.jpg",
+                width: 843,
+                height: 583,
+                service: {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id":
+                    "https://www.artic.edu/iiif/2/2fa24f36-cc26-41b6-4b49-12bba2a6c1c8",
+                  profile: "http://iiif.io/api/image/2/level2.json",
+                },
+              },
+            },
+          ],
+        },
+      ],
+    },
+  ],
+};
+
+export const prefetchedManifest = {
+  "@context": "http://iiif.io/api/presentation/3/context.json",
+  id: "https://iiif.io/api/cookbook/recipe/0001-mvm-image/manifest.json",
+  type: "Manifest",
+  label: {
+    en: ["Single Image Example"],
+  },
+  items: [
+    {
+      id: "https://iiif.io/api/cookbook/recipe/0001-mvm-image/canvas/p1",
+      type: "Canvas",
+      height: 1800,
+      width: 1200,
+      items: [
+        {
+          id: "https://iiif.io/api/cookbook/recipe/0001-mvm-image/page/p1/1",
+          type: "AnnotationPage",
+          items: [
+            {
+              id: "https://iiif.io/api/cookbook/recipe/0001-mvm-image/annotation/p0001-image",
+              type: "Annotation",
+              motivation: "painting",
+              body: {
+                id: "http://iiif.io/api/presentation/2.1/example/fixtures/resources/page1-full.png",
+                type: "Image",
+                format: "image/png",
+                height: 1800,
+                width: 1200,
+              },
+              target:
+                "https://iiif.io/api/cookbook/recipe/0001-mvm-image/canvas/p1",
+            },
+          ],
+        },
+      ],
+    },
+  ],
+};
+
+export const prefetchedCollection = {
+  "@context": "http://iiif.io/api/presentation/3/context.json",
+  id: "https://iiif.io/api/cookbook/recipe/0032-collection/collection.json",
+  type: "Collection",
+  label: {
+    en: ["Simple Collection Example"],
+  },
+  items: [
+    {
+      id: "https://iiif.io/api/cookbook/recipe/0032-collection/manifest-01.json",
+      type: "Manifest",
+      label: {
+        en: ["The Gulf Stream"],
+      },
+    },
+    {
+      id: "https://iiif.io/api/cookbook/recipe/0032-collection/manifest-02.json",
+      type: "Manifest",
+      label: {
+        en: ["Northeaster"],
+      },
+    },
+  ],
+};
+
+## Viewer (Prefetched Content)
+
+<br />
+
+<CallToAction href="/docs/viewer" text="Docs" size="small" />
+
+<CustomManifest placeholder="IIIF Manifest or Collection" />
+
+A UI component that renders a multicanvas IIIF item viewer with pan-zoom support for `Image` via [OpenSeadragon](https://openseadragon.github.io/) and `Video` and `Sound` content resources using the [HTML video element](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/video).
+
+---
+
+<Viewer
+  iiifContent={prefetchedManifest}
+  options={{
+    canvasHeight: "640px",
+    openSeadragon: {
+      gestureSettingsMouse: {
+        scrollToZoom: false,
+      },
+    },
+    showIIIFBadge: false,
+  }}
+/>

--- a/src/components/Viewer/index.tsx
+++ b/src/components/Viewer/index.tsx
@@ -37,7 +37,7 @@ export interface CloverViewerProps {
   customDisplays?: Array<CustomDisplay>;
   plugins?: Array<PluginConfig>;
   customTheme?: any;
-  iiifContent: string;
+  iiifContent: string | object;
   id?: string;
   manifestId?: string;
   options?: ViewerConfigOptions;
@@ -123,7 +123,7 @@ const RenderViewer: React.FC<CloverViewerProps> = ({
     visibleCanvases,
   } = store;
   const [iiifResource, setIiifResource] = useState<
-    CollectionNormalized | ManifestNormalized | AnnotationNormalized
+    CollectionNormalized | ManifestNormalized | AnnotationNormalized | undefined
   >();
   const [manifest, setManifest] = useState<ManifestNormalized>();
 
@@ -240,7 +240,10 @@ const RenderViewer: React.FC<CloverViewerProps> = ({
           | ManifestNormalized
           | CollectionNormalized
           | AnnotationNormalized
-          | undefined = await vault.load(contentState);
+          | undefined =
+          typeof contentState === "object" && contentState?.id
+            ? await vault.loadSync(contentState?.id, contentState)
+            : await vault.load(contentState);
         setIiifResource(data);
       } catch (error) {
         if (!contentState || !contentState.id)

--- a/src/lib/iiif.test.ts
+++ b/src/lib/iiif.test.ts
@@ -1,6 +1,12 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 
-import { decodeContentStateContainerURI, getActiveCanvas } from "src/lib/iiif";
+import {
+  decodeContentStateContainerURI,
+  getActiveCanvas,
+  getContextAsArray,
+  parseIiifContent,
+  upgradeIiifContent,
+} from "src/lib/iiif";
 
 import { ManifestNormalized } from "@iiif/presentation-3";
 import { encodeContentState } from "@iiif/helpers";
@@ -79,7 +85,69 @@ const emptyPartOfContentState2 = encodeContentState(
   }),
 );
 
+const pseudoManifestPres2 = {
+  "@context": "http://iiif.io/api/presentation/2/context.json",
+  "@id": "https://api.artic.edu/api/v1/artworks/89503/manifest.json",
+  "@type": "sc:Manifest",
+  label:
+    'Under the Wave off Kanagawa (Kanagawa oki nami ura), also known as The Great Wave, from the series "Thirty-Six Views of Mount Fuji (Fugaku sanjurokkei)"',
+  description: [
+    {
+      value:
+        "Katsushika Hokusai’s much celebrated series, Thirty-Six Views of Mount Fuji (Fugaku sanjûrokkei), was begun in 1830, when the artist was 70 years old. This tour-de-force series established the popularity of landscape prints, which continues to this day. Perhaps most striking about the series is Hokusai’s copious use of the newly affordable Berlin blue pigment, featured in many of the compositions in the color for the sky and water. Mount Fuji is the protagonist in each scene, viewed from afar or up close, during various weather conditions and seasons, and from all directions.\nThe most famous image from the set is the &quot;Great Wave&quot; (Kanagawa oki nami ura), in which a diminutive Mount Fuji can be seen in the distance under the crest of a giant wave. The three impressions of Hokusai’s Great Wave in the Art Institute are all later impressions than the first state of the design.\n",
+      language: "en",
+    },
+  ],
+  metadata: [
+    {
+      label: "Artist / Maker",
+      value: "Katsushika Hokusai 葛飾 北斎\nJapanese, 1760-1849",
+    },
+    {
+      label: "Medium",
+      value: "Color woodblock print; oban",
+    },
+  ],
+  sequences: [
+    {
+      "@type": "sc:Sequence",
+      canvases: [
+        {
+          "@type": "sc:Canvas",
+          "@id":
+            "https://www.artic.edu/iiif/2/2fa24f36-cc26-41b6-4b49-12bba2a6c1c8",
+          label:
+            'Under the Wave off Kanagawa (Kanagawa oki nami ura), also known as The Great Wave, from the series "Thirty-Six Views of Mount Fuji (Fugaku sanjurokkei)", 1830/33. Katsushika Hokusai 葛飾 北斎, Japanese, 1760-1849',
+          width: 843,
+          height: 583,
+          images: [
+            {
+              "@type": "oa:Annotation",
+              motivation: "sc:painting",
+              on: "https://www.artic.edu/iiif/2/2fa24f36-cc26-41b6-4b49-12bba2a6c1c8",
+              resource: {
+                "@type": "dctypes:Image",
+                "@id":
+                  "https://www.artic.edu/iiif/2/2fa24f36-cc26-41b6-4b49-12bba2a6c1c8/full/843,/0/default.jpg",
+                width: 843,
+                height: 583,
+                service: {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id":
+                    "https://www.artic.edu/iiif/2/2fa24f36-cc26-41b6-4b49-12bba2a6c1c8",
+                  profile: "http://iiif.io/api/image/2/level2.json",
+                },
+              },
+            },
+          ],
+        },
+      ],
+    },
+  ],
+};
+
 const pseudoManifest = {
+  "@context": "http://iiif.io/api/presentation/3/context.json",
   id: manifest1,
   type: "Manifest",
   items: [
@@ -104,6 +172,13 @@ const badCanvasId = encodeContentState(
   }),
 );
 
+const invalidManifestJson = {
+  dog: true,
+  breed: "Pug",
+  name: "Nina",
+  age: 16,
+};
+
 const pseudoCollection = {
   id: collection2,
   type: "Collection",
@@ -127,6 +202,74 @@ const badManifestId = encodeContentState(
   }),
 );
 
+test("getContextArray organizes context as arrays", () => {
+  const context = getContextAsArray(pseudoManifest);
+  expect(context).toStrictEqual([
+    "https://iiif.io/api/presentation/3/context.json",
+  ]);
+});
+
+test("upgradeIiifContent converts presentation2 manifest to presentation3", () => {
+  const upgradedManifest = upgradeIiifContent(pseudoManifestPres2);
+  expect(upgradedManifest["@context"]).toBe(
+    "http://iiif.io/api/presentation/3/context.json",
+  );
+  expect(upgradedManifest.id).toBe(
+    "https://api.artic.edu/api/v1/artworks/89503/manifest.json",
+  );
+  expect(upgradedManifest.type).toBe("Manifest");
+  expect(upgradedManifest.label.none[0]).toBe(
+    'Under the Wave off Kanagawa (Kanagawa oki nami ura), also known as The Great Wave, from the series "Thirty-Six Views of Mount Fuji (Fugaku sanjurokkei)"',
+  );
+  expect(upgradedManifest.items[0].id).toBe(
+    "https://www.artic.edu/iiif/2/2fa24f36-cc26-41b6-4b49-12bba2a6c1c8",
+  );
+});
+
+test("logs a TypeError warning for invalid context on upgrade", () => {
+  const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+  upgradeIiifContent(invalidManifestJson);
+
+  expect(warnSpy).toHaveBeenCalledWith(expect.any(TypeError));
+  expect(warnSpy.mock.calls[0][0].message).toMatch(
+    /The IIIF content may not be a valid IIIF resource/,
+  );
+
+  warnSpy.mockRestore();
+});
+
+test("parseIiifContent parses iiifContent and returns object if JSON is provided", () => {
+  const parsed = parseIiifContent(pseudoManifest);
+  expect(parsed.resourceId).toBe(
+    "https://api.dc.library.northwestern.edu/api/v2/works/71153379-4283-43be-8b0f-4e7e3bfda275?as=iiif",
+  );
+  expect(parsed.resourceObject).toStrictEqual(pseudoManifest);
+});
+
+test("parseIiifContent parses iiifContent and returns object if URI is provided", () => {
+  const parsed = parseIiifContent(pseudoManifest.id);
+  expect(parsed.resourceId).toBe(pseudoManifest.id);
+  expect(parsed?.resourceObject).not.toBeDefined();
+});
+
+test("parseIiifContent parses iiifContent for base64 encoded content state", () => {
+  const parsed = parseIiifContent(canvasContentState);
+  expect(parsed.active.canvas).toBe(canvas1);
+  expect(parsed.active.manifest).toBe(manifest1);
+  expect(parsed.resourceId).not.toBeDefined();
+  expect(parsed.resourceObject).toStrictEqual({
+    id: canvas1,
+    type: "Canvas",
+    partOf: [
+      {
+        id: manifest1,
+        type: "Manifest",
+      },
+    ],
+  });
+});
+
 test("iiifContent as Manifest URI", () => {
   const containerURI = decodeContentStateContainerURI(manifestURI);
   expect(containerURI).toBe(manifest1);
@@ -138,6 +281,7 @@ test("iiifContent as Collection URI", () => {
 });
 
 test("getActiveCanvas validates Canvas exists in Manifest", () => {
+  // @ts-ignore
   const canvasId = getActiveCanvas(pseudoManifest as ManifestNormalized);
   expect(canvasId).toBe(canvas1);
 });


### PR DESCRIPTION
## What does this do?

This work adds the ability for the `iiifContent` prop to accept IIIF Manifests and Collections as JSON objects. In some use cases applications may already have these resources ready to feed to a viewer and do not want to make additional requests on the the `id`. This work accounts for manual upgrading of Presentation 2.x resources to 3.0 if required. It then sideloads the resource into `vault`. 

## How should we review?

If spinning up a Clover locally, navigate to the hidden page of http://localhost:3000/docs/viewer/prefetched. On this page, a resource will be loading. Note that no additional XHR request is made on the Manifest.