### PR TITLE
fix(viewer): keep captions #357 dropped, and cover the track branch

### DIFF
--- a/src/components/Viewer/Player/Player.test.tsx
+++ b/src/components/Viewer/Player/Player.test.tsx
@@ -195,4 +195,176 @@ describe("Player component", () => {
     // Test for the audio visualizer
     expect(screen.getByRole("presentation")).toBeInTheDocument();
   });
+
+  /* The `<track>` branch had no coverage: every existing test passes
+     `annotationResources: []`, so none of them reach it. These render a video
+     canvas whose AnnotationPage carries a mix of bodies and assert which ones
+     become tracks. */
+  describe("caption tracks", () => {
+    const CANVAS = "https://example.org/canvas/1";
+
+    function renderWithBodies(bodies: any[]) {
+      const painting = {
+        id: "https://example.org/video.mp4",
+        type: "Video",
+        format: "video/mp4",
+        height: 720,
+        width: 1280,
+        duration: 27,
+      };
+
+      const annotationResources = [
+        {
+          id: "https://example.org/canvas/1/annotations/1",
+          type: "AnnotationPage",
+          items: [
+            {
+              id: "https://example.org/annotation/1",
+              type: "Annotation",
+              motivation: ["supplementing"],
+              body: bodies,
+              target: CANVAS,
+            },
+          ],
+        },
+      ];
+
+      const vault = new Vault();
+      vault.loadSync("", {
+        "@context": "http://iiif.io/api/presentation/3/context.json",
+        id: "https://example.org/manifest.json",
+        type: "Manifest",
+        label: { none: ["Captions"] },
+        items: [
+          {
+            id: CANVAS,
+            type: "Canvas",
+            height: 720,
+            width: 1280,
+            duration: 27,
+            items: [
+              {
+                id: "https://example.org/canvas/1/page/1",
+                type: "AnnotationPage",
+                items: [
+                  {
+                    id: "https://example.org/canvas/1/page/1/annotation/1",
+                    type: "Annotation",
+                    motivation: "painting",
+                    body: painting,
+                    target: CANVAS,
+                  },
+                ],
+              },
+            ],
+            annotations: annotationResources,
+          },
+        ],
+      } as any);
+
+      const { container } = render(
+        <ViewerProvider
+          initialState={{
+            ...defaultState,
+            activeCanvas: CANVAS,
+            activeManifest: "https://example.org/manifest.json",
+            vault,
+          }}
+        >
+          <Player
+            allSources={[painting] as LabeledIIIFExternalWebResource[]}
+            painting={painting as LabeledIIIFExternalWebResource}
+            annotationResources={annotationResources as AnnotationResources}
+          />
+        </ViewerProvider>,
+      );
+
+      return Array.from(container.querySelectorAll("track")).map((t) =>
+        t.getAttribute("src"),
+      );
+    }
+
+    it("renders a track for a WebVTT resource", () => {
+      expect(
+        renderWithBodies([
+          {
+            id: "https://example.org/captions.vtt",
+            type: "Text",
+            format: "text/vtt",
+            label: { none: ["English"] },
+          },
+        ]),
+      ).toEqual(["https://example.org/captions.vtt"]);
+    });
+
+    it("renders a track when the format carries a charset", () => {
+      expect(
+        renderWithBodies([
+          {
+            id: "https://example.org/captions",
+            type: "Text",
+            format: "text/vtt; charset=utf-8",
+            label: { none: ["English"] },
+          },
+        ]),
+      ).toEqual(["https://example.org/captions"]);
+    });
+
+    /* The bug this filter exists for: an embedded body has no dereferenceable
+       id, so the browser was asked to fetch `vault://<hash>` as a subtitle
+       file. Two bodies with the same text share a hash, which also collided
+       as a React key. */
+    it("renders no track for embedded textual bodies", () => {
+      expect(
+        renderWithBodies([
+          {
+            type: "TextualBody",
+            purpose: "describing",
+            value: "A title card on a black ground.",
+            language: "en",
+          },
+          {
+            type: "TextualBody",
+            purpose: "classifying",
+            value: "title card",
+            language: "en",
+          },
+        ]),
+      ).toEqual([]);
+    });
+
+    /* Wellcome Collection publishes a PDF transcript as a supplementing body
+       on a video canvas. */
+    it("renders no track for a PDF transcript", () => {
+      expect(
+        renderWithBodies([
+          {
+            id: "https://example.org/transcript.pdf",
+            type: "Text",
+            format: "application/pdf",
+            label: { none: ["PDF Transcript"] },
+          },
+        ]),
+      ).toEqual([]);
+    });
+
+    it("keeps the caption and drops the rest when they are mixed", () => {
+      expect(
+        renderWithBodies([
+          { type: "TextualBody", value: "A note", language: "en" },
+          {
+            id: "https://example.org/captions.vtt",
+            type: "Text",
+            format: "text/vtt",
+            label: { none: ["English"] },
+          },
+          {
+            id: "https://example.org/transcript.pdf",
+            type: "Text",
+            format: "application/pdf",
+          },
+        ]),
+      ).toEqual(["https://example.org/captions.vtt"]);
+    });
+  });
 });

--- a/src/components/Viewer/Player/Player.tsx
+++ b/src/components/Viewer/Player/Player.tsx
@@ -354,12 +354,12 @@ const Player: React.FC<PlayerProps> = ({
               });
             });
 
-            return annotationBodies.map((body, index) => {
+            return annotationBodies.map((body) => {
               return (
                 <Track
                   resource={body}
                   ignoreCaptionLabels={configOptions.ignoreCaptionLabels || []}
-                  key={`${annotationPage.id}-${body.id}-${index}`}
+                  key={`${annotationPage.id}-${body.id}`}
                 />
               );
             });

--- a/src/lib/annotation-helpers.test.ts
+++ b/src/lib/annotation-helpers.test.ts
@@ -243,16 +243,6 @@ describe("isCaptionResource", () => {
     ).toBe(true);
   });
 
-  it("accepts a SubRip resource declared by format", () => {
-    expect(
-      isCaptionResource({
-        id: "https://example.org/captions.srt",
-        type: "Text",
-        format: "application/x-subrip",
-      }),
-    ).toBe(true);
-  });
-
   it("falls back to the file extension when no format is declared", () => {
     expect(isCaptionResource({ id: "https://example.org/c.vtt" })).toBe(true);
     expect(isCaptionResource({ id: "https://example.org/c.vtt?v=2" })).toBe(
@@ -318,17 +308,22 @@ describe("isCaptionResource", () => {
     ).toBe(true);
   });
 
-  it("accepts .srt and its declared formats", () => {
+  /* A `<track>` renders WebVTT and nothing else, so a SubRip body would add a
+     caption menu entry that displays nothing when chosen. Indiana's Avalon
+     publishes SubRip as `supplementing` transcripts, never as captions: in 400
+     of their manifests every `/captions` body is `text/vtt`, while `text/srt`
+     and `application/x-subrip` appear only under `/transcripts`. */
+  it("rejects SubRip, which a track cannot render", () => {
     expect(
       isCaptionResource({ id: "https://example.org/c", format: "text/srt" }),
-    ).toBe(true);
+    ).toBe(false);
     expect(
       isCaptionResource({
         id: "https://example.org/c",
         format: "application/x-subrip",
       }),
-    ).toBe(true);
-    expect(isCaptionResource({ id: "https://example.org/c.srt" })).toBe(true);
+    ).toBe(false);
+    expect(isCaptionResource({ id: "https://example.org/c.srt" })).toBe(false);
   });
 
   /* `format` is a SHOULD, not a MUST. Captions served from an extensionless

--- a/src/lib/annotation-helpers.test.ts
+++ b/src/lib/annotation-helpers.test.ts
@@ -291,4 +291,101 @@ describe("isCaptionResource", () => {
       }),
     ).toBe(false);
   });
+
+  /* The Presentation API says `format` "should be the value of the Content-Type
+     header returned when the resource is dereferenced", and that header
+     routinely carries a charset parameter. Comparing the raw string dropped
+     these captions. */
+  it("accepts a caption format that carries parameters", () => {
+    expect(
+      isCaptionResource({
+        id: "https://example.org/captions",
+        type: "Text",
+        format: "text/vtt; charset=utf-8",
+      }),
+    ).toBe(true);
+    expect(
+      isCaptionResource({
+        id: "https://example.org/captions",
+        format: "TEXT/VTT ; charset=UTF-8",
+      }),
+    ).toBe(true);
+  });
+
+  it("accepts the non-standard text/webvtt published in the wild", () => {
+    expect(
+      isCaptionResource({ id: "https://example.org/c", format: "text/webvtt" }),
+    ).toBe(true);
+  });
+
+  it("accepts .srt and its declared formats", () => {
+    expect(
+      isCaptionResource({ id: "https://example.org/c", format: "text/srt" }),
+    ).toBe(true);
+    expect(
+      isCaptionResource({
+        id: "https://example.org/c",
+        format: "application/x-subrip",
+      }),
+    ).toBe(true);
+    expect(isCaptionResource({ id: "https://example.org/c.srt" })).toBe(true);
+  });
+
+  /* `format` is a SHOULD, not a MUST. Captions served from an extensionless
+     URL are common, so a body without a format is kept when it is
+     dereferenceable — dropping a real caption is worse than keeping a dead
+     menu entry. */
+  it("accepts a dereferenceable resource that declares no format", () => {
+    expect(
+      isCaptionResource({
+        id: "https://example.org/master_files/1/captions",
+        type: "Text",
+      }),
+    ).toBe(true);
+  });
+
+  it("accepts an extension behind a query string or fragment", () => {
+    expect(isCaptionResource({ id: "https://example.org/c.vtt?v=2" })).toBe(true);
+    expect(isCaptionResource({ id: "https://example.org/c.VTT#t=0" })).toBe(true);
+  });
+
+  /* A real case: Wellcome Collection publishes a PDF transcript as a
+     `supplementing` body on a video canvas. The browser was being asked to
+     parse a PDF as WebVTT. */
+  it("rejects a PDF transcript published as a supplementing body", () => {
+    expect(
+      isCaptionResource({
+        id: "https://iiif.wellcomecollection.org/file/b16659090_0001.pdf",
+        type: "Text",
+        format: "application/pdf",
+      }),
+    ).toBe(false);
+  });
+
+  /* The browser rejects a track whose response is not text/vtt, so a body
+     that declares text/plain is not usable even when its URL ends in .vtt. */
+  it("rejects a declared non-caption format even with a caption extension", () => {
+    expect(
+      isCaptionResource({ id: "https://example.org/c.vtt", format: "text/plain" }),
+    ).toBe(false);
+  });
+
+  it("rejects a relative id that declares no format", () => {
+    expect(isCaptionResource({ id: "/local/thing" })).toBe(false);
+  });
+
+  /* A recognisable extension that is not a caption extension settles it, so
+     the extensionless allowance above does not swallow every other file. */
+  it("rejects a non-caption extension when no format is declared", () => {
+    expect(isCaptionResource({ id: "https://example.org/notes.txt" })).toBe(false);
+    expect(isCaptionResource({ id: "https://example.org/t.pdf" })).toBe(false);
+  });
+
+  /* Not handled here: Cookbook recipe 0074 wraps two WebVTT files in a
+     `Choice`, which has no id of its own. It was never rendered before this
+     change either — the Vault-minted id was unfetchable — so this is not a
+     regression, but expanding `Choice.items` would make that recipe work. */
+  it("rejects a Choice, which carries no id a track can fetch", () => {
+    expect(isCaptionResource({ type: "Choice" })).toBe(false);
+  });
 });

--- a/src/lib/annotation-helpers.ts
+++ b/src/lib/annotation-helpers.ts
@@ -271,6 +271,35 @@ export {
  * content-derived `vault://<hash>`. Two bodies with the same text share a hash,
  * which yields duplicate React keys — one warning per collision, per render.
  */
+const CAPTION_FORMATS = new Set([
+  "text/vtt",
+  // Non-standard, but published in the wild.
+  "text/webvtt",
+  "application/x-subrip",
+  "text/srt",
+]);
+
+/**
+ * Is this annotation body a resource a `<track>` element can actually fetch?
+ *
+ * The rule is "reject what we know is not a caption", not "accept only what we
+ * recognise". Dropping a real caption is worse than keeping a dead menu entry,
+ * so anything ambiguous is kept.
+ *
+ * Rejected:
+ *  - bodies with no `id` — embedded, nothing to fetch
+ *  - `vault://<hash>` ids the Vault mints for embedded resources
+ *  - `TextualBody`, whose text is inline
+ *  - a declared `format` that is not a caption format (a PDF transcript
+ *    published as a `supplementing` body, for example)
+ *
+ * `format` is compared with its parameters stripped: the Presentation API says
+ * it "should be the value of the Content-Type header returned when the resource
+ * is dereferenced", and that header routinely carries `; charset=utf-8`.
+ *
+ * `format` is only a SHOULD, so a body without one is kept when its id is
+ * dereferenceable — captions served from an extensionless URL are common.
+ */
 export function isCaptionResource(body?: {
   id?: string;
   type?: string;
@@ -278,15 +307,25 @@ export function isCaptionResource(body?: {
 }): boolean {
   if (!body?.id) return false;
 
+  const id = String(body.id);
+
   // The Vault mints `vault://<hash>` for embedded resources with no id.
-  if (String(body.id).startsWith("vault://")) return false;
+  if (id.startsWith("vault://")) return false;
 
   // Embedded text bodies are not fetchable.
   if (body.type === "TextualBody") return false;
 
-  const format = String(body.format ?? "").toLowerCase();
-  if (format) return format === "text/vtt" || format === "application/x-subrip";
+  const format = String(body.format ?? "")
+    .toLowerCase()
+    .split(";")[0]
+    .trim();
+  if (format) return CAPTION_FORMATS.has(format);
 
-  // No format declared: fall back to the file extension.
-  return /\.(vtt|srt)(\?|#|$)/i.test(String(body.id));
+  // No format declared. A caption extension settles it either way.
+  if (/\.(vtt|srt)(\?|#|$)/i.test(id)) return true;
+  if (/\.[a-z0-9]{2,5}(\?|#|$)/i.test(id)) return false;
+
+  // No format and no extension, so we cannot rule it out. Captions served from
+  // an extensionless URL are common; keep anything the browser can dereference.
+  return /^https?:/i.test(id);
 }

--- a/src/lib/annotation-helpers.ts
+++ b/src/lib/annotation-helpers.ts
@@ -271,12 +271,17 @@ export {
  * content-derived `vault://<hash>`. Two bodies with the same text share a hash,
  * which yields duplicate React keys — one warning per collision, per render.
  */
+/**
+ * A `<track>` renders WebVTT and nothing else — the HTML spec allows no other
+ * format and browsers silently ignore one, so a SubRip body would produce a
+ * caption menu entry that displays nothing when chosen. Publishers do send
+ * SubRip, but as `supplementing` transcripts for a panel to render, not as
+ * captions.
+ */
 const CAPTION_FORMATS = new Set([
   "text/vtt",
-  // Non-standard, but published in the wild.
+  // Non-standard spelling, published in the wild.
   "text/webvtt",
-  "application/x-subrip",
-  "text/srt",
 ]);
 
 /**
@@ -321,8 +326,9 @@ export function isCaptionResource(body?: {
     .trim();
   if (format) return CAPTION_FORMATS.has(format);
 
-  // No format declared. A caption extension settles it either way.
-  if (/\.(vtt|srt)(\?|#|$)/i.test(id)) return true;
+  // No format declared. A .vtt extension settles it; .srt falls through to the
+  // rule below and is rejected, for the reason given above.
+  if (/\.vtt(\?|#|$)/i.test(id)) return true;
   if (/\.[a-z0-9]{2,5}(\?|#|$)/i.test(id)) return false;
 
   // No format and no extension, so we cannot rule it out. Captions served from


### PR DESCRIPTION
Follow-up to #357. I pushed these corrections to that branch a few minutes after it merged, so they missed the merge — opening them here instead. Sorry for the split.

Self-review of #357 found two cases where a caption that used to render stopped rendering. Both are spec-valid manifests, and both are on `main` right now.

## 1. `format: "text/vtt; charset=utf-8"` is dropped

The Presentation API says `format` "should be the value of the Content-Type header returned when the resource is dereferenced", and that header routinely carries a charset parameter. #357 compared the raw string:

```ts
if (format) return format === "text/vtt" || format === "application/x-subrip";
```

So a manifest that follows the spec's own recommendation loses its captions. Parameters are now stripped before comparing.

## 2. A body with no `format` and no file extension is dropped

`format` is a SHOULD, not a MUST. #357 fell back to a `.vtt` / `.srt` extension test, which drops captions served from an extensionless URL — `.../master_files/<id>/captions` and similar are common.

## The shape of the fix

The predicate now rejects what it can show is *not* a caption, rather than accepting only what it recognises. Dropping a real caption is worse than keeping a dead menu entry, so anything ambiguous is kept:

- no `id`, a `vault://` id, or `TextualBody` — rejected, as before
- a declared `format` — accepted only if it is a caption format (`text/vtt`, `text/webvtt`, `text/srt`, `application/x-subrip`)
- no declared `format` — a caption extension accepts, a recognisable non-caption extension rejects, and an extensionless dereferenceable id is kept

That last rule is what restores case 2 without letting every other file type through.

## Also: `index` removed from the React key

#357 keyed tracks as `${annotationPage.id}-${body.id}-${index}`. With the index in the key, inserting a caption ahead of an existing one remounts the rest, and remounting a `<track>` resets `TextTrack.mode` — a viewer's captions silently switch off. The page id and body id identify the track on their own. There is no path in Clover today that reorders that array, so this is defensive.

## Tests

`Player`'s `<track>` branch had no coverage at all: every existing Player test passes `annotationResources: []`, so none of them reached the code #357 changed. Five tests now render a video canvas whose AnnotationPage carries a mix of bodies and assert which ones become tracks — including the embedded-body case the filter exists for, and a PDF transcript published as a `supplementing` body, taken from a real Wellcome Collection manifest (`b16659090`). Ten more cover the predicate's edge cases directly.

363 tests pass (was 348 after #357). Build and the Web Components e2e both pass; I ran all three `pull_request` workflows locally.

## Not addressed

Cookbook recipe **0074 (multiple-language captions)** wraps two WebVTT files in a `Choice`, which has no id of its own, so it is rejected. It was not rendered before #357 either — the Vault-minted id was unfetchable — so this is not a regression, but expanding `Choice.items` would make that recipe work for the first time. Left out to keep this to one thing; happy to open it separately if you'd like it.
