### PR TITLE
Refine full screen mode.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,37 @@ assigned at release time.
 
 ### Changed
 
+- **Full screen keeps the whole viewer.** It used to hand the job to OpenSeadragon's
+  `setFullPage()`, which is not the Fullscreen API: it sets `display: none` on every child of
+  `<body>` except its own canvas element. Everything else Clover draws is a sibling of that
+  element, so the header, the image controls, the thumbnail rail and the information panel all
+  disappeared — the rail only survived because it was portalled to the body on purpose, as a
+  small panel floating in one corner, and the controls could not be portalled at all because
+  OpenSeadragon binds them by element id at init.
+
+  Clover now asks the browser to full-screen its own root instead. Nothing is reparented and
+  nothing is hidden, so the reader keeps the viewer they were already using:
+  - The thumbnail rail is a band across the full width of the bottom, under both the image and
+    the information panel.
+  - The image controls and the information panel toggle stay where they are.
+  - The viewer header is hidden, giving the image the room; its title, IIIF badge and download
+    are a click away in the information panel.
+  - The OpenSeadragon navigator drops below the exit control, which shares its corner.
+  - The full-screen control turns its arrows inward while full screen is active, and renames
+    itself **Exit full screen**, so it reads as where it will take you rather than where you
+    already are.
+  - An **Exit full screen** control sits top left. `Escape` has always worked, but an
+    unadvertised keystroke is not an affordance.
+
+  A standalone `Image` gets the same treatment: it full-screens its own wrapper, offers the
+  same **Exit full screen** control, and drops its navigator clear of it. Only one element is
+  ever full screen, so an `Image` nested in a full-screen `Viewer` stays quiet and the viewer
+  provides the single way back.
+
+  `openSeadragonConfig.showFullPageControl` still decides whether the control appears.
+  A `controlButtons.fullPage` replacement now receives an `onClick` in its `buttonProps` and no
+  longer depends on rendering the id it is given.
+
 - **Thumbnails fade in once their image has loaded**, in the `Viewer`'s canvas rail and the
   `Slider` alike. Coming on screen and the image arriving are two different moments, and a
   tile used to snap from placeholder to photograph at the second one. The fade is 150ms and

--- a/src/components/Image/Controls/Button.tsx
+++ b/src/components/Image/Controls/Button.tsx
@@ -6,9 +6,20 @@ interface ButtonProps {
   id: string;
   label: string;
   children: React.ReactChild;
+  /*
+   * Only the full-screen control passes one. The rest are bound by OpenSeadragon through
+   * their id, which is why this is optional rather than required.
+   */
+  onClick?: React.MouseEventHandler<HTMLButtonElement>;
 }
 
-const Button: React.FC<ButtonProps> = ({ className, id, label, children }) => {
+const Button: React.FC<ButtonProps> = ({
+  className,
+  id,
+  label,
+  children,
+  onClick,
+}) => {
   // Extract button type from id (e.g., "rotateLeft-abc123" → "rotate-left")
   // This ensures data-button is language-independent for CSS selectors
   const buttonType = id.split("-")[0];
@@ -22,6 +33,8 @@ const Button: React.FC<ButtonProps> = ({ className, id, label, children }) => {
       className={className}
       data-testid="openseadragon-button"
       data-button={dataButton}
+      onClick={onClick}
+      type="button"
     >
       <svg
         xmlns="http://www.w3.org/2000/svg"

--- a/src/components/Image/Controls/Controls.test.tsx
+++ b/src/components/Image/Controls/Controls.test.tsx
@@ -81,79 +81,12 @@ describe("Controls component with controlButtons", () => {
     );
   });
 
-  describe("full-page focus restore", () => {
-    const fullPageButtonId = "fullPage-test";
-
-    // Fake OSD viewer exposing just enough of addHandler/removeHandler for
-    // Controls to register its "full-page" listener and for the test to
-    // trigger it directly.
-    const createFakeViewer = () => {
-      const handlers: Record<string, Array<(event: unknown) => void>> = {};
-      return {
-        addHandler: (name: string, handler: (event: unknown) => void) => {
-          handlers[name] = handlers[name] ?? [];
-          handlers[name].push(handler);
-        },
-        removeHandler: (name: string, handler: (event: unknown) => void) => {
-          handlers[name] = (handlers[name] ?? []).filter((h) => h !== handler);
-        },
-        removeAllHandlers: (name: string) => {
-          handlers[name] = [];
-        },
-        trigger: (name: string, event: unknown) => {
-          (handlers[name] ?? []).forEach((handler) => handler(event));
-        },
-        viewport: { getRotation: () => 0 },
-      };
-    };
-
-    it("focuses the full page button when full-page mode exits", () => {
-      const viewer = createFakeViewer();
-      document.body.innerHTML = `<button id="${fullPageButtonId}"></button>`;
-      const button = document.getElementById(fullPageButtonId) as HTMLElement;
-
-      render(
-        <ViewerProvider
-          initialState={{
-            ...defaultState,
-            openSeadragonViewer: viewer as never,
-          }}
-        >
-          <Controls
-            config={{ fullPageButton: fullPageButtonId }}
-            _cloverViewerHasPlaceholder={false}
-          />
-        </ViewerProvider>,
-      );
-
-      viewer.trigger("full-page", { fullPage: false });
-
-      expect(document.activeElement).toBe(button);
-    });
-
-    it("does not move focus when full-page mode is entered", () => {
-      const viewer = createFakeViewer();
-      document.body.innerHTML = `<button id="${fullPageButtonId}"></button>`;
-
-      render(
-        <ViewerProvider
-          initialState={{
-            ...defaultState,
-            openSeadragonViewer: viewer as never,
-          }}
-        >
-          <Controls
-            config={{ fullPageButton: fullPageButtonId }}
-            _cloverViewerHasPlaceholder={false}
-          />
-        </ViewerProvider>,
-      );
-
-      viewer.trigger("full-page", { fullPage: true });
-
-      expect(document.activeElement).not.toBe(
-        document.getElementById(fullPageButtonId),
-      );
-    });
-  });
+  /*
+   * The "full-page focus restore" block is gone with the behaviour it covered.
+   *
+   * It asserted that Clover put focus back on the full-screen button when OpenSeadragon's
+   * `full-page` event reported an exit — necessary only because `setFullPage()` reparented
+   * the viewer out of the DOM and back, dropping focus on the way. Clover full-screens its
+   * own root now, nothing is reparented, focus is never lost, and that event never fires.
+   */
 });

--- a/src/components/Image/Controls/Controls.tsx
+++ b/src/components/Image/Controls/Controls.tsx
@@ -10,6 +10,8 @@ import { CanvasNormalized } from "@iiif/presentation-3";
 import { Options } from "openseadragon";
 import React, { useEffect } from "react";
 import { Wrapper } from "src/components/Image/Controls/Controls.styled";
+import { toggleFullscreen } from "src/lib/fullscreen";
+import useWithinFullscreen from "src/hooks/useWithinFullscreen";
 import { useCloverTranslation } from "src/i18n/useCloverTranslation";
 
 const ZoomIn = () => {
@@ -43,6 +45,25 @@ const ZoomFullScreen = () => {
       strokeLinejoin="round"
       strokeWidth="32"
       d="M432 320v112H320M421.8 421.77L304 304M80 192V80h112M90.2 90.23L208 208M320 80h112v112M421.77 90.2L304 208M192 432H80V320M90.23 421.8L208 304"
+    />
+  );
+};
+
+/**
+ * The same four corners, arrows turned inward.
+ *
+ * Shown in place of the expand glyph while full screen is active, so the control reads as
+ * where it will take you rather than where you already are.
+ */
+const ZoomExitFullScreen = () => {
+  return (
+    <path
+      fill="none"
+      stroke="currentColor"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      strokeWidth="32"
+      d="M304 416v-112h112M405.77 405.77L304 304M208 96v112H96M106.23 106.23L208 208M416 208H304V96M405.77 106.23L304 208M96 304h112v112M106.23 405.77L208 304"
     />
   );
 };
@@ -103,6 +124,17 @@ const Controls = ({
   config: Options;
 }) => {
   const { t } = useCloverTranslation();
+
+  /*
+   * Whether these controls are inside whatever is full screen.
+   *
+   * Containment rather than identity, because the control cannot know which root the browser
+   * put in full screen: the `Viewer`'s when nested, the `Image`'s own wrapper when standalone.
+   */
+  const [controlsElement, setControlsElement] =
+    React.useState<HTMLDivElement | null>(null);
+  const isFullscreen = useWithinFullscreen(controlsElement);
+
   const viewerState: ViewerContextStore = useViewerState();
   const {
     activeCanvas,
@@ -127,22 +159,35 @@ const Controls = ({
     id: string,
     label: string,
     glyph: React.ReactElement,
+    onClick?: React.MouseEventHandler<HTMLButtonElement>,
   ) {
     const Custom = configOptions.controlButtons?.[key];
     if (Custom)
       return (
         <Custom
-          buttonProps={{ id, type: "button", "aria-label": label }}
+          buttonProps={{ id, type: "button", "aria-label": label, onClick }}
           icon={<ControlIcon label={label}>{glyph}</ControlIcon>}
           label={label}
         />
       );
     return (
-      <Button id={id} label={label}>
+      <Button id={id} label={label} onClick={onClick}>
         {glyph}
       </Button>
     );
   }
+
+  /*
+   * Full screen is Clover's, not OpenSeadragon's.
+   *
+   * Called straight from the click rather than routed through state: the Fullscreen API only
+   * honours a request made inside a user gesture, and a dispatch followed by an effect can
+   * land outside it. The root is found from the button itself, so the same control serves a
+   * standalone `Image` and one nested in a `Viewer` without either being told which it is.
+   */
+  const handleFullscreen: React.MouseEventHandler<HTMLButtonElement> = (
+    event,
+  ) => void toggleFullscreen(event.currentTarget);
 
   const canvas = vault.get({
     id: activeCanvas,
@@ -209,29 +254,19 @@ const Controls = ({
   }, [openSeadragonViewer]);
 
   /*
-   * OpenSeadragon moves the viewer in and out of the DOM to go full page, which
-   * drops focus. Without this a keyboard user is returned to the top of the
-   * document and has to tab back to the controls.
+   * Nothing to restore focus for any more.
+   *
+   * This listened for OpenSeadragon's `full-page` event and put focus back on the button,
+   * because OpenSeadragon moved the viewer out of the DOM and back, dropping focus on the
+   * way. Clover full-screens its own root now: no element is reparented, so focus stays
+   * where the reader left it and the event never fires.
    */
-  useEffect(() => {
-    if (!openSeadragonViewer) return;
-
-    // "full-page" fires on both entering and exiting full page mode, with
-    // fullPage true on entry. Only restore focus on exit, when OSD has just
-    // moved the viewer back into its original place in the DOM.
-    const restoreFocus = ({ fullPage }: { fullPage: boolean }) => {
-      if (fullPage) return;
-      const button = document.getElementById(config.fullPageButton as string);
-      if (button) button.focus();
-    };
-
-    openSeadragonViewer.addHandler("full-page", restoreFocus);
-    return () => openSeadragonViewer.removeHandler("full-page", restoreFocus);
-  }, [openSeadragonViewer, config.fullPageButton]);
 
   return (
     <Wrapper
+      data-fullscreen={isFullscreen}
       data-testid="clover-iiif-image-openseadragon-controls"
+      ref={setControlsElement}
       hasPlaceholder={_cloverViewerHasPlaceholder}
       hasInformationToggle={hasInformationToggle}
       panelOpen={isInformationOpen}
@@ -256,8 +291,9 @@ const Controls = ({
         renderControl(
           "fullPage",
           config.fullPageButton as string,
-          t("imageFullScreen"),
-          <ZoomFullScreen />,
+          isFullscreen ? t("imageExitFullScreen") : t("imageFullScreen"),
+          isFullscreen ? <ZoomExitFullScreen /> : <ZoomFullScreen />,
+          handleFullscreen,
         )}
       {config.showRotationControl && (
         <>

--- a/src/components/Image/Image.styled.tsx
+++ b/src/components/Image/Image.styled.tsx
@@ -1,3 +1,4 @@
+import { ExitFullscreenStyled } from "src/components/Shared/Fullscreen/ExitFullscreen";
 import { styled } from "src/styles/stitches.config";
 import { themeVarBridge } from "src/styles/tokens";
 
@@ -158,6 +159,35 @@ const Wrapper = styled("div", {
   position: "relative",
   zIndex: "0",
   overflow: "hidden",
+
+  /*
+   * Full screen, for an `Image` used on its own.
+   *
+   * The wrapper is already `100%` of whatever contains it, so full screen mostly takes care
+   * of itself — what is needed is the way out, and room for it. The navigator shares the
+   * top-left corner, so it drops below the exit control exactly as it does in the `Viewer`.
+   *
+   * None of this applies to an `Image` inside a `Viewer`: only one element is ever full
+   * screen, and there it is the viewer's root, so this wrapper's attribute stays `false`.
+   */
+  "&[data-fullscreen='true']": {
+    backgroundColor: "$secondary",
+
+    /*
+     * Direct child only.
+     *
+     * A descendant selector here also matched the exit control belonging to a nested `Image`,
+     * so a full-screen `Viewer` showed two of them. Each host reveals its own and no one
+     * else's.
+     */
+    [`& > ${ExitFullscreenStyled}`]: {
+      display: "flex",
+    },
+
+    [`& ${Navigator}`]: {
+      top: "4.5rem",
+    },
+  },
 
   variants: {
     hasNavigator: {

--- a/src/components/Image/OSD/OSD.tsx
+++ b/src/components/Image/OSD/OSD.tsx
@@ -7,9 +7,11 @@ import {
 } from "src/components/Image/Image.styled";
 import OpenSeadragon, { Options, Overlay } from "openseadragon";
 import React, { useEffect, useRef, useState } from "react";
+import useFullscreen from "src/hooks/useFullscreen";
 
 import { Annotation } from "@iiif/presentation-3";
 import Controls from "src/components/Image/Controls/Controls";
+import ExitFullscreen from "src/components/Shared/Fullscreen/ExitFullscreen";
 import { OpenSeadragonImageTypes } from "src/types/open-seadragon";
 import { getInfoResponse } from "src/lib/iiif";
 import { parseAnnotationTarget } from "src/lib";
@@ -75,6 +77,18 @@ const OSD: React.FC<OSDProps> = ({
 
   const annotationClassName = "clover-iiif-image-openseadragon-annotation";
 
+  /*
+   * Whether this wrapper is the element in full screen.
+   *
+   * False whenever a `Viewer` is the one full screen: the browser has only one full-screen
+   * element, and there it is the viewer's root. That is what keeps a nested `Image` from
+   * offering a second, redundant way out.
+   */
+  const [wrapperElement, setWrapperElement] = useState<HTMLDivElement | null>(
+    null,
+  );
+  const isFullscreen = useFullscreen(wrapperElement);
+
   /**
    * check the OSD config for scrollToZoom setting
    */
@@ -85,7 +99,22 @@ const OSD: React.FC<OSDProps> = ({
   useEffect(() => {
     if (!initializeOSD.current) {
       initializeOSD.current = true;
-      if (!openSeadragon) setOpenSeadragon(OpenSeadragon(config));
+      if (!openSeadragon)
+        setOpenSeadragon(
+          OpenSeadragon({
+            ...config,
+            /*
+             * Never let OpenSeadragon own the full-screen button.
+             *
+             * Given the id it binds its own `setFullPage()`, which hides every other child
+             * of `<body>` — taking Clover's header, controls, thumbnail rail and information
+             * panel with it. Clover renders the button itself and full-screens its own root
+             * instead; `config.showFullPageControl` still decides whether that button
+             * appears. See `src/lib/fullscreen.ts`.
+             */
+            showFullPageControl: false,
+          }),
+        );
     }
     return () => openSeadragon?.destroy();
   }, []);
@@ -558,9 +587,16 @@ const OSD: React.FC<OSDProps> = ({
     <Wrapper
       className="clover-iiif-image-openseadragon"
       data-testid="clover-iiif-image-openseadragon"
+      data-fullscreen={isFullscreen}
       data-openseadragon-instance={config.id}
       hasNavigator={config.showNavigator}
+      ref={setWrapperElement}
     >
+      {/*
+       * Shown by CSS only while this wrapper is the full-screen element — see the
+       * `[data-fullscreen]` block in Image.styled. A `Viewer` renders its own.
+       */}
+      <ExitFullscreen />
       <Controls
         _cloverViewerHasPlaceholder={_cloverViewerHasPlaceholder}
         config={config}

--- a/src/components/Image/OSD/defaults.ts
+++ b/src/components/Image/OSD/defaults.ts
@@ -26,6 +26,10 @@ function defaultOpenSeadragonConfiguration(
     zoomInButton: `zoomIn-${openSeadragonInstance}`,
     zoomOutButton: `zoomOut-${openSeadragonInstance}`,
     showNavigator: true,
+    /*
+     * Whether Clover renders a full-screen control, not whether OpenSeadragon binds one.
+     * `OSD.tsx` hands OpenSeadragon `false` regardless — see the comment there.
+     */
     showFullPageControl: true,
     showHomeControl: true,
     showRotationControl: true,

--- a/src/components/Shared/Fullscreen/ExitFullscreen.tsx
+++ b/src/components/Shared/Fullscreen/ExitFullscreen.tsx
@@ -1,0 +1,79 @@
+import React from "react";
+import { styled } from "src/styles/stitches.config";
+import { toggleFullscreen } from "src/lib/fullscreen";
+import { useCloverTranslation } from "src/i18n/useCloverTranslation";
+
+/**
+ * The way out of full screen, for whichever Clover root is in it.
+ *
+ * Hidden by default and revealed by the host: the `Viewer` shows it when its own root is full
+ * screen, and a standalone `Image` when its wrapper is. Keeping the rule with the host is what
+ * lets an `Image` nested inside a full-screen `Viewer` stay quiet — only one root is ever full
+ * screen, and only that one should offer a way back.
+ *
+ * `Escape` exits too. This exists because an unadvertised keystroke is not an affordance: a
+ * reader who entered by clicking looks for something to click.
+ */
+const ExitFullscreenStyled = styled("button", {
+  display: "none",
+  position: "absolute",
+  top: "1rem",
+  left: "1rem",
+  zIndex: "3",
+
+  alignItems: "center",
+  gap: "0.5rem",
+  height: "2.5rem",
+  padding: "0 1rem 0 0.75rem",
+  border: "none",
+  borderRadius: "2rem",
+  backgroundColor: "$secondary",
+  color: "$primary",
+  fontFamily: "inherit",
+  fontSize: "0.8333rem",
+  fontWeight: "700",
+  lineHeight: "1",
+  whiteSpace: "nowrap",
+  cursor: "pointer",
+  transition: "$all",
+
+  svg: {
+    height: "1.25rem",
+    width: "1.25rem",
+    flexShrink: 0,
+  },
+
+  "&:hover, &:focus-visible": {
+    backgroundColor: "$accent",
+    color: "$secondary",
+  },
+});
+
+const ExitFullscreen: React.FC = () => {
+  const { t } = useCloverTranslation();
+  const label = t("imageExitFullScreen");
+
+  return (
+    <ExitFullscreenStyled
+      aria-label={label}
+      className="clover-exit-full-screen"
+      onClick={(event) => void toggleFullscreen(event.currentTarget)}
+      type="button"
+    >
+      <svg viewBox="0 0 512 512" aria-hidden="true" focusable="false">
+        <path
+          fill="none"
+          stroke="currentColor"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          strokeWidth="45"
+          d="M244 400L100 256l144-144M120 256h292"
+        />
+      </svg>
+      {label}
+    </ExitFullscreenStyled>
+  );
+};
+
+export { ExitFullscreenStyled };
+export default ExitFullscreen;

--- a/src/components/Viewer/Viewer/Content.tsx
+++ b/src/components/Viewer/Viewer/Content.tsx
@@ -18,13 +18,14 @@ import { Icon } from "src/components/UI";
 import InformationPanel from "src/components/Viewer/InformationPanel/InformationPanel";
 import Media from "src/components/Viewer/Media/Media";
 import Painting from "../Painting/Painting";
-import React, { useEffect, useRef, useState } from "react";
-import { createPortal } from "react-dom";
+import React, { useRef, useState } from "react";
 import { useViewerDispatch, useViewerState } from "src/context/viewer-context";
 import { useCloverTranslation } from "src/i18n/useCloverTranslation";
 
 export interface ViewerContentProps {
   activeCanvas: string;
+  /** Full screen moves the thumbnail rail out from beside the information panel. */
+  isFullscreen?: boolean;
   annotationResources: AnnotationResources;
   searchServiceUrl?: string;
   setContentSearchResource: React.Dispatch<
@@ -40,6 +41,7 @@ export interface ViewerContentProps {
 
 const ViewerContent: React.FC<ViewerContentProps> = ({
   activeCanvas,
+  isFullscreen = false,
   annotationResources,
   searchServiceUrl,
   setContentSearchResource,
@@ -54,7 +56,6 @@ const ViewerContent: React.FC<ViewerContentProps> = ({
     contentStateAnnotation,
     isInformationOpen,
     configOptions,
-    openSeadragonViewer,
     sequence,
     visibleCanvases,
   } = useViewerState();
@@ -63,62 +64,15 @@ const ViewerContent: React.FC<ViewerContentProps> = ({
   const { t } = useCloverTranslation();
 
   /*
-   * Whether OpenSeadragon has taken over the window.
+   * No full-page tracking here any more.
    *
-   * Going full page is not a CSS change — OpenSeadragon sets `display: none` on every
-   * direct child of `<body>` except its own element, then reparents that element to
-   * `<body>`. The thumbnail strip lives inside the tree that just got hidden, so it
-   * disappears along with the rest of the page. Tracking the state lets us re-home the
-   * strip somewhere that survives (see the portal below).
-   *
-   * `full-page` fires for both directions, carrying `fullPage`.
+   * This used to watch OpenSeadragon's `full-page` event, hold the reader's intent in a ref
+   * so a rebuilt viewer could re-enter, and portal the thumbnail rail to `<body>` so it
+   * survived — all of it working around `setFullPage()` hiding every other child of the
+   * body. Clover full-screens its own root instead, so the rail (and the header, the
+   * controls, the information panel) never leaves the tree and there is nothing to track.
+   * See `src/lib/fullscreen.ts`.
    */
-  const [isFullPage, setIsFullPage] = useState(false);
-  /*
-   * The reader's *intent*, held separately from the observed state.
-   *
-   * Painting keys its OpenSeadragon instance on the active canvas, so selecting a
-   * thumbnail tears the viewer down and builds a new one that has never been full page.
-   * Without remembering the intent, navigating would silently drop the reader back to
-   * the inline layout — the strip would work exactly once.
-   */
-  const wantsFullPage = useRef(false);
-
-  useEffect(() => {
-    if (!openSeadragonViewer) return;
-
-    const handleFullPage = ({ fullPage }: { fullPage: boolean }) => {
-      wantsFullPage.current = Boolean(fullPage);
-      setIsFullPage(Boolean(fullPage));
-    };
-    openSeadragonViewer.addHandler("full-page", handleFullPage);
-
-    /*
-     * Restore full page on a viewer built while the reader was already in it. Deferred a
-     * frame: OpenSeadragon measures the container as it goes full page, and this runs
-     * during the same commit that inserted the element.
-     */
-    let raf = 0;
-    if (wantsFullPage.current && !openSeadragonViewer.isFullPage()) {
-      raf = requestAnimationFrame(() => {
-        if (wantsFullPage.current) openSeadragonViewer.setFullPage(true);
-      });
-    }
-
-    return () => {
-      if (raf) cancelAnimationFrame(raf);
-      openSeadragonViewer.removeHandler("full-page", handleFullPage);
-      /*
-       * Leaving full page before this viewer goes away is not optional.
-       * `Viewer.destroy()` does not undo it — only `setFullPage(false)` restores the
-       * `display: none` OpenSeadragon wrote onto every other child of `<body>`. Skip
-       * this and navigating away mid-full-page leaves the whole page blank.
-       */
-      if (openSeadragonViewer.isFullPage()) {
-        openSeadragonViewer.setFullPage(false);
-      }
-    };
-  }, [openSeadragonViewer]);
 
   const contentRef = useRef<HTMLDivElement>(null);
   const [asideWidth, setAsideWidth] = useState<number | null>(null);
@@ -181,122 +135,113 @@ const ViewerContent: React.FC<ViewerContentProps> = ({
   const asideStyle =
     asideWidth !== null && isAside ? { width: `${asideWidth}%` } : undefined;
 
+  const hasRail = sequence[1].length > 1;
+
+  const rail = (
+    <MediaWrapper className="clover-viewer-media-wrapper">
+      <Media items={items} activeItem={0} />
+    </MediaWrapper>
+  );
+
+  /*
+   * In full screen the rail leaves `Main` and becomes a sibling of the whole row.
+   *
+   * `Content` lays the painting and the information panel out side by side, so a rail inside
+   * `Main` is only ever as wide as the painting — it stops where the panel starts. Full screen
+   * wants it across the whole bottom, under both, which means it has to sit outside the row
+   * rather than in one of its columns.
+   */
   return (
-    <Content
-      ref={contentRef}
-      className="clover-viewer-content"
-      data-testid="clover-viewer-content"
-    >
-      <Main
-        data-aside-active={isAside}
-        data-aside-toggle={renderToggle}
-        style={mainStyle}
+    <>
+      <Content
+        ref={contentRef}
+        className="clover-viewer-content"
+        data-testid="clover-viewer-content"
       >
-        <Painting
-          activeCanvas={activeCanvas}
-          annotationResources={annotationResources}
-          contentSearchResource={contentSearchResource}
-          isMedia={isAudioVideo}
-          painting={painting}
-        />
-
-        {sequence[1].length > 1 && !isFullPage && (
-          <MediaWrapper className="clover-viewer-media-wrapper">
-            <Media items={items} activeItem={0} />
-          </MediaWrapper>
-        )}
-
-        {renderToggle &&
-          (CustomToggle ? (
-            <CustomPanelToggle data-aside-active={isAside}>
-              <CustomToggle
-                buttonProps={{
-                  type: "button",
-                  "aria-label": t("informationPanelToggle"),
-                  "aria-expanded": isInformationOpen,
-                  onClick: handleToggle,
-                }}
-                icon={
-                  <Icon fill="currentColor" aria-hidden="true">
-                    {isInformationOpen ? (
-                      <Icon.PanelExpand />
-                    ) : (
-                      <Icon.PanelCollapse />
-                    )}
-                  </Icon>
-                }
-                isOpen={isInformationOpen}
-                label={t("informationPanelToggle")}
-              />
-            </CustomPanelToggle>
-          ) : (
-            <PanelToggle
-              data-aside-active={isAside}
-              onClick={handleToggle}
-              aria-label={t("informationPanelToggle")}
-              aria-expanded={isInformationOpen}
-            >
-              <Icon fill="currentColor" aria-hidden="true">
-                {isInformationOpen ? (
-                  <Icon.PanelExpand />
-                ) : (
-                  <Icon.PanelCollapse />
-                )}
-              </Icon>
-            </PanelToggle>
-          ))}
-      </Main>
-      {isAside && (
-        <>
-          <DragHandle
-            onPointerDown={handleDragStart}
-            onPointerMove={handleDragMove}
-            onPointerUp={handleDragEnd}
-            data-dragging={dragging.current}
-            aria-hidden="true"
+        <Main
+          data-aside-active={isAside}
+          data-aside-toggle={renderToggle}
+          style={mainStyle}
+        >
+          <Painting
+            activeCanvas={activeCanvas}
+            annotationResources={annotationResources}
+            contentSearchResource={contentSearchResource}
+            isMedia={isAudioVideo}
+            painting={painting}
           />
-          <Aside
-            data-aside-active={isAside}
-            data-aside-toggle={renderToggle}
-            style={asideStyle}
-          >
-            <InformationPanel
-              activeCanvas={activeCanvas}
-              annotationResources={annotationResources}
-              searchServiceUrl={searchServiceUrl}
-              setContentSearchResource={setContentSearchResource}
-              contentSearchResource={contentSearchResource}
-              contentSearchCallback={contentSearchCallback}
-              initialSearchQuery={initialSearchQuery}
-            />
-          </Aside>
-        </>
-      )}
 
-      {/*
-       * The thumbnail strip while OpenSeadragon owns the window, floated over the image
-       * so items stay navigable.
-       *
-       * Portalled to `document.body` rather than into the viewer's element, for two
-       * reasons. OpenSeadragon hides the body children that exist at the moment it goes
-       * full page, so a node appended afterwards is never hidden — being a late sibling
-       * is what keeps this visible. And the viewer's element is rebuilt whenever the
-       * canvas changes, which would take the strip down with it mid-navigation; body
-       * outlives that.
-       */}
-      {sequence[1].length > 1 &&
-        isFullPage &&
-        typeof document !== "undefined" &&
-        createPortal(
-          <MediaWrapper
-            className="clover-viewer-media-wrapper"
-            data-fullpage="true"
-          >
-            <Media items={items} activeItem={0} />
-          </MediaWrapper>,
-          document.body,
+          {hasRail && !isFullscreen && rail}
+
+          {renderToggle &&
+            (CustomToggle ? (
+              <CustomPanelToggle data-aside-active={isAside}>
+                <CustomToggle
+                  buttonProps={{
+                    type: "button",
+                    "aria-label": t("informationPanelToggle"),
+                    "aria-expanded": isInformationOpen,
+                    onClick: handleToggle,
+                  }}
+                  icon={
+                    <Icon fill="currentColor" aria-hidden="true">
+                      {isInformationOpen ? (
+                        <Icon.PanelExpand />
+                      ) : (
+                        <Icon.PanelCollapse />
+                      )}
+                    </Icon>
+                  }
+                  isOpen={isInformationOpen}
+                  label={t("informationPanelToggle")}
+                />
+              </CustomPanelToggle>
+            ) : (
+              <PanelToggle
+                data-aside-active={isAside}
+                onClick={handleToggle}
+                aria-label={t("informationPanelToggle")}
+                aria-expanded={isInformationOpen}
+              >
+                <Icon fill="currentColor" aria-hidden="true">
+                  {isInformationOpen ? (
+                    <Icon.PanelExpand />
+                  ) : (
+                    <Icon.PanelCollapse />
+                  )}
+                </Icon>
+              </PanelToggle>
+            ))}
+        </Main>
+        {isAside && (
+          <>
+            <DragHandle
+              onPointerDown={handleDragStart}
+              onPointerMove={handleDragMove}
+              onPointerUp={handleDragEnd}
+              data-dragging={dragging.current}
+              aria-hidden="true"
+            />
+            <Aside
+              data-aside-active={isAside}
+              data-aside-toggle={renderToggle}
+              style={asideStyle}
+            >
+              <InformationPanel
+                activeCanvas={activeCanvas}
+                annotationResources={annotationResources}
+                searchServiceUrl={searchServiceUrl}
+                setContentSearchResource={setContentSearchResource}
+                contentSearchResource={contentSearchResource}
+                contentSearchCallback={contentSearchCallback}
+                initialSearchQuery={initialSearchQuery}
+              />
+            </Aside>
+          </>
         )}
-    </Content>
+      </Content>
+      {hasRail && isFullscreen && rail}
+    </>
   );
 };
 

--- a/src/components/Viewer/Viewer/Viewer.styled.tsx
+++ b/src/components/Viewer/Viewer/Viewer.styled.tsx
@@ -1,3 +1,5 @@
+import { ExitFullscreenStyled } from "src/components/Shared/Fullscreen/ExitFullscreen";
+import { Navigator } from "src/components/Image/Image.styled";
 import { styled } from "src/styles/stitches.config";
 import { themeVarBridge } from "src/styles/tokens";
 
@@ -11,65 +13,8 @@ const MediaWrapper = styled("div", {
    * the rail is the Viewer's business — a deep-zoom canvas, a video, an audio player — and
    * the Slider has no idea it is underneath any of them. Standing alone it should still sit
    * flush with whatever a consumer puts around it.
-   *
-   * Matched to the gap the header already leaves beneath itself, so the rhythm above and
-   * below the controls is even. The full-page rule below re-declares `padding` outright and
-   * wins on specificity, which is what that floating panel wants.
    */
   paddingTop: "$4",
-
-  /*
-   * Floating over OpenSeadragon's full-page view, bottom left.
-   *
-   * `position: fixed` against the viewport rather than absolute, because at this point
-   * the strip is a direct child of `<body>` — see the portal in Content.tsx. The z-index
-   * clears OpenSeadragon's own furniture: its controls sit at 100 and its full-page
-   * element is appended to body alongside this, so this has to win on both counts.
-   *
-   * Width is capped so a long sequence does not span the whole screen, and the strip
-   * scrolls within itself instead.
-   */
-  "&[data-fullpage='true']": {
-    /*
-     * The token bridge has to be re-declared here.
-     *
-     * `themeVarBridge` maps `--colors-*` onto `--clover-color-*`, and it is declared on
-     * each component's own wrapper. In full page this strip is portalled to `<body>`,
-     * outside that subtree — so every `$token` below would resolve against nothing and
-     * fall back to whatever `--clover-color-*` happened to sit on `:root`, or to
-     * transparent for a consumer who sets none. Carrying the bridge makes the strip
-     * self-sufficient wherever it is re-homed.
-     */
-    ...themeVarBridge,
-    position: "fixed",
-    zIndex: "200",
-    bottom: "1rem",
-    left: "1rem",
-    width: "auto",
-    maxWidth: "min(38rem, calc(100vw - 2rem))",
-    padding: "0.5rem",
-    borderRadius: "5px",
-    /*
-     * `$secondary` is the surface token — `$primary` is Clover's foreground (it defaults
-     * to #1A1D1E and a dark theme flips it light), so using it here painted the panel in
-     * the text colour and inverted with the theme.
-     *
-     * Solid rather than translucent: the strip sits over arbitrary imagery, and a wash
-     * lets the picture bleed through the thumbnails it is meant to distinguish.
-     *
-     * The border does what the drop shadow used to. In full page this floats over the
-     * artwork itself, so it needs some boundary of its own; a hairline is the flat way to
-     * draw one.
-     */
-    backgroundColor: "$secondary",
-    border: "1px solid #6663",
-
-    "@sm": {
-      maxWidth: "calc(100vw - 1rem)",
-      bottom: "0.5rem",
-      left: "0.5rem",
-    },
-  },
 });
 
 const Content = styled("div", {
@@ -233,6 +178,107 @@ const Wrapper = styled("div", {
 
   "&[data-information-panel-open='true']": {
     "@sm": {},
+  },
+
+  /*
+   * Full screen.
+   *
+   * This is Clover's own root, so everything it draws is still here — header, image
+   * controls, thumbnail rail, information panel. Nothing is portalled and nothing is hidden;
+   * the layout simply has a whole screen to use instead of a slot in a page.
+   *
+   * What changes is the proportion: the painting takes the height left over rather than the
+   * configured `canvasHeight`, and the rail spans the full width along the bottom instead of
+   * floating in a corner.
+   */
+  /*
+   * Keyed to the attribute rather than the `:fullscreen` pseudo-class. The attribute is set
+   * from the browser's own `fullscreenchange`, so it is just as accurate and it can be
+   * asserted on — `:fullscreen` cannot be forced, which leaves a layout keyed to it
+   * verifiable only by eye.
+   */
+
+  "&[data-fullscreen='true']": {
+    // A positioning context for the absolutely positioned exit control.
+    position: "relative",
+    width: "100vw",
+    height: "100vh",
+    maxHeight: "100vh",
+    backgroundColor: "$secondary",
+
+    /*
+     * Direct child only.
+     *
+     * A descendant selector here also matched the exit control belonging to a nested `Image`,
+     * so a full-screen `Viewer` showed two of them. Each host reveals its own and no one
+     * else's.
+     */
+    [`& > ${ExitFullscreenStyled}`]: {
+      display: "flex",
+    },
+
+    /*
+     * The header goes.
+     *
+     * Its title, IIIF badge and download live one click away in the information panel, and
+     * full screen is the one place the image should get the room instead. The panel toggle is
+     * not in the header — it sits over the painting — so it survives this.
+     */
+    ".clover-viewer-header": {
+      display: "none",
+    },
+
+    /*
+     * Room above the information panel's tabs.
+     *
+     * With the header hidden the panel starts at the very top of the screen, and its tab row
+     * sat flush against the edge. This is the space the header used to provide.
+     */
+    ".clover-viewer-information-panel": {
+      paddingTop: "$4",
+    },
+
+    /*
+     * The navigator drops below the exit control.
+     *
+     * Both want the top-left corner: the minimap sits at `1rem` and the exit control is
+     * `2.5rem` tall from `1rem`, so left alone the button lands on top of the minimap.
+     */
+    [`& ${Navigator}`]: {
+      top: "4.5rem",
+    },
+
+    ".clover-viewer-painting": {
+      display: "flex",
+      flexDirection: "column",
+      flexGrow: "1",
+      minHeight: "0",
+    },
+
+    /*
+     * `!important` because `canvasHeight` is applied as an inline style on the painting's
+     * canvas, and an inline declaration outranks any rule here. Full screen should fill what
+     * is left after the header and the rail, whatever height was configured for the embedded
+     * case.
+     */
+    ".clover-viewer-painting > div": {
+      height: "auto !important",
+      flexGrow: "1",
+      minHeight: "0",
+    },
+
+    /*
+     * The rail: a full-width band across the bottom.
+     *
+     * `Content.tsx` moves it out of `Main` for full screen, so by the time these rules apply
+     * it is a sibling of the painting-and-panel row rather than sitting inside one column of
+     * it. That is what lets `100%` mean the whole screen.
+     */
+    [`& ${MediaWrapper}`]: {
+      flexShrink: "0",
+      width: "100%",
+      paddingTop: "$3",
+    },
   },
 });
 

--- a/src/components/Viewer/Viewer/Viewer.tsx
+++ b/src/components/Viewer/Viewer/Viewer.tsx
@@ -27,6 +27,9 @@ import ViewerHeader from "src/components/Viewer/Viewer/Header";
 import { Wrapper } from "src/components/Viewer/Viewer/Viewer.styled";
 import { getVisibleCanvasesFromCanvasId } from "@iiif/helpers";
 import { media } from "src/styles/stitches.config";
+import ExitFullscreen from "src/components/Shared/Fullscreen/ExitFullscreen";
+import useFullscreen from "src/hooks/useFullscreen";
+import { useCloverTranslation } from "src/i18n/useCloverTranslation";
 import { useMediaQuery } from "src/hooks/useMediaQuery";
 
 interface ViewerProps {
@@ -43,6 +46,17 @@ const Viewer: React.FC<ViewerProps> = ({
   iiifContentSearchQuery,
   contentSearchCallback,
 }) => {
+  const { t } = useCloverTranslation();
+
+  /*
+   * The root element, and whether it is the one full screen.
+   *
+   * Held in state rather than a ref so the hook re-runs once the element exists: assigning a
+   * ref does not re-render, and the listener has to know what to compare against.
+   */
+  const [rootElement, setRootElement] = useState<HTMLDivElement | null>(null);
+  const isFullscreen = useFullscreen(rootElement);
+
   /**
    * Viewer State
    */
@@ -173,8 +187,16 @@ const Viewer: React.FC<ViewerProps> = ({
         style={themeStyle}
         css={{ background: configOptions?.background }}
         data-absolute-position={isAbsolutePosition}
+        data-fullscreen={isFullscreen}
         data-information-panel-open={isInformationOpen}
+        ref={setRootElement}
       >
+        {/*
+         * Shown by CSS only while this root is full screen — see the `[data-fullscreen]`
+         * block in Viewer.styled. A standalone `Image` renders its own, so whichever root
+         * the browser put in full screen is the one offering a way back.
+         */}
+        <ExitFullscreen />
         <Collapsible.Root
           open={isInformationOpen}
           onOpenChange={setInformationOpen}
@@ -185,6 +207,7 @@ const Viewer: React.FC<ViewerProps> = ({
           />
           <ViewerContent
             activeCanvas={activeCanvas}
+            isFullscreen={isFullscreen}
             painting={painting}
             annotationResources={annotationResources}
             searchServiceUrl={searchServiceUrl}

--- a/src/context/viewer-context.tsx
+++ b/src/context/viewer-context.tsx
@@ -105,6 +105,13 @@ export type ControlButtonProps = {
     id: string;
     type: "button";
     "aria-label": string;
+    /*
+     * Present only on the full-screen control, which Clover drives itself rather than
+     * handing to OpenSeadragon. Every other control is still bound by id, so it has no
+     * handler to give. A replacement should spread `buttonProps` and not worry which is
+     * which.
+     */
+    onClick?: React.MouseEventHandler<HTMLButtonElement>;
   };
   icon: React.ReactNode;
   label: string;

--- a/src/hooks/useFullscreen.ts
+++ b/src/hooks/useFullscreen.ts
@@ -1,0 +1,35 @@
+import { getFullscreenElement } from "src/lib/fullscreen";
+import { useEffect, useState } from "react";
+
+/**
+ * Whether `element` is the one currently full screen.
+ *
+ * Driven by the browser's own `fullscreenchange`, so it is right however full screen was
+ * entered or left — the button, `Escape`, the window controls, or another element taking over.
+ *
+ * The result is published as a `data-` attribute rather than left to the `:fullscreen`
+ * pseudo-class. Both would be accurate, but an attribute can be asserted on: `:fullscreen`
+ * cannot be forced, so a layout keyed only to it can only ever be checked by eye, and not at
+ * all in an embedded browser that declines the request.
+ */
+export default function useFullscreen(element: HTMLElement | null): boolean {
+  const [isFullscreen, setIsFullscreen] = useState(false);
+
+  useEffect(() => {
+    if (!element) return;
+
+    const sync = () => setIsFullscreen(getFullscreenElement() === element);
+    sync();
+
+    // The prefixed event is Safari's; both are harmless to listen for.
+    document.addEventListener("fullscreenchange", sync);
+    document.addEventListener("webkitfullscreenchange", sync);
+
+    return () => {
+      document.removeEventListener("fullscreenchange", sync);
+      document.removeEventListener("webkitfullscreenchange", sync);
+    };
+  }, [element]);
+
+  return isFullscreen;
+}

--- a/src/hooks/useWithinFullscreen.ts
+++ b/src/hooks/useWithinFullscreen.ts
@@ -1,0 +1,38 @@
+import { getFullscreenElement } from "src/lib/fullscreen";
+import { useEffect, useState } from "react";
+
+/**
+ * Whether `element` sits inside whatever is currently full screen.
+ *
+ * Containment, not identity — which is the difference from `useFullscreen`. A control deep
+ * inside the tree needs to know that *something above it* is full screen, and it cannot know
+ * which root that is: in a `Viewer` the full-screen element is the viewer, while a standalone
+ * `Image` full-screens its own wrapper. Asking whether the full-screen element contains this
+ * one answers both without the control being told where it lives.
+ *
+ * `useFullscreen` deliberately keeps the stricter test, because the exit control uses it to
+ * decide which single root offers the way out.
+ */
+export default function useWithinFullscreen(
+  element: HTMLElement | null,
+): boolean {
+  const [isWithin, setIsWithin] = useState(false);
+
+  useEffect(() => {
+    if (!element) return;
+
+    const sync = () =>
+      setIsWithin(Boolean(getFullscreenElement()?.contains(element)));
+    sync();
+
+    document.addEventListener("fullscreenchange", sync);
+    document.addEventListener("webkitfullscreenchange", sync);
+
+    return () => {
+      document.removeEventListener("fullscreenchange", sync);
+      document.removeEventListener("webkitfullscreenchange", sync);
+    };
+  }, [element]);
+
+  return isWithin;
+}

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -14,6 +14,7 @@
   "contentSearchResultsNone": "No Results",
   "contentSearchResultsMore": "More Results",
   "imageFullScreen": "Full screen",
+  "imageExitFullScreen": "Exit full screen",
   "imageResetZoom": "Reset zoom",
   "imageRotateLeft": "Rotate left",
   "imageRotateRight": "Rotate right",

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -14,6 +14,7 @@
   "contentSearchResultsNone": "Sin resultados",
   "contentSearchResultsMore": "Más resultados",
   "imageFullScreen": "Pantalla completa",
+  "imageExitFullScreen": "Salir de pantalla completa",
   "imageResetZoom": "Restablecer zoom",
   "imageRotateLeft": "Girar a la izquierda",
   "imageRotateRight": "Girar a la derecha",

--- a/src/i18n/locales/fi.json
+++ b/src/i18n/locales/fi.json
@@ -28,5 +28,6 @@
   "canvasAnimationPreviousFrame": "Edellinen ruutu",
   "canvasAnimationNextFrame": "Seuraava ruutu",
   "canvasAnimationRepeat": "Toista uudelleen",
-  "canvasAnimationSpeed": "Nopeus"
+  "canvasAnimationSpeed": "Nopeus",
+  "imageExitFullScreen": "Poistu koko näytöstä"
 }

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -14,6 +14,7 @@
   "contentSearchResultsNone": "Aucun résultat",
   "contentSearchResultsMore": "Plus de résultats",
   "imageFullScreen": "Plein écran",
+  "imageExitFullScreen": "Quitter le plein écran",
   "imageResetZoom": "Réinitialiser le zoom",
   "imageRotateLeft": "Rotation à gauche",
   "imageRotateRight": "Rotation à droite",

--- a/src/i18n/locales/nb.json
+++ b/src/i18n/locales/nb.json
@@ -28,5 +28,6 @@
   "canvasAnimationPreviousFrame": "Forrige bilde",
   "canvasAnimationNextFrame": "Neste bilde",
   "canvasAnimationRepeat": "Gjenta",
-  "canvasAnimationSpeed": "Hastighet"
+  "canvasAnimationSpeed": "Hastighet",
+  "imageExitFullScreen": "Avslutt fullskjerm"
 }

--- a/src/i18n/locales/nn.json
+++ b/src/i18n/locales/nn.json
@@ -28,5 +28,6 @@
   "canvasAnimationPreviousFrame": "Førre bilete",
   "canvasAnimationNextFrame": "Neste bilete",
   "canvasAnimationRepeat": "Gjenta",
-  "canvasAnimationSpeed": "Hastigheit"
+  "canvasAnimationSpeed": "Hastigheit",
+  "imageExitFullScreen": "Avslutt fullskjerm"
 }

--- a/src/i18n/locales/no.json
+++ b/src/i18n/locales/no.json
@@ -28,5 +28,6 @@
   "canvasAnimationPreviousFrame": "Forrige bilde",
   "canvasAnimationNextFrame": "Neste bilde",
   "canvasAnimationRepeat": "Gjenta",
-  "canvasAnimationSpeed": "Hastighet"
+  "canvasAnimationSpeed": "Hastighet",
+  "imageExitFullScreen": "Avslutt fullskjerm"
 }

--- a/src/i18n/locales/pt.json
+++ b/src/i18n/locales/pt.json
@@ -5,5 +5,6 @@
   "canvasAnimationNextFrame": "Próximo fotograma",
   "canvasAnimationRepeat": "Repetir",
   "canvasAnimationSpeed": "Velocidade",
-  "informationPanelTabsContents": "Conteúdo"
+  "informationPanelTabsContents": "Conteúdo",
+  "imageExitFullScreen": "Sair do ecrã completo"
 }

--- a/src/lib/fullscreen.ts
+++ b/src/lib/fullscreen.ts
@@ -1,0 +1,77 @@
+/**
+ * The Fullscreen API, with Safari's prefixes and a way to find Clover's own root.
+ *
+ * Clover used to reach full screen through OpenSeadragon's `setFullPage()`, which is not the
+ * Fullscreen API at all: it sets `display: none` on every child of `<body>` except its own
+ * viewport element and reparents that element to the body. Everything else Clover draws —
+ * the header, the image controls, the thumbnail rail, the information panel — are siblings of
+ * that element, so they all disappeared. The rail only survived because it was portalled to
+ * the body on purpose, and the controls could not be: OpenSeadragon binds them by element id
+ * at init, so re-rendering them anywhere else leaves it holding a detached node.
+ *
+ * Asking the browser to full-screen Clover's own root instead keeps the whole component on
+ * screen, because it never leaves the tree. OpenSeadragon simply resizes into its container.
+ */
+
+type PrefixedElement = HTMLElement & {
+  webkitRequestFullscreen?: () => Promise<void> | void;
+};
+
+type PrefixedDocument = Document & {
+  webkitFullscreenElement?: Element | null;
+  webkitExitFullscreen?: () => Promise<void> | void;
+};
+
+/** The element currently full screen, if any. */
+export const getFullscreenElement = (): Element | null => {
+  if (typeof document === "undefined") return null;
+  const doc = document as PrefixedDocument;
+  return doc.fullscreenElement ?? doc.webkitFullscreenElement ?? null;
+};
+
+export const isFullscreenSupported = (): boolean => {
+  if (typeof document === "undefined") return false;
+  const doc = document as PrefixedDocument;
+  return Boolean(doc.fullscreenEnabled ?? doc.webkitExitFullscreen);
+};
+
+/**
+ * Clover's root, found from an element inside it.
+ *
+ * `.clover-viewer` is checked first on purpose. Both selectors match when an `Image` is
+ * nested in a `Viewer`, and the image wrapper is the nearer ancestor — so a plain
+ * `closest()` over both would full-screen the image alone and leave the rest of the viewer
+ * behind, which is the problem this is here to solve.
+ */
+export const getCloverRoot = (from: Element | null): HTMLElement | null =>
+  (from?.closest(".clover-viewer") as HTMLElement | null) ??
+  (from?.closest(".clover-iiif-image-openseadragon") as HTMLElement | null);
+
+/**
+ * Enter or leave full screen for the Clover root containing `from`.
+ *
+ * Must be called from within a user gesture — browsers reject a request that is not, and they
+ * reject it silently enough that routing it through state and an effect can lose it.
+ *
+ * A refusal is swallowed rather than left to surface as an unhandled promise rejection. A
+ * browser may decline for reasons that have nothing to do with the click: a permissions
+ * policy, an embedded frame that was never allowed full screen.
+ */
+export const toggleFullscreen = async (from: Element | null) => {
+  const root = getCloverRoot(from);
+  if (!root) return;
+
+  try {
+    if (getFullscreenElement()) {
+      const doc = document as PrefixedDocument;
+      await (doc.exitFullscreen?.() ?? doc.webkitExitFullscreen?.());
+      return;
+    }
+
+    const element = root as PrefixedElement;
+    await (element.requestFullscreen?.() ??
+      element.webkitRequestFullscreen?.());
+  } catch {
+    // Declined. Nothing to undo — the reader stays where they were.
+  }
+};


### PR DESCRIPTION
## Full screen keeps the whole viewer

Full screen previously handed the job to OpenSeadragon's `setFullPage()`, which is not the
Fullscreen API: it sets `display: none` on every child of `<body>` except its own canvas
element. Everything else Clover draws is a *sibling* of that element, so the header, the image
controls, the thumbnail rail and the information panel all disappeared. The rail only survived
because it was portalled to `<body>` on purpose — as a small panel floating in one corner —
and the controls could not be portalled at all, because OpenSeadragon binds them by element id
at init and re-rendering them elsewhere leaves it holding a detached node.

Clover now asks the browser to full-screen its own root. Nothing is reparented and nothing is
hidden, so the reader keeps the viewer they were already using.

### What the reader gets

| | before | now |
| --- | --- | --- |
| thumbnail rail | floating panel, bottom-left, capped at 38rem | full-width band across the bottom |
| image controls | gone | present |
| information panel toggle | gone | present |
| viewer header | gone | hidden deliberately; the image gets the room |
| OSD navigator | top-left, under the exit control | dropped to `4.5rem`, clear of it |
| way out | `Escape` only, unadvertised | **← Exit full screen**, top left, plus `Escape` |

The full-screen control turns its arrows inward while active and renames itself _Exit full
screen_, so it reads as where it will take you rather than where you already are.

A standalone `Image` gets the same treatment: it full-screens its own wrapper, offers the same
exit control, and drops its navigator clear of it. Only one element is ever full screen, so an
`Image` nested in a full-screen `Viewer` stays quiet and the viewer provides the single way back.

### How it works

- `src/lib/fullscreen.ts` — vendor-prefixed request/exit, and `getCloverRoot()`, which finds
  the root from any element inside it. `.clover-viewer` is checked before the image wrapper
  because both match when an `Image` is nested and the wrapper is nearer — a plain `closest()`
  over both would full-screen the image alone.
- `useFullscreen(element)` — identity: is *this* element the full-screen one. Used by each host
  to decide which single root offers the way out.
- `useWithinFullscreen(element)` — containment: is something *above* me full screen. Used by
  the control deep in the tree, which cannot know which root the browser took.
- Layout is keyed to a `data-fullscreen` attribute set from the browser's own
  `fullscreenchange`, not to the `:fullscreen` pseudo-class. Both are accurate, but
  `:fullscreen` cannot be forced, so a layout keyed only to it can never be asserted on.
- The rail moves out of `Main` for full screen. `Content` lays the painting and the information
  panel out as a row, so a rail inside `Main` stops where the panel starts — it measured 960px
  in a 1553px root. It is now a sibling of the whole row.

### Fixed along the way

- A refused full-screen request surfaced as an **unhandled promise rejection**. Browsers
  decline for reasons unrelated to the click — a permissions policy, an embedded frame never
  granted it — and decline by rejecting. Now caught; nothing to undo, the reader stays put.
- A descendant selector revealed the nested `Image`'s exit control as well as the viewer's, so
  a full-screen `Viewer` showed **two** exit buttons. Scoped to a direct child.
- Removed the focus-restore effect that put focus back on the control after OpenSeadragon's
  `full-page` event. It existed because `setFullPage()` reparented the viewer and dropped
  focus; nothing is reparented now, so focus is never lost and the event never fires.

### API notes

- `openSeadragonConfig.showFullPageControl` still decides whether the control appears. Clover
  passes `false` to OpenSeadragon regardless, so it never binds its own handler.
- A `controlButtons.fullPage` replacement now receives an `onClick` in its `buttonProps` and no
  longer depends on rendering the id it is given.
- New i18n key `imageExitFullScreen`, added to all 8 locales.